### PR TITLE
Alert: Add dismissAlertProps to override the destructured Alert props

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,9 @@ For an interactive demo of all components, see https://resin-io-modules.github.i
 | `plaintText` | `boolean` | - | - | If true, the alert will be rendered without a border or a background |
 | `prefix` | <code>JSX.Element &#124; string &#124; false</code> | - | - | Set a prefix on the alert message, if this prop is set to false, the default prefix will not be shown |
 | `onDismiss` | `() => void` | - | - | A function that is called when dismissing an alert
+| `dismissButtonProps` | `object` | - | - | Properties that are passed to the dismiss button wrapper element. These are the same props used for the [`Box`][1] component |
+
+[1]: /?selectedKind=Box
 
 ### Badge
 

--- a/src/components/Alert.tsx
+++ b/src/components/Alert.tsx
@@ -4,16 +4,11 @@ import FaClose = require('react-icons/lib/fa/close');
 import FaExclamationCircle = require('react-icons/lib/fa/exclamation-circle');
 import FaExclamationTriangle = require('react-icons/lib/fa/exclamation-triangle');
 import FaInfoCircle = require('react-icons/lib/fa/info-circle');
+import { AlertProps } from 'rendition';
 import styled, { StyledFunction, withTheme } from 'styled-components';
 import asRendition from '../asRendition';
 import { bold, getColor, normal, px } from '../utils';
-import { Flex } from './Grid';
-
-interface AlertProps extends DefaultProps, Coloring, Sizing {
-	plaintext?: boolean;
-	prefix?: JSX.Element | string | false;
-	onDismiss?: () => void;
-}
+import { Box, Flex } from './Grid';
 
 const getPadding = (props: AlertProps) =>
 	props.emphasized ? '15px 40px' : '8px 32px';
@@ -43,7 +38,7 @@ const AlertTitle = styled.span`
 
 // Firefox didn't middle align absolute positioned elements
 // using flex, so we had to use an extra wrapper element
-const DismissButtonWrapper = (styled.div as StyledFunction<AlertProps>)`
+const DismissButtonWrapper = (styled(Box) as StyledFunction<AlertProps>)`
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
@@ -153,7 +148,18 @@ const DismissAlert = (props: AlertProps) => (
 
 export default withTheme(
 	asRendition((props: AlertProps) => {
-		const { emphasized, plaintext, prefix, ...restProps } = props;
+		const {
+			emphasized,
+			plaintext,
+			prefix,
+			onDismiss,
+			dismissButtonProps,
+			...restProps
+		} = props;
+		const dismissAlertProps = {
+			onDismiss,
+			...(dismissButtonProps || restProps),
+		};
 		const title = plaintext ? getIcon(props) : getTitle(props);
 		if (plaintext) {
 			return (
@@ -162,7 +168,7 @@ export default withTheme(
 						{title && <AlertTitle children={title} />}
 						{props.children}
 					</Flex>
-					{props.onDismiss && <DismissAlert {...restProps} />}
+					{onDismiss && <DismissAlert {...dismissAlertProps} />}
 				</Plaintext>
 			);
 		} else if (emphasized) {
@@ -172,7 +178,7 @@ export default withTheme(
 						{title && <AlertTitle children={title} />}
 						{props.children}
 					</div>
-					{props.onDismiss && <DismissAlert {...restProps} />}
+					{onDismiss && <DismissAlert {...dismissAlertProps} />}
 				</Filled>
 			);
 		} else {
@@ -182,7 +188,7 @@ export default withTheme(
 						{title && <AlertTitle children={title} />}
 						{props.children}
 					</div>
-					{props.onDismiss && <DismissAlert {...restProps} />}
+					{onDismiss && <DismissAlert {...dismissAlertProps} />}
 				</Outline>
 			);
 		}

--- a/src/stories/README/Alert.md
+++ b/src/stories/README/Alert.md
@@ -18,3 +18,6 @@
 | `plaintText` | `boolean` | - | - | If true, the alert will be rendered without a border or a background |
 | `prefix` | <code>JSX.Element &#124; string &#124; false</code> | - | - | Set a prefix on the alert message, if this prop is set to false, the default prefix will not be shown |
 | `onDismiss` | `() => void` | - | - | A function that is called when dismissing an alert
+| `dismissButtonProps` | `object` | - | - | Properties that are passed to the dismiss button wrapper element. These are the same props used for the [`Box`][1] component |
+
+[1]: /?selectedKind=Box

--- a/typings/rendition.d.ts
+++ b/typings/rendition.d.ts
@@ -121,6 +121,7 @@ declare module 'rendition' {
 		plaintext?: boolean;
 		prefix?: JSX.Element | string | false;
 		onDismiss?: () => void;
+		dismissButtonProps?: BoxProps;
 	}
 
 	class Alert extends RenderableElementWithProps<AlertProps, any> {}


### PR DESCRIPTION
This is a backwards compatible workaround to bypass the issues we have b/c of destructuring most Alert props to the Alert's dismiss button wrapper.

See: #631
Resolves: #633
Change-type: minor
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>