### PR TITLE
Use native Date instead of Momentjs

### DIFF
--- a/__tests__/DataTypes.spec.js
+++ b/__tests__/DataTypes.spec.js
@@ -1,5 +1,6 @@
 /* globals expect, describe, it */
 import { getDataModel } from '../src/components/DataTypes'
+import { normalizeDateTime } from '../src/components/DataTypes/date-time-helpers'
 
 const expectMatchesKeys = (data, keys) =>
   expect(Object.keys(data).sort()).toEqual(keys.sort())
@@ -67,6 +68,21 @@ describe('DataTypes', () => {
         type: 'number'
       }
       expectMatchesKeys(getDataModel(schema), dataModelKeys)
+    })
+  })
+
+  describe('normalizeDateTime', () => {
+    it('rejects invalid date', () => {
+      expect(normalizeDateTime('wrong time')).toEqual('Invalid date')
+      expect(normalizeDateTime('')).toEqual('Invalid date')
+    })
+
+    it('formats the date correctly', () => {
+      expect(normalizeDateTime('2017-01-01T08:49:26Z')).toEqual('2017-01-01T08:49:26Z')
+      // This case will fail, if you are in a different TZ than UTC
+      // Set a TZ when running tests: $ TZ='Europe/London' npm test
+      expect(normalizeDateTime('2018-03-26T11:43')).toEqual('2018-03-26T11:43:00Z')
+      expect(normalizeDateTime('Sun, 01 Jan 2017 08:49:26 +0000')).toEqual('2017-01-01T08:49:26Z')
     })
   })
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -12492,7 +12492,6 @@
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
       "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
       "dev": true,
-      "optional": true,
       "requires": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
@@ -12502,15 +12501,13 @@
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -114,7 +114,6 @@
     "lodash": "^4.17.4",
     "marked": "^0.4.0",
     "mermaid": "^8.0.0-rc.8",
-    "moment": "^2.20.1",
     "react-icons": "^2.2.5",
     "react-jsonschema-form": "^1.2.1",
     "recompose": "0.26.0",

--- a/src/components/DataTypes/date-time-helpers.tsx
+++ b/src/components/DataTypes/date-time-helpers.tsx
@@ -1,0 +1,31 @@
+import memoize = require('lodash/memoize');
+import * as moment from 'moment';
+
+const pad = (n: number) => (n < 10 ? `0${n}` : n);
+
+export const getDefaultDate = (): string => {
+	const now = new Date();
+	const day = pad(now.getDate());
+	const month = pad(now.getMonth() + 1);
+	return `${now.getFullYear()}-${month}-${day}T10:00`;
+};
+
+// Normalize a timestamp to a RFC3339 timestamp, which is required for JSON
+// schema.
+export const normalizeDateTimeNew = memoize((timestamp: string) => {
+	const d = new Date(timestamp);
+	if (isNaN(d.getTime())) {
+		return 'Invalid date';
+	}
+	return `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(
+		d.getUTCDate(),
+	)}T${pad(d.getUTCHours())}:${pad(d.getUTCMinutes())}:${pad(
+		d.getUTCSeconds(),
+	)}Z`;
+});
+
+export const normalizeDateTime = memoize((timestamp: string) =>
+	moment(timestamp)
+		.utc()
+		.format(),
+);

--- a/src/components/DataTypes/date-time-helpers.tsx
+++ b/src/components/DataTypes/date-time-helpers.tsx
@@ -1,24 +1,17 @@
 import memoize = require('lodash/memoize');
 
-const pad = (n: number) => (n < 10 ? `0${n}` : n);
-
 export const getDefaultDate = (): string => {
-	const now = new Date();
-	const day = pad(now.getDate());
-	const month = pad(now.getMonth() + 1);
-	return `${now.getFullYear()}-${month}-${day}T10:00`;
+	const date = new Date();
+	date.setUTCHours(0, 0, 0, 0);
+	return date.toISOString().split('.')[0] + 'Z';
 };
 
-// Normalize a timestamp to a RFC3339 timestamp, which is required for JSON
-// schema.
+// Normalize a timestamp to a RFC3339 timestamp, which is required for JSON schema.
 export const normalizeDateTime = memoize((timestamp: string) => {
 	const d = new Date(timestamp);
 	if (isNaN(d.getTime())) {
 		return 'Invalid date';
 	}
-	return `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(
-		d.getUTCDate(),
-	)}T${pad(d.getUTCHours())}:${pad(d.getUTCMinutes())}:${pad(
-		d.getUTCSeconds(),
-	)}Z`;
+	// Remove miliseconds
+	return d.toISOString().split('.')[0] + 'Z';
 });

--- a/src/components/DataTypes/date-time-helpers.tsx
+++ b/src/components/DataTypes/date-time-helpers.tsx
@@ -1,5 +1,4 @@
 import memoize = require('lodash/memoize');
-import * as moment from 'moment';
 
 const pad = (n: number) => (n < 10 ? `0${n}` : n);
 
@@ -12,7 +11,7 @@ export const getDefaultDate = (): string => {
 
 // Normalize a timestamp to a RFC3339 timestamp, which is required for JSON
 // schema.
-export const normalizeDateTimeNew = memoize((timestamp: string) => {
+export const normalizeDateTime = memoize((timestamp: string) => {
 	const d = new Date(timestamp);
 	if (isNaN(d.getTime())) {
 		return 'Invalid date';
@@ -23,9 +22,3 @@ export const normalizeDateTimeNew = memoize((timestamp: string) => {
 		d.getUTCSeconds(),
 	)}Z`;
 });
-
-export const normalizeDateTime = memoize((timestamp: string) =>
-	moment(timestamp)
-		.utc()
-		.format(),
-);

--- a/src/components/DataTypes/date-time.tsx
+++ b/src/components/DataTypes/date-time.tsx
@@ -1,29 +1,10 @@
 import { JSONSchema6 } from 'json-schema';
 import assign = require('lodash/assign');
-import memoize = require('lodash/memoize');
-import * as moment from 'moment';
 import * as React from 'react';
 import { DataTypeEditProps, InputProps } from 'rendition';
 import * as utils from '../../utils';
 import Input from '../Input';
-
-const getDefaultDate = (): string => {
-	const now = new Date();
-	const day = ('0' + now.getDate()).slice(-2);
-	const month = ('0' + (now.getMonth() + 1)).slice(-2);
-	const today = now.getFullYear() + '-' + month + '-' + day;
-
-	return `${today}T00:00`;
-};
-
-// Normalize a timestamp to a RFC3339 timestamp, which is required for JSON
-// schema.
-// https://momentjs.com/docs/#default-format
-const normalizeDateTime = memoize((timestamp: string) =>
-	moment(timestamp)
-		.utc()
-		.format(),
-);
+import { getDefaultDate, normalizeDateTime } from './date-time-helpers';
 
 export const operators = {
 	is: {


### PR DESCRIPTION
Change-type: patch
Connects-to: #760 

First tested the previous Moment.js implementation and then changed it to Date()