### PR TITLE
Hide scope tag in views if less than one viewScopes are passed

### DIFF
--- a/__tests__/components/Filters.spec.js
+++ b/__tests__/components/Filters.spec.js
@@ -4,6 +4,8 @@ import React from 'react'
 import renderer from 'react-test-renderer'
 import Provider from '../../src/components/Provider'
 import Filters from '../../src/components/Filters'
+import Txt from '../../src/components/Txt'
+import Select from '../../src/components/Select'
 import FiltersSummary from '../../src/components/Filters/Summary'
 import Search from '../../src/components/Search'
 import * as SchemaSieve from '../../src/components/Filters/SchemaSieve'
@@ -31,6 +33,17 @@ const view = {
   scope: null,
   filters: [ filter ]
 }
+
+const viewScopes = [
+  {
+    slug: 'foo',
+    name: 'foo'
+  },
+  {
+    slug: 'bar',
+    name: 'bar'
+  }
+]
 
 describe('Filters component', () => {
   it('should match the stored snapshot', () => {
@@ -106,6 +119,56 @@ describe('Filters component', () => {
     })
   })
 
+  describe('save views modal', () => {
+    it('should not show scopes selector if one or less scopes are passed', () => {
+      const withOneViewScope = mount(
+        <Provider>
+          <Filters
+            schema={schema}
+            filters={[filter]}
+            viewScopes={[viewScopes[0]]}
+          />
+        </Provider>
+      )
+
+      const withNoViewScopes = mount(
+        <Provider>
+          <Filters
+            schema={schema}
+            filters={[filter]}
+            viewScopes={[viewScopes[0]]}
+          />
+        </Provider>
+      )
+
+      withOneViewScope.find('button').at(2).simulate('click')
+      expect(withOneViewScope.find(Select)).toHaveLength(0)
+
+      withNoViewScopes.find('button').at(2).simulate('click')
+      expect(withNoViewScopes.find(Select)).toHaveLength(0)
+
+      withOneViewScope.unmount()
+      withNoViewScopes.unmount()
+    })
+
+    it('should show scopes selector if viewScopes are passed', () => {
+      const component = mount(
+        <Provider>
+          <Filters
+            schema={schema}
+            filters={[filter]}
+            viewScopes={viewScopes}
+          />
+        </Provider>
+      )
+
+      component.find('button').at(2).simulate('click')
+      expect(component.find(Select)).toHaveLength(1)
+
+      component.unmount()
+    })
+  })
+
   describe('views property', () => {
     it('should not render a views menu if there are no views', () => {
       const component = mount(
@@ -133,6 +196,79 @@ describe('Filters component', () => {
 
       component.find('button').at(1).simulate('click')
       expect(component.find(ViewListItem)).toHaveLength(1)
+      component.unmount()
+    })
+
+    it('should not render scoped views in the views menu if no scopes are passed', () => {
+      const component = mount(
+        <Provider>
+          <Filters
+            schema={schema}
+            views={[{...view, scope: 'foo'}]}
+          />
+        </Provider>
+      )
+
+      component.find('button').at(1).simulate('click')
+      expect(component.find("[children='foo']")).toHaveLength(0)
+      expect(component.find("[children='null']")).toHaveLength(0)
+
+      component.unmount()
+    })
+
+    it('should not render scoped views in the views menu if one or less scopes are passed', () => {
+      const component = mount(
+        <Provider>
+          <Filters
+            schema={schema}
+            views={[{...view, scope: 'foo'}]}
+            viewScopes={[viewScopes[0]]}
+          />
+        </Provider>
+      )
+
+      component.find('button').at(1).simulate('click')
+      expect(component.find("[children='foo']")).toHaveLength(0)
+
+      component.unmount()
+    })
+
+    it('should render scoped views in the views menu if more than one viewScopes are passed', () => {
+      const component = mount(
+        <Provider>
+          <Filters
+            schema={schema}
+            views={[{...view, scope: 'foo'}]}
+            viewScopes={viewScopes}
+          />
+        </Provider>
+      )
+
+      component.find('button').at(1).simulate('click')
+
+      expect(component.find(Txt).at(0).text()).toEqual('foo')
+      expect(component.find("[children='bar']")).toHaveLength(0)
+
+      component.unmount()
+    })
+
+    it('should render views as "Unscoped" if they do not have a scope and more than one viewScopes are passed', () => {
+      const component = mount(
+        <Provider>
+          <Filters
+            schema={schema}
+            views={[{...view}]}
+            viewScopes={viewScopes}
+          />
+        </Provider>
+      )
+
+      component.find('button').at(1).simulate('click')
+
+      expect(component.find(Txt).at(0).text()).toEqual('Unscoped')
+      expect(component.find("[children='foo']")).toHaveLength(0)
+      expect(component.find("[children='bar']")).toHaveLength(0)
+
       component.unmount()
     })
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rendition",
-  "version": "4.41.2",
+  "version": "4.41.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/components/Filters/ViewsMenu.tsx
+++ b/src/components/Filters/ViewsMenu.tsx
@@ -79,6 +79,7 @@ interface ViewsMenuProps {
 	disabled?: boolean;
 	views: FiltersView[];
 	schema: JSONSchema6;
+	hasMultipleScopes?: boolean;
 	setFilters: (filters: JSONSchema6[]) => void;
 	deleteView: (view: FiltersView) => any;
 	renderMode?: FilterRenderMode | FilterRenderMode[];
@@ -104,9 +105,10 @@ class ViewsMenu extends React.Component<ViewsMenuProps, ViewsMenuState> {
 	}
 
 	render() {
-		const { views, renderMode } = this.props;
+		const { views, renderMode, hasMultipleScopes } = this.props;
 		const hasViews = views.length > 0;
-		const groupedViews = groupBy(views, 'scope');
+		const groupedViews = groupBy(views, item => item.scope || 'Unscoped');
+
 		let soloRender = false;
 		if (renderMode) {
 			const mode = Array.isArray(renderMode) ? renderMode : [renderMode];
@@ -140,7 +142,7 @@ class ViewsMenu extends React.Component<ViewsMenuProps, ViewsMenuState> {
 						{hasViews &&
 							map(groupedViews, (views: FiltersView[], scope) => (
 								<Box key={scope}>
-									{!!scope && (
+									{hasMultipleScopes && (
 										<Txt fontSize={13} ml={20} mb={2} mt={2} color="#aaa">
 											{scope}
 										</Txt>

--- a/src/components/Filters/index.tsx
+++ b/src/components/Filters/index.tsx
@@ -404,6 +404,9 @@ class Filters extends React.Component<FiltersProps, FiltersState> {
 							disabled={this.props.disabled}
 							views={this.state.views || []}
 							schema={this.props.schema}
+							hasMultipleScopes={
+								this.props.viewScopes && this.props.viewScopes.length > 1
+							}
 							setFilters={filters => this.setFilters(filters)}
 							deleteView={view => this.deleteView(view)}
 							renderMode={this.props.renderMode}
@@ -498,6 +501,7 @@ class Filters extends React.Component<FiltersProps, FiltersState> {
 					!!filters.length &&
 					!this.props.disabled && (
 						<Summary
+							scopes={this.props.viewScopes}
 							edit={(filter: JSONSchema6) => this.editFilter(filter)}
 							delete={(filter: JSONSchema6) => this.removeFilter(filter)}
 							saveView={(name, scope) => this.saveView(name, scope)}

--- a/src/stories/Filters.js
+++ b/src/stories/Filters.js
@@ -188,10 +188,24 @@ storiesOf('Core/Filters', module)
   .addDecorator(withReadme(Readme))
   .addDecorator(withScreenshot())
   .add('Standard', () => {
+    const props = {
+      viewScopes: [
+        {
+          slug: 'bleh',
+          name: 'bleh',
+          label: 'bla'
+        },
+        {
+          slug: 'foo',
+          name: 'foo'
+        }
+      ]
+    }
+
     return (
       <Provider>
         <Box m={3}>
-          <FiltersDemo />
+          <FiltersDemo extra={props} />
         </Box>
       </Provider>
     )


### PR DESCRIPTION
Passed the viewScopes prop to the Summary component as expected,
added tests for viewScopes.

The scopes will only be shown if more than 1 `viewScopes` are passed to the filters. This will both show a select box in the "save view" modal, and show scopes in the "views" menu.

Connects-to: #705
Change-type: minor
Signed-off-by: Stevche Radevski <stevche@balena.io>