### PR TITLE
Unignore package-lock.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,6 +100,5 @@ nbproject
 dist
 .out
 
-package-lock.json
 .reg
 reg.json


### PR DESCRIPTION
Seems to get ignored by an accident.
Changes in the file itself are a result of running `npm install` - please see if this makes sense