### PR TITLE
Fix formula evaluation inside arrays

### DIFF
--- a/__tests__/components/JellyForm.formulas.spec.js
+++ b/__tests__/components/JellyForm.formulas.spec.js
@@ -34,6 +34,7 @@ describe('JellyForm formula runner should', () => {
   describe('substitute formula text from schema', () => {
     it('on the the top level', () => {
       const schema = {
+        type: 'object',
         properties: {
           time: {
             type: 'string',
@@ -49,14 +50,20 @@ describe('JellyForm formula runner should', () => {
       expect(ran).not.toEqual(data)
       expect(ran.time).toBeTruthy()
     })
-    it('when wrapped in object', () => {
+
+    it('when wrapped in an object', () => {
       const schema = {
+        type: 'object',
         properties: {
           wrapper: {
-            time: {
-              type: 'string',
-              $$formula: 'NOW()'
-            }}
+            type: 'object',
+            properties: {
+              time: {
+                type: 'string',
+                $$formula: 'NOW()'
+              }
+            }
+          }
         }
       }
       const data = {
@@ -68,6 +75,61 @@ describe('JellyForm formula runner should', () => {
       const ran = runFormulas(schema, data)
       expect(ran).not.toEqual(data)
       expect(ran.wrapper.time).toBeTruthy()
+    })
+
+    it('when wrapped in an array', () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          wrapper: {
+            type: 'array',
+            items: {
+              type: 'string',
+              $$formula: 'NOW()'
+            }
+          }
+        }
+      }
+      const data = {
+        wrapper: [{
+          time: 'some previous value'
+        }]
+      }
+
+      const ran = runFormulas(schema, data)
+      expect(ran).not.toEqual(data)
+      expect(ran.wrapper[0]).toBeTruthy()
+    })
+
+    it('when wrapped in a nested array', () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          wrapper: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                anotherWrapper: {
+                  type: 'array',
+                  items:
+                    {
+                      type: 'string',
+                      $$formula: 'NOW()'
+                    }}}}}}
+      }
+
+      const data = {
+        wrapper: [{
+          anotherWrapper: [{
+            time: 'some previous value'
+          }]
+        }]
+      }
+
+      const ran = runFormulas(schema, data)
+      expect(ran).not.toEqual(data)
+      expect(ran.wrapper[0].anotherWrapper[0]).toBeTruthy()
     })
   })
 })

--- a/src/unstable/components/JellyForm/formulas.tsx
+++ b/src/unstable/components/JellyForm/formulas.tsx
@@ -6,43 +6,12 @@ import isPlainObject = require('lodash/isPlainObject');
 import merge = require('lodash/merge');
 import set = require('lodash/set');
 
