### PR TITLE
JSONSchema: Strip unknown string formats inside arrays

### DIFF
--- a/__tests__/utils.spec.js
+++ b/__tests__/utils.spec.js
@@ -6,6 +6,13 @@ describe('utils', () => {
     const schema = {
       type: 'object',
       properties: {
+        array: {
+          type: 'array',
+          items: {
+            type: 'string',
+            format: 'dnsmasq-address'
+          }
+        },
         foo: {
           type: 'object',
           properties: {
@@ -30,6 +37,12 @@ describe('utils', () => {
       expect(utils.stripSchemaFormats(schema)).toEqual({
         type: 'object',
         properties: {
+          array: {
+            type: 'array',
+            items: {
+              type: 'string'
+            }
+          },
           foo: {
             type: 'object',
             properties: {
@@ -56,6 +69,12 @@ describe('utils', () => {
       expect(utils.stripSchemaFormats(schema, whitelist)).toEqual({
         type: 'object',
         properties: {
+          array: {
+            type: 'array',
+            items: {
+              type: 'string'
+            }
+          },
           foo: {
             type: 'object',
             properties: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rendition",
-  "version": "4.49.1",
+  "version": "4.49.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -173,6 +173,9 @@ export const stripSchemaFormats = (
 				_strip(subSchema as JSONSchema6);
 			});
 		}
+		if (schema.items) {
+			_strip(schema.items as JSONSchema6);
+		}
 	};
 
 	_strip(newSchema);


### PR DESCRIPTION
Right now we strip unknown string formats in `JSONSchema` to avoid `rjsf`
crashing when trying to render them. The formats were not stripped for
schemas defining items inside arrays. Fixed that.

Fixes: #743