### PR TITLE
Upgrade xterm to fix crashing on tab character

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17926,7 +17926,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-css-comments/-/strip-css-comments-3.0.0.tgz",
       "integrity": "sha1-elYl7/iisibPiUehElTaluE9rok=",
-      "dev": true,
       "requires": {
         "is-regexp": "^1.0.0"
       }
@@ -19675,9 +19674,9 @@
       "dev": true
     },
     "xterm": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/xterm/-/xterm-3.12.0.tgz",
-      "integrity": "sha512-U5w1NJdrqAtnNju4W05uOxLzNgMD1sk0AnIkZ//Wa7xRdQTi9Dl1qkPdAaxWJ1a7A8xzNM4ogrX/4oSVl15qOw=="
+      "version": "3.12.2",
+      "resolved": "https://registry.npmjs.org/xterm/-/xterm-3.12.2.tgz",
+      "integrity": "sha512-FSXovDdsqIKqoayC6+zFzhaHi+A3NSceM5rgTW88DH7sS96HdwMToB2p1rW+FyNsSqfAgFwlXDRQk+fh/aHvPQ=="
     },
     "y18n": {
       "version": "3.2.1",

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "styled-system": "^1.0.5",
     "tag-hoc": "1.0.0",
     "uuid": "^3.2.1",
-    "xterm": "^3.12.0"
+    "xterm": "^3.12.2"
   },
   "lint-staged": {
     "{package.json, package-lock.json}": [


### PR DESCRIPTION
The issue was fixed by https://github.com/xtermjs/xterm.js/releases/tag/3.12.1

Connects-to: #805
Change-type: patch
Signed-off-by: Stevche Radevski <stevche@balena.io>