### PR TITLE
Prevent `grid-styled` from installing styled-components v4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rendition",
-  "version": "4.34.0",
+  "version": "4.39.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -65,6 +65,15 @@
             "has-flag": "^3.0.0"
           }
         }
+      }
+    },
+    "@balena/grid-styled": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@balena/grid-styled/-/grid-styled-3.1.1.tgz",
+      "integrity": "sha512-gkuJrx8ssEbywppT63QQiQ0yweVeOH0rPziTbNiWKkcge7+MM0hU+LRMEBnCzDYOxNJODivsVkfSLc3IfgZ77w==",
+      "requires": {
+        "styled-components": "3.x",
+        "styled-system": "^1.1.1"
       }
     },
     "@sinonjs/formatio": {
@@ -6125,8 +6134,7 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "combined-stream": {
           "version": "1.0.5",
@@ -6431,7 +6439,6 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6620,8 +6627,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "oauth-sign": {
           "version": "0.8.2",
@@ -6849,7 +6855,6 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7340,15 +7345,6 @@
       "integrity": "sha512-XTcvT55L8u4MBZrM37zXoUxsgxs/7sow7YSygd9CIwfWTVO8RVu7AYXhhCiTuFEf+APKgx6Jk4SuQbYR0vYKmQ==",
       "requires": {
         "lodash": "^4.17.5"
-      }
-    },
-    "grid-styled": {
-      "version": "3.1.1",
-      "resolved": "http://registry.npmjs.org/grid-styled/-/grid-styled-3.1.1.tgz",
-      "integrity": "sha512-5hfUzPJNEgeA98ndaYsGmrwnk4iMnTGPqI1f96tXu4sBh2tkTx3dHr2EqbMyu1S5HwkGrvzmuQzq9c0yU/ZBkw==",
-      "requires": {
-        "styled-components": ">=2.0 || >=3.0",
-        "styled-system": "^1.1.1"
       }
     },
     "growly": {

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "typescript": "^2.6.2"
   },
   "dependencies": {
+    "@balena/grid-styled": "3.1.1",
     "@types/chart.js": "^2.7.14",
     "@types/color": "^2.0.0",
     "@types/grid-styled": "^3.2.0",
@@ -94,7 +95,6 @@
     "color": "^2.0.0",
     "color-hash": "^1.0.3",
     "copy-to-clipboard": "^3.0.8",
-    "grid-styled": "3.1.1",
     "lodash": "^4.17.4",
     "marked": "^0.4.0",
     "mermaid": "^8.0.0-rc.8",

--- a/src/components/Grid.tsx
+++ b/src/components/Grid.tsx
@@ -1,4 +1,4 @@
-import { Box as _Box, Flex as _Flex } from 'grid-styled';
+import { Box as _Box, Flex as _Flex } from '@balena/grid-styled';
 import { compose } from 'recompose';
 import { BoxProps, FlexProps } from 'rendition';
 import styled from 'styled-components';

--- a/src/typings/balena-grid-styled.d.ts
+++ b/src/typings/balena-grid-styled.d.ts
@@ -1,0 +1,7 @@
+declare module '@balena/grid-styled' {
+	import { Box as _Box, Flex as _Flex } from 'grid-styled';
+
+	class Box extends _Box {}
+
+	class Flex extends _Flex {}
+}


### PR DESCRIPTION
This prevents a bug where different major versions of styled-components
would be loaded, causing errors

Change-type: patch
Signed-off-by: Lucian <lucian.buzzo@gmail.com>