### PR TITLE
Change from deep equality comparison in TableRow to PureComponent

### DIFF
--- a/src/components/Table/TableRow.tsx
+++ b/src/components/Table/TableRow.tsx
@@ -1,5 +1,4 @@
 import get = require('lodash/get');
-import isEqual = require('lodash/isEqual');
 import isFunction = require('lodash/isFunction');
 import map = require('lodash/map');
 import * as React from 'react';
@@ -32,11 +31,7 @@ export interface TableRowProps<T> {
 	checkboxAttributes?: React.InputHTMLAttributes<HTMLInputElement>;
 }
 
-export class TableRow<T> extends React.Component<TableRowProps<T>, {}> {
-	shouldComponentUpdate(nextProps: TableRowProps<T>) {
-		const update = !isEqual(nextProps, this.props);
-		return update;
-	}
+export class TableRow<T> extends React.PureComponent<TableRowProps<T>, {}> {
 	render() {
 		const {
 			attributes,


### PR DESCRIPTION
This should significantly improve Table rendering performance. The only potential breaking change that could affect users of the Table is mutating the `columns` prop and expecting a re-render, but because this is not recommended in the first place, I suggest we treat this as a minor change.

Connects-to: #726
Change-type: minor
Signed-off-by: Stevche Radevski <stevche@balena.io>