### PR TITLE
Import lodash methods independently to reduce bundle size

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,7 @@
 {
   "rules": {
     "react/prop-types": 0,
-    "no-restricted-imports": ["error", "react-icons/lib/fa"],
+    "no-restricted-imports": ["error", "lodash", "react-icons/lib/fa"],
     "no-unused-expressions": 1,
     "import/first": 0,
     // Prevents clashes with jsx specific rules about indenting, by ignoring JSX elements

--- a/__tests__/SchemaSieve.spec.js
+++ b/__tests__/SchemaSieve.spec.js
@@ -1,5 +1,6 @@
 /* globals expect, describe, it */
-import * as _ from 'lodash'
+import isArray from 'lodash/isArray'
+import mapValues from 'lodash/mapValues'
 import { JSDOM } from 'jsdom'
 const Ajv = require('ajv')
 const ajvKeywords = require('ajv-keywords')
@@ -22,7 +23,7 @@ describe('SchemaSieve', () => {
         }
       }
 
-      const nestedCollection = _.mapValues(collection, (value) => ({ data: value }))
+      const nestedCollection = mapValues(collection, (value) => ({ data: value }))
 
       tests.forEach(({ operator, value, expected }) => {
         it(`should correctly test values using the "${operator}" operator with a value of "${value}"`, function () {
@@ -770,7 +771,7 @@ describe('SchemaSieve', () => {
           }
         }
 
-        const nestedCollection = _.mapValues(collection, (value) => ({ data: value }))
+        const nestedCollection = mapValues(collection, (value) => ({ data: value }))
 
         const filter = sieve.createFullTextSearchFilter(sieve.flattenSchema(nestedSchema), 'lorem')
 
@@ -819,7 +820,7 @@ describe('SchemaSieve', () => {
         }])
 
         const result = sieve.filter(filter, collection)
-        expect(_.isArray(result)).toBe(true)
+        expect(isArray(result)).toBe(true)
       })
 
       it('should return the correct values', function () {

--- a/__tests__/components/Pager.spec.js
+++ b/__tests__/components/Pager.spec.js
@@ -1,6 +1,6 @@
 /* globals expect, describe, it */
 import { mount } from 'enzyme'
-import * as _ from 'lodash'
+import noop from 'lodash/noop'
 import React from 'react'
 import renderer from 'react-test-renderer'
 import sinon from 'sinon'
@@ -15,8 +15,8 @@ describe('Pager component', () => {
           totalItems={436}
           itemsPerPage={50}
           page={0}
-          nextPage={_.noop}
-          prevPage={_.noop}
+          nextPage={noop}
+          prevPage={noop}
         />
       </Provider>
     )
@@ -32,7 +32,7 @@ describe('Pager component', () => {
           totalItems={436}
           itemsPerPage={50}
           page={0}
-          nextPage={_.noop}
+          nextPage={noop}
           prevPage={callback}
         />
       </Provider>
@@ -54,7 +54,7 @@ describe('Pager component', () => {
           itemsPerPage={50}
           page={1}
           nextPage={callback}
-          prevPage={_.noop}
+          prevPage={noop}
         />
       </Provider>
     )

--- a/__tests__/components/Select.spec.js
+++ b/__tests__/components/Select.spec.js
@@ -1,6 +1,6 @@
 /* globals expect, describe, it */
 import { mount } from 'enzyme'
-import * as _ from 'lodash'
+import noop from 'lodash/noop'
 import sinon from 'sinon'
 import React from 'react'
 import renderer from 'react-test-renderer'
@@ -26,7 +26,7 @@ describe('Select component', () => {
     it('should set the value of the select element', () => {
       const component = mount(
         <Provider>
-          <Select value={2} onChange={_.noop}>
+          <Select value={2} onChange={noop}>
             <option value={1}>Option 1</option>
             <option value={2}>Option 2</option>
             <option value={3}>Option 3</option>

--- a/__tests__/components/Table.spec.js
+++ b/__tests__/components/Table.spec.js
@@ -1,6 +1,11 @@
 /* globals expect, describe, it */
 import { mount } from 'enzyme'
-import * as _ from 'lodash'
+import first from 'lodash/first'
+import get from 'lodash/get'
+import last from 'lodash/last'
+import map from 'lodash/map'
+import noop from 'lodash/noop'
+import reverse from 'lodash/reverse'
 import React from 'react'
 import renderer from 'react-test-renderer'
 import sinon from 'sinon'
@@ -101,7 +106,7 @@ describe('Table component', () => {
         const cellsText = component.find('[data-display="table-body"] [data-display="table-cell"]')
           .map(element => element.text())
 
-        const dataText = _.map(PokeDex, cols[0].field)
+        const dataText = map(PokeDex, cols[0].field)
 
         expect(cellsText).toEqual(dataText)
       })
@@ -182,8 +187,8 @@ describe('Table component', () => {
 
         expect(spy.callCount).toEqual(PokeDex.length)
 
-        const calls = _.map(spy.getCalls(), 'args')
-        const expected = _.map(PokeDex, (item) => [item[field], item])
+        const calls = map(spy.getCalls(), 'args')
+        const expected = map(PokeDex, (item) => [item[field], item])
 
         expect(calls).toEqual(expected)
       })
@@ -257,7 +262,7 @@ describe('Table component', () => {
         const cellsText = component.find('[data-display="table-body"] [data-display="table-cell"]')
           .map(element => element.text())
 
-        const expected = _.map(PokeDex, field).sort()
+        const expected = map(PokeDex, field).sort()
 
         expect(cellsText).toEqual(expected)
       })
@@ -284,7 +289,7 @@ describe('Table component', () => {
         const cellsText = component.find('[data-display="table-body"] [data-display="table-cell"]')
           .map(element => element.text())
 
-        const expected = _.reverse(_.map(PokeDex, field).sort())
+        const expected = reverse(map(PokeDex, field).sort())
 
         expect(cellsText).toEqual(expected)
       })
@@ -311,14 +316,14 @@ describe('Table component', () => {
         const cellsText = component.find('[data-display="table-body"] [data-display="table-cell"]')
           .map(element => element.text())
 
-        const expected = _.reverse(_.map(PokeDex, field).sort())
+        const expected = reverse(map(PokeDex, field).sort())
 
         expect(cellsText).toEqual(expected)
       })
 
       it('should allow a custom sorting function', () => {
         const field = 'Name'
-        const biasName = _.get(_.last(PokeDex), field)
+        const biasName = get(last(PokeDex), field)
         const sorter = (a, b) => a[field] === biasName ? -1 : 1
         const cols = [
           {
@@ -370,7 +375,7 @@ describe('Table component', () => {
       const cellsText = component.find('[data-display="table-body"] [data-display="table-cell"]')
         .map(element => element.text())
 
-      const dataText = _.map(data, 'Name')
+      const dataText = map(data, 'Name')
 
       expect(cellsText).toEqual(dataText)
     })
@@ -400,7 +405,7 @@ describe('Table component', () => {
       const cellsText = component.find('[data-display="table-body"] [data-display="table-cell"]')
         .map(element => element.text())
 
-      const dataText = _.map(data, 'Name')
+      const dataText = map(data, 'Name')
 
       expect(cellsText).toEqual(dataText)
 
@@ -413,7 +418,7 @@ describe('Table component', () => {
       const updatedCellsText = component.find('[data-display="table-body"] [data-display="table-cell"]')
         .map(element => element.text())
 
-      const updatedDataText = _.map(data, 'Name')
+      const updatedDataText = map(data, 'Name')
 
       expect(updatedCellsText).toEqual(updatedDataText)
     })
@@ -450,7 +455,7 @@ describe('Table component', () => {
       const cellsText = component.find('[data-display="table-body"] [data-display="table-cell"]')
         .map(element => element.text())
 
-      const dataText = _.map(data, (field) => `Name: ${field.Name}`)
+      const dataText = map(data, (field) => `Name: ${field.Name}`)
 
       expect(cellsText).toEqual(dataText)
     })
@@ -480,7 +485,7 @@ describe('Table component', () => {
       const cellsText = component.find('[data-display="table-body"] [data-display="table-cell"]')
         .map(element => element.text())
 
-      const dataText = _.map(data, 'Name')
+      const dataText = map(data, 'Name')
 
       expect(cellsText).toEqual(dataText)
 
@@ -491,7 +496,7 @@ describe('Table component', () => {
       const updatedCellsText = component.find('[data-display="table-body"] [data-display="table-cell"]')
         .map(element => element.text())
 
-      const updatedDataText = _.map(data, 'Name')
+      const updatedDataText = map(data, 'Name')
 
       expect(updatedCellsText).not.toEqual(updatedDataText)
     })
@@ -521,7 +526,7 @@ describe('Table component', () => {
       const cellsText = component.find('[data-display="table-body"] [data-display="table-cell"]')
         .map(element => element.text())
 
-      const dataText = _.map(data, 'Name')
+      const dataText = map(data, 'Name')
 
       expect(cellsText).toEqual(dataText)
 
@@ -532,7 +537,7 @@ describe('Table component', () => {
       const updatedCellsText = component.find('[data-display="table-body"] [data-display="table-cell"]')
         .map(element => element.text())
 
-      const updatedDataText = _.map(data, 'Name')
+      const updatedDataText = map(data, 'Name')
 
       expect(updatedCellsText).toEqual(updatedDataText)
     })
@@ -565,7 +570,7 @@ describe('Table component', () => {
     it('should cause a checkbox to be rendered in the header', () => {
       const component = mount(
         <Provider>
-          <Table rowKey='pokedex_number' onCheck={_.noop} columns={columns} data={PokeDex} />
+          <Table rowKey='pokedex_number' onCheck={noop} columns={columns} data={PokeDex} />
         </Provider>
       )
       expect(component.find('[data-display="table-head"] input[type="checkbox"]')).toHaveLength(1)
@@ -574,7 +579,7 @@ describe('Table component', () => {
     it('should cause a checkbox to be rendered on each row', () => {
       const component = mount(
         <Provider>
-          <Table rowKey='pokedex_number' onCheck={_.noop} columns={columns} data={PokeDex} />
+          <Table rowKey='pokedex_number' onCheck={noop} columns={columns} data={PokeDex} />
         </Provider>
       )
       expect(component.find('[data-display="table-body"] input[type="checkbox"]')).toHaveLength(PokeDex.length)
@@ -653,7 +658,7 @@ describe('Table component', () => {
 
       component.find('[data-display="table-body"] [data-display="table-cell"]').first().simulate('click')
       expect(spy.callCount).toEqual(1)
-      expect(spy.firstCall.args[0]).toEqual(_.first(PokeDex))
+      expect(spy.firstCall.args[0]).toEqual(first(PokeDex))
 
       component.find('[data-display="table-body"] [data-display="table-cell"]').at(clickIndex).simulate('click')
       expect(spy.callCount).toEqual(2)

--- a/__tests__/components/Textarea.spec.js
+++ b/__tests__/components/Textarea.spec.js
@@ -1,6 +1,6 @@
 /* globals expect, describe, it */
 import { mount } from 'enzyme'
-import * as _ from 'lodash'
+import noop from 'lodash/noop'
 import React from 'react'
 import renderer from 'react-test-renderer'
 import Provider from '../../src/components/Provider'
@@ -22,7 +22,7 @@ describe('Textarea component', () => {
 
     const component = mount(
       <Provider>
-        <Textarea value={value} onChange={_.noop} />
+        <Textarea value={value} onChange={noop} />
       </Provider>
     )
 
@@ -43,7 +43,7 @@ describe('Textarea component', () => {
 
     it('should resize the textarea to match the content', () => {
       const component = mount(
-        <Textarea autoRows value={value} onChange={_.noop} />
+        <Textarea autoRows value={value} onChange={noop} />
       )
 
       // Sanity check to make sure autoRows doesn't change the default behaviour
@@ -75,7 +75,7 @@ describe('Textarea component', () => {
             autoRows
             maxRows={maxRows}
             value={value}
-            onChange={_.noop}
+            onChange={noop}
           />
         </Provider>
       )
@@ -96,7 +96,7 @@ describe('Textarea component', () => {
             autoRows
             minRows={minRows}
             value={value}
-            onChange={_.noop}
+            onChange={noop}
           />
         </Provider>
       )

--- a/__tests__/migrations.spec.js
+++ b/__tests__/migrations.spec.js
@@ -1,5 +1,5 @@
 /* globals expect, describe, it */
-import * as _ from 'lodash'
+import forEach from 'lodash/forEach'
 import { JSDOM } from 'jsdom'
 global.document = (new JSDOM('')).window.document
 
@@ -196,8 +196,8 @@ describe('migrations', () => {
       )
     })
 
-    _.forEach(legacyTypesAndOperators, ({ v4Type, operators, testValue }, legacyType) => {
-      _.forEach(operators, (legacyOperator, v4Operator) => {
+    forEach(legacyTypesAndOperators, ({ v4Type, operators, testValue }, legacyType) => {
+      forEach(operators, (legacyOperator, v4Operator) => {
         it(`should convert legacy '${legacyType}' type filters that use the legacy '${legacyOperator}' operator`, () => {
           const legacyFilter = {
             name: v4Type,

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -1,4 +1,4 @@
-import { map } from 'lodash';
+import map = require('lodash/map');
 import * as React from 'react';
 import { compose } from 'recompose';
 import { CardProps } from 'rendition';

--- a/src/components/Gauge.tsx
+++ b/src/components/Gauge.tsx
@@ -1,5 +1,6 @@
 import { Chart, ChartOptions } from 'chart.js';
-import { map, reduce } from 'lodash';
+import map = require('lodash/map');
+import reduce = require('lodash/reduce');
 import * as React from 'react';
 import { compose } from 'recompose';
 import styled, { withTheme } from 'styled-components';

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -1,4 +1,5 @@
-import * as _ from 'lodash';
+import assign = require('lodash/assign');
+import cloneDeep = require('lodash/cloneDeep');
 import * as React from 'react';
 import { TerminalProps } from 'rendition';
 import styled from 'styled-components';
@@ -152,7 +153,7 @@ class Terminal extends React.Component<ThemedTerminalProps, {}> {
 	constructor(props: ThemedTerminalProps) {
 		super(props);
 
-		this.termConfig = _.assign({}, props.config, {
+		this.termConfig = assign({}, props.config, {
 			cols: 80,
 			cursorBlink: false,
 			rows: 24,
@@ -170,7 +171,7 @@ class Terminal extends React.Component<ThemedTerminalProps, {}> {
 		} else {
 			// Xterm mutates the options object passed into it, so we have to clone it
 			// here
-			this.tty = new Xterm(_.cloneDeep(this.termConfig));
+			this.tty = new Xterm(cloneDeep(this.termConfig));
 		}
 
 		this.resize = this.resize.bind(this);

--- a/src/stories/Table.js
+++ b/src/stories/Table.js
@@ -1,4 +1,4 @@
-import * as _ from 'lodash'
+import * as cloneDeep from 'lodash/cloneDeep'
 import * as React from 'react'
 import { storiesOf } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
@@ -63,7 +63,7 @@ class HOC extends React.Component {
     super()
 
     this.state = {
-      PokeDex: _.cloneDeep(PokeDex)
+      PokeDex: cloneDeep(PokeDex)
     }
 
     this.changeName = this.changeName.bind(this)

--- a/src/unstable/components/Form/widgets/TabbedBox.tsx
+++ b/src/unstable/components/Form/widgets/TabbedBox.tsx
@@ -1,4 +1,4 @@
-import * as _ from 'lodash';
+import map = require('lodash/map');
 import * as React from 'react';
 import { Box, Button, Flex, Txt } from '../../../../';
 
@@ -34,7 +34,7 @@ export class TabbedBox extends React.Component<TabbedBoxProps, TabbedBoxState> {
 			<Box>
 				<Flex justify="space-between" mb={1}>
 					<Flex>
-						{_.map(this.props.tabs, (tab, index: number) => {
+						{map(this.props.tabs, (tab, index: number) => {
 							return (
 								<Button
 									key={index}

--- a/tslint.json
+++ b/tslint.json
@@ -19,7 +19,7 @@
     "no-console": [false],
     "no-empty-interface": false,
     "no-string-literal": false,
-    "import-blacklist": [true, "react-icons/lib/fa/"],
+    "import-blacklist": [true, "lodash", "react-icons/lib/fa/"],
     "interface-name": [false],
     "interface-over-type-literal": false,
     "variable-name": [


### PR DESCRIPTION
Didn't have an impact on the storybook bundle size, since mermaid
imports lodash as a whole. On the other hand, the dashboard bundle
doesn't include mermaid at all, which means that we are already
tree-shaking it away and we will benefit from the lodash change as well.

Also adds linter rules to prevent re-importing as a whole.

Resolves: #145
Change-type: patch
See: https://github.com/knsv/mermaid/blob/a4992963b3873ec7a566ba91b92596d2a360e3b9/src/diagrams/git/gitGraphAst.js#L1
See: https://github.com/knsv/mermaid/blob/a4992963b3873ec7a566ba91b92596d2a360e3b9/src/diagrams/git/gitGraphRenderer.js#L1
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>
