### PR TITLE
Refactoring: extract functions responsible for running formulas.

### DIFF
--- a/__tests__/components/JellyForm.formulas.spec.js
+++ b/__tests__/components/JellyForm.formulas.spec.js
@@ -1,0 +1,73 @@
+/* globals expect, describe, it */
+
+import { runFormulas } from '../../src/unstable/components/JellyForm/formulas'
+
+describe('JellyForm formula runner should', () => {
+  it('not modify empty object', () => {
+    const schema = {}
+    const data = {}
+    const ran = runFormulas(schema, data)
+    expect(ran).toEqual(data)
+  })
+
+  it('not modify object without a schema', () => {
+    const schema = {}
+    const data = {
+      hello: 'one',
+      nested: {
+        sub: 'two'
+      },
+      nestedArray: [
+        {
+          itemId: 'first'
+        },
+        {
+          itemId: 'second'
+        }
+      ]
+    }
+
+    const ran = runFormulas(schema, data)
+    expect(ran).toEqual(data)
+  })
+
+  describe('substitute formula text from schema', () => {
+    it('on the the top level', () => {
+      const schema = {
+        properties: {
+          time: {
+            type: 'string',
+            $$formula: 'NOW()'
+          }
+        }
+      }
+      const data = {
+        time: 'some previous value'
+      }
+
+      const ran = runFormulas(schema, data)
+      expect(ran).not.toEqual(data)
+      expect(ran.time).toBeTruthy()
+    })
+    it('when wrapped in object', () => {
+      const schema = {
+        properties: {
+          wrapper: {
+            time: {
+              type: 'string',
+              $$formula: 'NOW()'
+            }}
+        }
+      }
+      const data = {
+        wrapper: {
+          time: 'some previous value'
+        }
+      }
+
+      const ran = runFormulas(schema, data)
+      expect(ran).not.toEqual(data)
+      expect(ran.wrapper.time).toBeTruthy()
+    })
+  })
+})

--- a/src/unstable/components/JellyForm/formulas.tsx
+++ b/src/unstable/components/JellyForm/formulas.tsx
@@ -1,0 +1,65 @@
+import * as temen from 'balena-temen';
+import { JSONSchema6 } from 'json-schema';
+import cloneDeep = require('lodash/cloneDeep');
+import get = require('lodash/get');
+import isPlainObject = require('lodash/isPlainObject');
+import merge = require('lodash/merge');
+import set = require('lodash/set');
+
+const getFormulaKeys = function(obj: any, prefix: string = '') {
+	const keys = Object.keys(obj);
+	prefix = prefix ? prefix + '.' : '';
+	return keys.reduce(
+		(result, key) => {
+			if (isPlainObject(obj[key])) {
+				result = result.concat(getFormulaKeys(obj[key], prefix + key));
+			} else if (key === '$$formula') {
+				result.push(prefix + key);
+			}
+			return result;
+		},
+		[] as string[],
+	);
+};
+
+// Given a JSON Schema, find all fields that have a formula field, evaluate the
+// formula and then update the provided value with the result
+const runFormulas = (schema: JSONSchema6, value: any) => {
+	// Start by cloning the value to avoid any awkward mutation bugs
+	const data = cloneDeep(value);
+
+	// Find all the keypaths that use formulas
+	const keys = getFormulaKeys(schema).map(path => {
+		return {
+			formula: get(schema, path),
+			path: path.replace(/properties\./g, ''),
+		};
+	});
+
+	// Replace each field that is the result of a formula with the formula itself.
+	// This is done because the formula may reference other fields in the data
+	// object, and they all need to be present when running the object through
+	// temen.
+	keys.forEach(y => {
+		set(data, y.path, y.formula);
+	});
+
+	let evaluate;
+
+	// Attempt to evaluate the final data object containing formulas, if there is
+	// an error, then set the result to the original value.
+	try {
+		evaluate = temen.evaluate(data);
+	} catch (e) {
+		console.error('Caught error when evaluating formulas', e);
+		evaluate = value;
+	}
+	const startingState = defaultValueForSchema(schema);
+	return merge(startingState, value, evaluate);
+};
+
+const defaultValueForSchema = (schema: JSONSchema6) => {
+	return schema.type === 'array' ? [] : {};
+};
+
+export { defaultValueForSchema, runFormulas };

--- a/src/unstable/components/JellyForm/index.tsx
+++ b/src/unstable/components/JellyForm/index.tsx
@@ -1,73 +1,14 @@
-import * as temen from 'balena-temen';
 import * as jellyschema from 'jellyschema';
 import { JSONSchema6 } from 'json-schema';
 import cloneDeep = require('lodash/cloneDeep');
-import get = require('lodash/get');
 import isEqual = require('lodash/isEqual');
-import isPlainObject = require('lodash/isPlainObject');
 import merge = require('lodash/merge');
 import omit = require('lodash/omit');
-import set = require('lodash/set');
 import * as React from 'react';
 import { BaseFormProps } from 'rendition/dist/unstable';
 import { JellyFormProps } from 'rendition/dist/unstable/components/JellyForm';
-import { default as Form } from './Form';
-
-const getFormulaKeys = function(obj: any, prefix: string = '') {
-	const keys = Object.keys(obj);
-	prefix = prefix ? prefix + '.' : '';
-	return keys.reduce(
-		(result, key) => {
-			if (isPlainObject(obj[key])) {
-				result = result.concat(getFormulaKeys(obj[key], prefix + key));
-			} else if (key === '$$formula') {
-				result.push(prefix + key);
-			}
-			return result;
-		},
-		[] as string[],
-	);
-};
-
-// Given a JSON Schema, find all fields that have a formula field, evaluate the
-// formula and then update the provided value with the result
-const runFormulas = (schema: JSONSchema6, value: any) => {
-	// Start by cloning the value to avoid any awkward mutation bugs
-	const data = cloneDeep(value);
-
-	// Find all the keypaths that use formulas
-	const keys = getFormulaKeys(schema).map(path => {
-		return {
-			formula: get(schema, path),
-			path: path.replace(/properties\./g, ''),
-		};
-	});
-
-	// Replace each field that is the result of a formula with the formula itself.
-	// This is done because the formula may reference other fields in the data
-	// object, and they all need to be present when running the object through
-	// temen.
-	keys.forEach(y => {
-		set(data, y.path, y.formula);
-	});
-
-	let evaluate;
-
-	// Attempt to evaluate the final data object containing formulas, if there is
-	// an error, then set the result to the original value.
-	try {
-		evaluate = temen.evaluate(data);
-	} catch (e) {
-		console.error('Caught error when evaluating formulas', e);
-		evaluate = value;
-	}
-	const startingState = defaultValueForSchema(schema);
-	return merge(startingState, value, evaluate);
-};
-
-const defaultValueForSchema = (schema: JSONSchema6) => {
-	return schema.type === 'array' ? [] : {};
-};
+import { default as Form } from '../Form';
+import { defaultValueForSchema, runFormulas } from './formulas';
 
 const computeFormSchemas = (jellySchema: string, uiSchema: any) => {
 	const computed = jellyschema.generateJsonAndUiSchema(jellySchema);


### PR DESCRIPTION
This is a prefactoring for the coming fixes to the mechanism of running
formulas, see discussion in #767.

* Make JellyForm component into a directory
* Extract `runFormulas` and friends out
* Add tests to describe current behavior

Let me know if this makes sense or if there is a more idiomatic way to do the extraction maybe ?
