### PR TITLE
Prevent `grid-styled` from installing styled-components v4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7347,7 +7347,7 @@
       "resolved": "http://registry.npmjs.org/grid-styled/-/grid-styled-3.1.1.tgz",
       "integrity": "sha512-5hfUzPJNEgeA98ndaYsGmrwnk4iMnTGPqI1f96tXu4sBh2tkTx3dHr2EqbMyu1S5HwkGrvzmuQzq9c0yU/ZBkw==",
       "requires": {
-        "styled-components": ">=2.0 || >=3.0",
+        "styled-components": "^3.2.3",
         "styled-system": "^1.1.1"
       }
     },


### PR DESCRIPTION
This prevents a bug where different major versions of styled-components
would be loaded, causing errors

Change-type: patch
Signed-off-by: Lucian <lucian.buzzo@gmail.com>