-const getFormulaKeys = function(obj: any, prefix: string = '') {
-	const keys = Object.keys(obj);
-	prefix = prefix ? prefix + '.' : '';
-	return keys.reduce(
-		(result, key) => {
-			if (isPlainObject(obj[key])) {
-				result = result.concat(getFormulaKeys(obj[key], prefix + key));
-			} else if (key === '$$formula') {
-				result.push(prefix + key);
-			}
-			return result;
-		},
-		[] as string[],
-	);
-};
-
 // Given a JSON Schema, find all fields that have a formula field, evaluate the
 // formula and then update the provided value with the result
 const runFormulas = (schema: JSONSchema6, value: any) => {
-	// Start by cloning the value to avoid any awkward mutation bugs
 	const data = cloneDeep(value);
 
-	// Find all the keypaths that use formulas
-	const keys = getFormulaKeys(schema).map(path => {
-		return {
-			formula: get(schema, path),
-			path: path.replace(/properties\./g, ''),
-		};
-	});
-
-	// Replace each field that is the result of a formula with the formula itself.
-	// This is done because the formula may reference other fields in the data
-	// object, and they all need to be present when running the object through
-	// temen.
-	keys.forEach(y => {
-		set(data, y.path, y.formula);
-	});
+	replaceDataWithFormulaContent(schema, data);
 
 	let evaluate;
 
@@ -60,6 +29,68 @@ const runFormulas = (schema: JSONSchema6, value: any) => {
 
 const defaultValueForSchema = (schema: JSONSchema6) => {
 	return schema.type === 'array' ? [] : {};
+};
+
+const replaceDataWithFormulaContent = (schema: JSONSchema6, data: any) => {
+	// Find all the keypaths that use formulas
+	const keys = getFormulaKeys(schema).map(path => {
+		return {
+			formula: get(schema, path),
+			path: path.replace(/properties\./g, ''),
+		};
+	});
+
+	// Replace each field that is the result of a formula with the formula itself.
+	// This is done because the formula may reference other fields in the data
+	// object, and they all need to be present when running the object through
+	// temen.
+	keys.forEach(formula => {
+		const fullPath = formula.path;
+		const formulaText = formula.formula;
+
+		if (!fullPath.includes('.items.')) {
+			set(data, fullPath, formulaText);
+		} else {
+			const pathFragments = fullPath.split('.items.');
+			replaceArrayWithFormulaContent(pathFragments, data, formulaText);
+		}
+	});
+};
+
+const replaceArrayWithFormulaContent = (
+	pathFragments: string[],
+	data: any,
+	formulaText: string,
+) => {
+	const firstFragment = pathFragments[0];
+	const lastFragment = pathFragments[1];
+	const array = data[firstFragment] || [];
+	if (pathFragments.length > 2) {
+		const subFragments = pathFragments.slice(1, pathFragments.length);
+		array.forEach((item: any) => {
+			replaceArrayWithFormulaContent(subFragments, item, formulaText);
+		});
+	} else {
+		array.forEach((item: any) => {
+			set(item, lastFragment, formulaText);
+		});
+	}
+};
+
+const getFormulaKeys = (obj: any, prefix: string = '') => {
+	const keys = Object.keys(obj);
+	prefix = prefix ? prefix + '.' : '';
+	return keys.reduce(
+		(result, key) => {
+			if (isPlainObject(obj[key])) {
+				result = result.concat(getFormulaKeys(obj[key], prefix + key));
+			} else if (key === '$$formula') {
+				result.push(prefix + key);
+			}
+			return result;
+		},
+		[] as string[],
+	);
 };
 
 export { defaultValueForSchema, runFormulas };


### PR DESCRIPTION
Fixes #759 - a problem where if a formula definition would be inside of an array, it would not get evaluated properly.

### Background 
More info:
We preprocess the data before sending it to temen to evaluate - we put the formulas from the schema in the relevant places inside the data. This was done for objects but not for arrays of objects. The code in this PR basically goes through the data object and makes sure that for every item in every array on any level we invoke the substitution of existing data for the formula. 

While the code works and passes the tests - I'm creating a draft PR because I would like to discuss the approach here first before merging this (also a cool opportunity to test the new github draft PR stuff;) Once this is discussed and any changed to the code are done I will clean up the commits list and make versionist happy.

### Discussion:

I added more tests on the UI level to test this, however I feel that these are of not the best type of a test to use here - I'm testing data transformation logic through the UI, which makes the test more brittle and less clear. 

I was thinking what to do with the above and have two ideas here:
1) In the future - it may be good to move all this `data + schema => data_with_formulas` logic inside reconfix maybe, so that JellyForm only calls these functions ? Or maybe there is an existing functionality that we could reuse here ? cc @zrzka here

2) Extract out the code that does the formula transformations to the data to a separate place and test separately. UI tests would only test UI behavior and unit tests for the pure functions would test the data transformation. Do we want to do this in this PR maybe ? Or a PR that would be merged before this one ? 

In terms of implementation I have some doubts as well:
- Is there a simpler way to do the substitution ? When this code was used to substitute key-value pairs in objects it used lodash's `set` function and it was pretty much just an invocation of the said function in a loop. I tried to find a way to do the same for data in an array using lodash or similar libraries but couldn't find anything, but may have missed that - is there a more idiomatic way to do this ? The current implementation as in this PR feels quite naive.