### PR TITLE
Fix top-level array handling in Form/JellyForm

### DIFF
--- a/__tests__/components/Form.spec.js
+++ b/__tests__/components/Form.spec.js
@@ -216,6 +216,28 @@ describe('Form component', () => {
     })
   })
 
+  describe('top-level array fields', () => {
+    const arraySchema = {
+      'items': {
+        'type': 'string'
+      },
+      'type': 'array'
+    }
+
+    const callback = sinon.spy()
+
+    it('should not crash on render', () => {
+      mount(
+        <Provider>
+          <Form
+            schema={arraySchema}
+            onFormChange={callback}
+          />
+        </Provider>
+      )
+    })
+  })
+
   describe('array fields', () => {
     const arraySchema = {
       type: 'object',

--- a/__tests__/components/JellyForm.spec.js
+++ b/__tests__/components/JellyForm.spec.js
@@ -211,6 +211,28 @@ describe('JellyForm component', () => {
     })
   })
 
+  describe('top-level array fields', () => {
+    const schema = `
+      type: array
+      items:
+        type: string
+        formula: UUIDV4()
+    `
+
+    const callback = sinon.spy()
+
+    it('should not crash on render', () => {
+      mount(
+        <Provider>
+          <JellyForm
+            schema={schema}
+            onFormChange={callback}
+          />
+        </Provider>
+      )
+    })
+  })
+
   describe('array fields', () => {
     const arraySchema = `
       version: 1

--- a/src/unstable/components/Form/index.tsx
+++ b/src/unstable/components/Form/index.tsx
@@ -71,8 +71,8 @@ export default class FormHOC extends React.Component<
 		super(props);
 
 		this.state = {
-			value: this.props.value || {},
-			schema: this.parseSchema(this.props.schema),
+			value: props.value || (props.schema.type === 'array' ? [] : {}),
+			schema: this.parseSchema(props.schema),
 		};
 	}
 

--- a/src/unstable/components/JellyForm.tsx
+++ b/src/unstable/components/JellyForm.tsx
@@ -94,7 +94,7 @@ class JellyForm extends React.Component<JellyFormProps, JellyFormState> {
 		);
 
 		this.state = {
-			value: props.value || {},
+			value: props.value || (schema.type === 'array' ? [] : {}),
 			schema,
 			uiSchema,
 		};


### PR DESCRIPTION
When rendering a Form/JellyForm based on JSONSchema where its top-level
type would be an array we tried to put in a default value of `{}` which
crashed rjsf. Using better defaults now (`[]`) in these cases.

* Not sure if this is idiomatic TS/JS code (e.g. `static`)
* Not sure if this change needs to be replicated in Form and JellyForm - I followed the example in the existing code there - it was setting the default of `{}` in both places. Should contructors call each other instead ?

Fixes #743 

