### PR TITLE
Change xterms addon import  path

### DIFF
--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { TerminalProps } from 'rendition';
 import styled from 'styled-components';
 import { ITerminalOptions, Terminal as Xterm } from 'xterm';
-import { fit as fitTerm } from 'xterm/dist/addons/fit/fit';
+import { fit as fitTerm } from 'xterm/lib/addons/fit/fit';
 import Theme from '../theme';
 import { Box } from './Grid';
 


### PR DESCRIPTION
Changed XTerm library's addon path used, from `dist` to `lib`, as
recommended in XTerm [examples](https://github.com/xtermjs/xterm.js) - this may cause problems when importing -
seen production build errors for reconfix playground. Tested by
importing into reconfix playground via a local path. All other existing rendition  tests
seem happy, also checked the storybook manually to see if everything looks good in the terminal page.