### PR TITLE
Make typings for all components a bit more accurate.

### DIFF
--- a/__tests__/components/__snapshots__/Heading.spec.js.snap
+++ b/__tests__/components/__snapshots__/Heading.spec.js.snap
@@ -5,7 +5,7 @@ exports[`Heading renders correctly 1`] = `
   className="sc-bdVaJa iLLxmY"
 >
   <h3
-    className="sc-gqjmRU fFRxtu sc-gZMcBi binHFK"
+    className="sc-gqjmRU fFRxtu sc-gZMcBi ZBeRI"
   >
     Heading
   </h3>

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "@types/react-icons": "^2.2.4",
     "@types/react-jsonschema-form": "^1.0.9",
     "@types/recompose": "^0.26.2",
-    "@types/styled-components": "^4.1.8",
+    "@types/styled-components": "4.1.8",
     "@types/styled-system": "^4.0.0",
     "@types/uuid": "^3.4.3",
     "ajv": "^6.7.0",

--- a/src/asRendition.tsx
+++ b/src/asRendition.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 import { compose, getDisplayName } from 'recompose';
 import styled, { withTheme } from 'styled-components';
 import { color, fontSize, space, width } from 'styled-system';
-import { EnhancedType, StyledSystemProps } from './common-types';
+import { StyledSystemProps } from './common-types';
 import { Tooltips } from './tooltips';
 
 const tooltip = new Tooltips();
@@ -78,7 +78,7 @@ export const withTooltip = (Base: React.ComponentType) => {
 };
 
 export default function asRendition<T>(
-	component: React.ComponentType<T>,
+	component: React.ComponentType,
 	additionalEnhancers: Array<
 		(Base: React.ComponentType) => React.ComponentType
 	> = [],
@@ -90,5 +90,5 @@ export default function asRendition<T>(
 		withTooltip,
 		withStyledSystem,
 		filterStyledSystemProps(passthroughProps),
-	)(component) as unknown) as React.ComponentType<EnhancedType<T>>;
+	)(component) as unknown) as T;
 }

--- a/src/common-types.ts
+++ b/src/common-types.ts
@@ -131,7 +131,7 @@ export interface Sizing {
 	emphasized?: boolean;
 }
 
-export type EnhancedType<T> = T & Tooltip & StyledSystemProps;
+export type RenditionSystemProps = Tooltip & StyledSystemProps;
 
 export type TooltipPlacement = 'top' | 'right' | 'bottom' | 'left';
 

--- a/src/components/Alert.tsx
+++ b/src/components/Alert.tsx
@@ -6,16 +6,14 @@ import FaExclamationTriangle = require('react-icons/lib/fa/exclamation-triangle'
 import FaInfoCircle = require('react-icons/lib/fa/info-circle');
 import styled from 'styled-components';
 import asRendition from '../asRendition';
-import { Coloring, DefaultProps, Sizing } from '../common-types';
+import {
+	Coloring,
+	DefaultProps,
+	RenditionSystemProps,
+	Sizing,
+} from '../common-types';
 import { bold, getColor, normal, px } from '../utils';
 import { Flex } from './Grid';
-
-export interface AlertProps extends DefaultProps, Coloring, Sizing {
-	plaintext?: boolean;
-	bg?: string;
-	prefix?: JSX.Element | string | false;
-	onDismiss?: () => void;
-}
 
 const getPadding = (props: AlertProps) =>
 	props.emphasized ? '15px 40px' : '8px 32px';
@@ -45,7 +43,7 @@ const AlertTitle = styled.span`
 
 // Firefox didn't middle align absolute positioned elements
 // using flex, so we had to use an extra wrapper element
-const DismissButtonWrapper = styled.div<AlertProps>`
+const DismissButtonWrapper = styled.div<InternalAlertProps>`
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
@@ -68,7 +66,7 @@ const DismissButton = styled.button`
 	}
 `;
 
-const AlertBase = styled.div<AlertProps>`
+const AlertBase = styled.div<InternalAlertProps>`
 	display: flex;
 	align-items: center;
 	justify-content: normal;
@@ -90,7 +88,7 @@ const AlertBase = styled.div<AlertProps>`
 `;
 
 // That's the normal alert
-const Outline = styled(AlertBase)<AlertProps>`
+const Outline = styled(AlertBase)<InternalAlertProps>`
 	padding-left: 19px;
 	border: 1px solid ${props => getColor(props, 'bg', 'main')};
 	background: ${props => props.bg || getColor(props, 'bg', 'light')};
@@ -102,7 +100,7 @@ const Outline = styled(AlertBase)<AlertProps>`
 	}
 `;
 
-const Filled = styled(AlertBase)<AlertProps>`
+const Filled = styled(AlertBase)<InternalAlertProps>`
 	border: 0;
 	font-weight: ${props => bold(props)};
 	text-align: center;
@@ -110,7 +108,7 @@ const Filled = styled(AlertBase)<AlertProps>`
 	color: ${props => props.color || '#fff'};
 `;
 
-const Plaintext = styled(AlertBase)<AlertProps>`
+const Plaintext = styled(AlertBase)<InternalAlertProps>`
 	min-height: auto;
 	padding: 0;
 	font-size: 14px;
@@ -125,7 +123,7 @@ const Plaintext = styled(AlertBase)<AlertProps>`
 	}
 `;
 
-const getIcon = (props: AlertProps) => {
+const getIcon = (props: InternalAlertProps) => {
 	if (props.prefix === false) {
 		return;
 	}
@@ -153,7 +151,7 @@ const DismissAlert = ({ onDismiss }: { onDismiss: () => void }) => (
 	</DismissButtonWrapper>
 );
 
-const Alert = (props: AlertProps) => {
+const Alert = (props: InternalAlertProps) => {
 	const { emphasized, plaintext, prefix, onDismiss, ...restProps } = props;
 	const title = plaintext ? getIcon(props) : getTitle(props);
 	if (plaintext) {
@@ -189,4 +187,16 @@ const Alert = (props: AlertProps) => {
 	}
 };
 
-export default asRendition<AlertProps>(Alert, [], ['bg']);
+interface InternalAlertProps extends DefaultProps, Coloring, Sizing {
+	plaintext?: boolean;
+	bg?: string;
+	prefix?: JSX.Element | string | false;
+	onDismiss?: () => void;
+}
+
+export type AlertProps = InternalAlertProps & RenditionSystemProps;
+export default asRendition<React.FunctionComponent<AlertProps>>(
+	Alert,
+	[],
+	['bg'],
+);

--- a/src/components/ArcSlider.tsx
+++ b/src/components/ArcSlider.tsx
@@ -1,14 +1,7 @@
 import * as React from 'react';
 import styled from 'styled-components';
 import { constrainNumber, darken, getAngleBetweenPoints } from '../utils';
-import { Box, BoxProps, Flex, FlexProps } from './Grid';
-
-export interface ArcSliderProps extends BoxProps {
-	onValueChange?: (value: number) => void;
-	value?: number;
-	fillColor?: string;
-	background?: string;
-}
+import { Box, BoxProps, Flex } from './Grid';
 
 const ANGLERANGE = 135;
 
@@ -20,7 +13,7 @@ const StyledSVG = styled.svg`
 
 const ArcSliderContainer = styled(Box)`
 	position: relative;
-` as React.ComponentType<BoxProps>;
+`;
 
 const LabelContainer = styled(Flex).attrs({
 	justifyContent: 'center',
@@ -33,7 +26,7 @@ const LabelContainer = styled(Flex).attrs({
 	left: 0;
 	text-align: center;
 	pointer-events: none;
-` as React.ComponentType<FlexProps>;
+`;
 
 const polarToCartesian = (
 	centerX: number,
@@ -178,7 +171,7 @@ class ArcSlider extends React.Component<ArcSliderProps, ArcSliderState> {
 					style={{
 						cursor: this.state.isDragging ? 'grabbing' : 'grab',
 					}}
-					ref={(elem: any) => (this.$slider = elem)}
+					ref={elem => (this.$slider = elem)}
 					viewBox="0 0 600 600"
 					onMouseDown={this.handleMouseDown}
 					onTouchStart={this.handleMouseDown}
@@ -247,6 +240,13 @@ class ArcSlider extends React.Component<ArcSliderProps, ArcSliderState> {
 			</ArcSliderContainer>
 		);
 	}
+}
+
+export interface ArcSliderProps extends BoxProps {
+	onValueChange?: (value: number) => void;
+	value?: number;
+	fillColor?: string;
+	background?: string;
 }
 
 export default ArcSlider;

--- a/src/components/Badge.tsx
+++ b/src/components/Badge.tsx
@@ -4,30 +4,19 @@ import memoize = require('lodash/memoize');
 import * as React from 'react';
 import styled from 'styled-components';
 import asRendition from '../asRendition';
-import { Coloring, EnhancedType, Theme } from '../common-types';
+import { Coloring, RenditionSystemProps, Theme } from '../common-types';
 import { getColor, px } from '../utils';
 import { Box, BoxProps } from './Grid';
 
-export interface BadgeProps extends BoxProps, Coloring {
-	text: string;
-	small?: boolean;
-	color?: string;
-	bg?: string;
-}
-
 const colorHash = new ColorHash();
 const backgroundColor = memoize((text: string): string => colorHash.hex(text));
-
-export interface ThemedBadgeProps extends BadgeProps {
-	theme: Theme;
-}
 
 const BaseBadge = styled(Box)`
 	border-radius: ${props => px(props.theme.radius)};
 	display: inline-block;
 	min-width: 40px;
 	text-align: center;
-` as React.ComponentType<EnhancedType<BoxProps>>;
+`;
 
 const Badge = ({ small, text, theme, ...props }: ThemedBadgeProps) => {
 	return (
@@ -46,4 +35,21 @@ const Badge = ({ small, text, theme, ...props }: ThemedBadgeProps) => {
 	);
 };
 
-export default asRendition<BadgeProps>(Badge, [], ['bg', 'color']);
+export interface InternalBadgeProps extends BoxProps, Coloring {
+	text: string;
+	small?: boolean;
+	color?: string;
+	bg?: string;
+}
+
+export interface ThemedBadgeProps extends InternalBadgeProps {
+	theme: Theme;
+}
+
+export type BadgeProps = InternalBadgeProps & RenditionSystemProps;
+
+export default asRendition<React.FunctionComponent<BadgeProps>>(
+	Badge,
+	[],
+	['bg', 'color'],
+);

--- a/src/components/BadgeSelect.tsx
+++ b/src/components/BadgeSelect.tsx
@@ -2,25 +2,10 @@ import has = require('lodash/has');
 import includes = require('lodash/includes');
 import * as React from 'react';
 import styled from 'styled-components';
-import { EnhancedType } from '../common-types';
 import Badge from './Badge';
 import Divider from './Divider';
 import DropDownButton, { DropDownButtonProps } from './DropDownButton';
 import Txt from './Txt';
-
-export interface BadgeSelectProps extends DropDownButtonProps {
-	items: string[];
-	extraPrefix?: string[];
-	extraSuffix?: string[];
-	extra?: string[];
-	onItemChange?: (value: string) => void;
-	defaultSelected?: string;
-	placeholder?: string;
-}
-
-export interface BadgeSelectState {
-	selected: string | null | undefined;
-}
 
 const ButtonWrapper = styled.button`
 	border: 0;
@@ -41,11 +26,8 @@ const ButtonWrapper = styled.button`
 	}
 `;
 
-class BadgeSelect extends React.Component<
-	EnhancedType<BadgeSelectProps>,
-	BadgeSelectState
-> {
-	constructor(props: EnhancedType<BadgeSelectProps>) {
+class BadgeSelect extends React.Component<BadgeSelectProps, BadgeSelectState> {
+	constructor(props: BadgeSelectProps) {
 		super(props);
 
 		this.state = {
@@ -127,6 +109,20 @@ class BadgeSelect extends React.Component<
 			</DropDownButton>
 		);
 	}
+}
+
+export interface BadgeSelectProps extends DropDownButtonProps {
+	items: string[];
+	extraPrefix?: string[];
+	extraSuffix?: string[];
+	extra?: string[];
+	onItemChange?: (value: string) => void;
+	defaultSelected?: string;
+	placeholder?: string;
+}
+
+export interface BadgeSelectState {
+	selected: string | null | undefined;
 }
 
 export default BadgeSelect;

--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -4,11 +4,6 @@ import styled from 'styled-components';
 import asRendition from '../asRendition';
 import { DefaultProps } from '../common-types';
 
-export interface BannerProps extends DefaultProps {
-	backgroundImage?: string;
-	minHeight?: string;
-}
-
 const setDefaultProps = withProps((props: BannerProps) => {
 	// set defaults
 	// always allow override with provided props
@@ -34,4 +29,13 @@ const Base = styled.div`
 	background-image: ${(props: any) => setBgImage(props.backgroundImage)};
 `;
 
-export default asRendition<BannerProps>(Base, [setDefaultProps]);
+export interface BannerProps extends DefaultProps {
+	backgroundImage?: string;
+	minHeight?: string;
+}
+
+export default asRendition<
+	React.ForwardRefExoticComponent<
+		BannerProps & React.RefAttributes<HTMLDivElement>
+	>
+>(Base, [setDefaultProps]);

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -4,7 +4,7 @@ import asRendition from '../asRendition';
 import {
 	Coloring,
 	DefaultProps,
-	EnhancedType,
+	RenditionSystemProps,
 	ResponsiveStyle,
 	Sizing,
 	Theme,
@@ -18,30 +18,7 @@ import {
 	normal,
 	px,
 } from '../utils';
-import { LinkProps } from './Link';
-
-interface ButtonBaseProps extends Coloring, Sizing {
-	width?: ResponsiveStyle;
-	color?: string;
-	bg?: string;
-	active?: boolean;
-	square?: boolean;
-	disabled?: boolean;
-	outline?: boolean;
-	plaintext?: boolean;
-	underline?: boolean;
-	iconElement?: JSX.Element;
-}
-
-export interface ButtonAnchorProps extends ButtonBaseProps, LinkProps {}
-
-export interface ButtonProps extends ButtonBaseProps, DefaultProps {
-	type?: 'submit' | 'reset' | 'button';
-}
-
-export interface ThemedButtonProps extends ButtonProps {
-	theme: Theme;
-}
+import { InternalLinkProps } from './Link';
 
 const squareWidth = (val: number): number => (val / 9) * 10;
 
@@ -267,17 +244,46 @@ const ButtonFactory = <T extends keyof JSX.IntrinsicElements>(tag?: T) => {
 		);
 	};
 
-	return asRendition<ButtonProps>(Button, [], ['width', 'color', 'bg']);
+	return asRendition<React.FunctionComponent<ButtonProps>>(
+		Button,
+		[],
+		['width', 'color', 'bg'],
+	);
 };
 
-const Base = ButtonFactory() as React.ComponentType<
-	EnhancedType<ButtonProps>
-> & {
-	a: React.ComponentType<EnhancedType<ButtonAnchorProps>>;
+interface ButtonBaseProps extends Coloring, Sizing {
+	width?: ResponsiveStyle;
+	color?: string;
+	bg?: string;
+	active?: boolean;
+	square?: boolean;
+	disabled?: boolean;
+	outline?: boolean;
+	plaintext?: boolean;
+	underline?: boolean;
+	iconElement?: JSX.Element;
+}
+
+export interface InternalButtonAnchorProps
+	extends ButtonBaseProps,
+		InternalLinkProps {}
+
+export interface InternalButtonProps extends ButtonBaseProps, DefaultProps {
+	type?: 'submit' | 'reset' | 'button';
+}
+
+export interface ThemedButtonProps extends InternalButtonProps {
+	theme: Theme;
+}
+
+export type ButtonProps = InternalButtonProps & RenditionSystemProps;
+export type ButtonAnchorProps = InternalButtonAnchorProps &
+	RenditionSystemProps;
+
+const Base = ButtonFactory() as React.FunctionComponent<ButtonProps> & {
+	a: React.FunctionComponent<ButtonAnchorProps>;
 };
 
-Base.a = ButtonFactory('a') as React.ComponentType<
-	EnhancedType<ButtonAnchorProps>
->;
+Base.a = ButtonFactory('a');
 
 export default Base;

--- a/src/components/ButtonGroup.tsx
+++ b/src/components/ButtonGroup.tsx
@@ -1,6 +1,5 @@
 import styled from 'styled-components';
-import { EnhancedType } from '../common-types';
-import { Flex, FlexProps } from './Grid';
+import { Flex } from './Grid';
 
 export default styled(Flex)`
 	> * {
@@ -21,4 +20,4 @@ export default styled(Flex)`
 			border-bottom-right-radius: ${props => props.theme.radius}px;
 		}
 	}
-` as React.ComponentType<EnhancedType<FlexProps>>;
+`;

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -1,7 +1,7 @@
 import map = require('lodash/map');
 import * as React from 'react';
 import styled from 'styled-components';
-import { DefaultProps } from '../common-types';
+import { DefaultProps, RenditionSystemProps } from '../common-types';
 
 import asRendition from '../asRendition';
 import { px } from '../utils';
@@ -9,15 +9,7 @@ import Divider from './Divider';
 import { Box, Flex } from './Grid';
 import Txt from './Txt';
 
-export interface CardProps extends DefaultProps {
-	title?: string;
-	cta?: JSX.Element;
-	rows?: JSX.Element[];
-	children?: any;
-	minHeight?: string;
-}
-
-const Wrapper = styled.div<CardProps>`
+const Wrapper = styled.div<{ minHeight?: string }>`
 	border: solid 1px #dfdede;
 	border-radius: ${props => px(props.theme.radius || 3)};
 	box-shadow: 0 1px 4px 0 rgba(0, 0, 0, 0.14);
@@ -29,7 +21,7 @@ const Wrapper = styled.div<CardProps>`
 
 const styledDivider = <Divider height={1} color="#dfdede" />;
 
-const Card = ({ title, cta, rows, children, ...props }: CardProps) => {
+const Card = ({ title, cta, rows, children, ...props }: InternalCardProps) => {
 	const hasHeader = title || cta;
 
 	const Header = hasHeader && (
@@ -64,4 +56,14 @@ const Card = ({ title, cta, rows, children, ...props }: CardProps) => {
 	);
 };
 
-export default asRendition<CardProps>(Card);
+export interface InternalCardProps extends DefaultProps {
+	title?: string;
+	cta?: JSX.Element;
+	rows?: JSX.Element[];
+	children?: any;
+	minHeight?: string;
+}
+
+export type CardProps = InternalCardProps & RenditionSystemProps;
+
+export default asRendition<React.FunctionComponent<CardProps>>(Card);

--- a/src/components/CodeWithCopy.tsx
+++ b/src/components/CodeWithCopy.tsx
@@ -3,23 +3,12 @@ import * as React from 'react';
 import FaClipboard = require('react-icons/lib/fa/clipboard');
 import styled from 'styled-components';
 import asRendition from '../asRendition';
-import { DefaultProps, EnhancedType, Tooltip } from '../common-types';
+import { DefaultProps, RenditionSystemProps, Tooltip } from '../common-types';
 import { stopEvent } from '../utils';
 import Button from './Button';
 import Txt, { TxtProps } from './Txt';
 
-export interface CodeWithCopyProps extends DefaultProps, Tooltip, TxtProps {
-	color?: string;
-	copy?: string;
-	text: string;
-	showCopyButton?: 'hover' | 'always';
-}
-
-export interface CodeWithCopyBaseProps extends DefaultProps, Tooltip, TxtProps {
-	showCopyButton?: 'hover' | 'always';
-}
-
-const Wrapper = styled(Txt.span)<CodeWithCopyBaseProps>`
+const Wrapper = styled(Txt.span)<{ showCopyButton?: 'hover' | 'always' }>`
 	white-space: initial;
 
 	code {
@@ -49,9 +38,9 @@ const Wrapper = styled(Txt.span)<CodeWithCopyBaseProps>`
 	&:hover .code-with-copy__copy {
 		visibility: visible;
 	}
-` as React.ComponentType<EnhancedType<CodeWithCopyBaseProps>>;
+`;
 
-const Base = ({ copy, text, color, ...props }: CodeWithCopyProps) => {
+const Base = ({ copy, text, color, ...props }: InternalCodeWithCopyProps) => {
 	const normalizedText = (text || '').toString().trim();
 	const normalizedCopy = (copy || normalizedText).toString().trim();
 
@@ -73,4 +62,21 @@ const Base = ({ copy, text, color, ...props }: CodeWithCopyProps) => {
 	);
 };
 
-export default asRendition<CodeWithCopyProps>(Base, [], ['color']);
+export interface InternalCodeWithCopyProps
+	extends DefaultProps,
+		Tooltip,
+		TxtProps {
+	color?: string;
+	copy?: string;
+	text: string;
+	showCopyButton?: 'hover' | 'always';
+}
+
+export type CodeWithCopyProps = InternalCodeWithCopyProps &
+	RenditionSystemProps;
+
+export default asRendition<React.FunctionComponent<CodeWithCopyProps>>(
+	Base,
+	[],
+	['color'],
+);

--- a/src/components/Container.tsx
+++ b/src/components/Container.tsx
@@ -9,12 +9,7 @@ import {
 	TextAlignProps,
 } from 'styled-system';
 import asRendition from '../asRendition';
-import { Theme } from '../common-types';
-
-interface ContainerProps extends MaxWidthProps, TextAlignProps {}
-interface ThemedContainerProps extends ContainerProps {
-	theme: Theme;
-}
+import { DefaultProps, RenditionSystemProps, Theme } from '../common-types';
 
 const ContainerBase = styled.div<ThemedContainerProps>`
 	${textAlign}
@@ -35,7 +30,7 @@ const Container = (props: ThemedContainerProps) => {
 Container.displayName = 'Container';
 Container.defaultProps = {} as any;
 
-const setDefaultProps = withProps((props: ContainerProps) => {
+const setDefaultProps = withProps((props: InternalContainerProps) => {
 	return assign(
 		{
 			px: 3,
@@ -46,4 +41,16 @@ const setDefaultProps = withProps((props: ContainerProps) => {
 	);
 });
 
-export default asRendition<ContainerProps>(Container, [setDefaultProps]);
+export interface InternalContainerProps
+	extends DefaultProps,
+		MaxWidthProps,
+		TextAlignProps {}
+export interface ThemedContainerProps extends InternalContainerProps {
+	theme: Theme;
+}
+
+export type ContainerProps = InternalContainerProps & RenditionSystemProps;
+
+export default asRendition<React.FunctionComponent<ContainerProps>>(Container, [
+	setDefaultProps,
+]);

--- a/src/components/Divider.tsx
+++ b/src/components/Divider.tsx
@@ -1,16 +1,23 @@
 import styled from 'styled-components';
 import asRendition from '../asRendition';
-import { DefaultProps } from '../common-types';
+import { DefaultProps, RenditionSystemProps } from '../common-types';
 import { px } from '../utils';
 
-export interface DividerProps extends DefaultProps {
-	height?: number;
-	color?: string;
-}
-const Base = styled.hr<DividerProps & React.HTMLProps<HTMLInputElement>>`
+const Base = styled.hr<InternalDividerProps>`
 	border: none;
 	height: ${props => px(props.height || 2)};
 	background-color: ${props => props.color || '#333'};
 `;
 
-export default asRendition<DividerProps>(Base, [], ['color']);
+export interface InternalDividerProps extends DefaultProps {
+	height?: number;
+	color?: string;
+}
+
+export type DividerProps = InternalDividerProps & RenditionSystemProps;
+
+export default asRendition<
+	React.ForwardRefExoticComponent<
+		DividerProps & React.RefAttributes<HTMLHRElement>
+	>
+>(Base, [], ['color']);

--- a/src/components/DropDownButton.tsx
+++ b/src/components/DropDownButton.tsx
@@ -3,29 +3,12 @@ import IconCaretDown = require('react-icons/lib/fa/caret-down');
 import IconCaretUp = require('react-icons/lib/fa/caret-up');
 import styled from 'styled-components';
 import asRendition from '../asRendition';
-import {
-	Coloring,
-	DefaultProps,
-	EnhancedType,
-	ResponsiveStyle,
-} from '../common-types';
+import { RenditionSystemProps } from '../common-types';
 import { px } from '../utils';
 import Button, { ButtonProps } from './Button';
 import Divider from './Divider';
 import Fixed from './Fixed';
-import { Box, BoxProps, Flex } from './Grid';
-
-export interface DropDownButtonProps extends DefaultProps, Coloring {
-	disabled?: boolean;
-	label?: JSX.Element;
-	border?: boolean;
-	joined?: boolean;
-	outline?: boolean;
-	alignRight?: boolean;
-	noListFormat?: boolean;
-	width?: ResponsiveStyle;
-	maxHeight?: string | number;
-}
+import { Box, Flex } from './Grid';
 
 const ToggleBase = styled(Button)`
 	min-width: 0;
@@ -35,16 +18,20 @@ const ToggleBase = styled(Button)`
 	border-left: 0;
 	margin: 0;
 	vertical-align: top;
-` as React.ComponentType<EnhancedType<ButtonProps>>;
+`;
 
 const ButtonBase = styled(Button)`
 	border-top-right-radius: 0;
 	border-bottom-right-radius: 0;
 	border-right: 0;
 	margin: 0;
-` as React.ComponentType<EnhancedType<ButtonProps>>;
+`;
 
-const MenuBase = styled.div<DropDownButtonProps & { minWidth: string }>`
+const MenuBase = styled.div<{
+	minWidth: string;
+	alignRight?: boolean;
+	maxHeight: string | number;
+}>`
 	background: white;
 	position: absolute;
 	min-width: ${props => props.minWidth};
@@ -65,9 +52,9 @@ const Wrapper = styled(Box)`
 	border-radius: ${props => px(props.theme.radius)};
 	vertical-align: top;
 	position: relative;
-` as React.ComponentType<EnhancedType<BoxProps>>;
+`;
 
-const Item = styled.div<DropDownButtonProps>`
+const Item = styled.div<{ border: boolean }>`
 	padding-top: 5px;
 	padding-bottom: 5px;
 	padding-left: 16px;
@@ -79,7 +66,7 @@ const Item = styled.div<DropDownButtonProps>`
 	&:hover:enabled {
 		background: ${props => props.theme.colors.gray.light};
 	}
-` as React.ComponentType<EnhancedType<DropDownButtonProps>>;
+`;
 
 const IconWrapper = styled.span`
 	width: 28px;
@@ -87,7 +74,7 @@ const IconWrapper = styled.span`
 
 const JoinedButton = styled(Button)`
 	margin: 0;
-` as React.ComponentType<EnhancedType<ButtonProps>>;
+`;
 
 const Toggle = ({
 	open,
@@ -95,7 +82,7 @@ const Toggle = ({
 	label,
 	joined,
 	...props
-}: DropDownButtonProps & {
+}: InternalDropDownButtonProps & {
 	open: boolean;
 	handler: React.MouseEventHandler<HTMLElement>;
 }) => {
@@ -131,12 +118,12 @@ interface DropDownButtonState {
 }
 
 class DropDownButton extends React.Component<
-	DropDownButtonProps,
+	InternalDropDownButtonProps,
 	DropDownButtonState
 > {
 	dropdownNode: HTMLDivElement | null;
 
-	constructor(props: DropDownButtonProps) {
+	constructor(props: InternalDropDownButtonProps) {
 		super(props);
 		this.state = {
 			open: false,
@@ -196,7 +183,7 @@ class DropDownButton extends React.Component<
 			<Wrapper
 				className={className}
 				{...props}
-				ref={(node: any) => (this.dropdownNode = node)}
+				ref={node => (this.dropdownNode = node)}
 			>
 				{joined ? (
 					<Toggle
@@ -251,4 +238,20 @@ class DropDownButton extends React.Component<
 	}
 }
 
-export default asRendition<DropDownButtonProps>(DropDownButton, [], ['width']);
+export interface InternalDropDownButtonProps extends ButtonProps {
+	label?: JSX.Element;
+	border?: boolean;
+	joined?: boolean;
+	alignRight?: boolean;
+	noListFormat?: boolean;
+	maxHeight?: string | number;
+}
+
+export type DropDownButtonProps = InternalDropDownButtonProps &
+	RenditionSystemProps;
+
+export default asRendition<
+	React.ForwardRefExoticComponent<
+		DropDownButtonProps & React.RefAttributes<DropDownButton>
+	>
+>(DropDownButton, [], ['width']);

--- a/src/components/Filters/FilterDescription.tsx
+++ b/src/components/Filters/FilterDescription.tsx
@@ -3,8 +3,7 @@ import noop = require('lodash/noop');
 import * as React from 'react';
 import FaClose = require('react-icons/lib/fa/close');
 import styled from 'styled-components';
-import { EnhancedType } from '../../common-types';
-import Button, { ButtonProps } from '../Button';
+import Button from '../Button';
 import { Box, Flex } from '../Grid';
 
 const ButtonWrapper = styled.button`
@@ -22,7 +21,7 @@ const WrappingEm = styled.em`
 
 const DeleteButton = styled(Button)`
 	color: rgba(0, 0, 0, 0.4);
-` as React.ComponentType<EnhancedType<ButtonProps>>;
+`;
 
 const FilterDescriptionInner = (props: { filter: JSONSchema6 }) => (
 	<Box>
@@ -36,13 +35,6 @@ const FilterDescriptionInner = (props: { filter: JSONSchema6 }) => (
 		{!props.filter.anyOf && <span>{props.filter.description}</span>}
 	</Box>
 );
-
-interface FilterDescriptionProps {
-	dark?: boolean;
-	filter: JSONSchema6;
-	edit?: false | (() => void);
-	delete?: () => void;
-}
 
 const FilterDescription = (props: FilterDescriptionProps) => {
 	return (
@@ -68,5 +60,12 @@ const FilterDescription = (props: FilterDescriptionProps) => {
 		</div>
 	);
 };
+
+export interface FilterDescriptionProps {
+	dark?: boolean;
+	filter: JSONSchema6;
+	edit?: false | (() => void);
+	delete?: () => void;
+}
 
 export default FilterDescription;

--- a/src/components/Filters/FilterForm.tsx
+++ b/src/components/Filters/FilterForm.tsx
@@ -29,15 +29,6 @@ const FilterInput = (props: {
 	);
 };
 
-interface FilterFormProps {
-	handleEditChange: (value: string, key: string) => void;
-	inputModels: any;
-	name: string;
-	value: string;
-	operator: string;
-	schema: Schema;
-}
-
 const FilterForm = (props: FilterFormProps) => {
 	const {
 		handleEditChange,
@@ -91,5 +82,14 @@ const FilterForm = (props: FilterFormProps) => {
 		</Flex>
 	);
 };
+
+export interface FilterFormProps {
+	handleEditChange: (value: string, key: string) => void;
+	inputModels: any;
+	name: string;
+	value: string;
+	operator: string;
+	schema: Schema;
+}
 
 export default FilterForm;

--- a/src/components/Filters/Summary.tsx
+++ b/src/components/Filters/Summary.tsx
@@ -17,24 +17,6 @@ const BorderedDiv = styled.div`
 	border: solid 1px #979797;
 `;
 
-export interface FilterSummaryProps {
-	edit: (rule: JSONSchema6) => void;
-	delete: (rule: JSONSchema6) => void;
-	saveView: (name: string, scope: string | null) => void;
-	filters: JSONSchema6[];
-	views: FiltersView[];
-	scopes?: ViewScope[];
-	schema: JSONSchema6;
-	dark?: boolean;
-}
-
-export interface FilterSummaryState {
-	name: string;
-	showForm: boolean;
-	id: string;
-	scope: string | null;
-}
-
 class FilterSummary extends React.Component<
 	FilterSummaryProps,
 	FilterSummaryState
@@ -158,6 +140,24 @@ class FilterSummary extends React.Component<
 			</BorderedDiv>
 		);
 	}
+}
+
+export interface FilterSummaryProps {
+	edit: (rule: JSONSchema6) => void;
+	delete: (rule: JSONSchema6) => void;
+	saveView: (name: string, scope: string | null) => void;
+	filters: JSONSchema6[];
+	views: FiltersView[];
+	scopes?: ViewScope[];
+	schema: JSONSchema6;
+	dark?: boolean;
+}
+
+export interface FilterSummaryState {
+	name: string;
+	showForm: boolean;
+	id: string;
+	scope: string | null;
 }
 
 export default FilterSummary;

--- a/src/components/Filters/ViewsMenu.tsx
+++ b/src/components/Filters/ViewsMenu.tsx
@@ -7,10 +7,9 @@ import FaPieChart = require('react-icons/lib/fa/pie-chart');
 import FaTrash = require('react-icons/lib/fa/trash');
 import styled from 'styled-components';
 import { FilterRenderMode, FiltersView } from '.';
-import { EnhancedType } from '../../common-types';
 import DropDownButton, { DropDownButtonProps } from '../DropDownButton';
 import { Box } from '../Grid';
-import Txt, { TxtProps } from '../Txt';
+import Txt from '../Txt';
 import FilterDescription from './FilterDescription';
 
 const Wrapper = styled.div``;
@@ -73,22 +72,7 @@ export const ViewListItem = styled.li`
 
 const ViewListItemLabel = styled(Txt)`
 	cursor: pointer;
-` as React.ComponentType<EnhancedType<TxtProps>>;
-
-interface ViewsMenuProps {
-	buttonProps?: DropDownButtonProps;
-	disabled?: boolean;
-	views: FiltersView[];
-	schema: JSONSchema6;
-	hasMultipleScopes?: boolean;
-	setFilters: (filters: JSONSchema6[]) => void;
-	deleteView: (view: FiltersView) => any;
-	renderMode?: FilterRenderMode | FilterRenderMode[];
-}
-
-interface ViewsMenuState {
-	showViewsMenu: boolean;
-}
+`;
 
 class ViewsMenu extends React.Component<ViewsMenuProps, ViewsMenuState> {
 	constructor(props: ViewsMenuProps) {
@@ -182,6 +166,21 @@ class ViewsMenu extends React.Component<ViewsMenuProps, ViewsMenuState> {
 			</Wrapper>
 		);
 	}
+}
+
+export interface ViewsMenuProps {
+	buttonProps?: DropDownButtonProps;
+	disabled?: boolean;
+	views: FiltersView[];
+	schema: JSONSchema6;
+	hasMultipleScopes?: boolean;
+	setFilters: (filters: JSONSchema6[]) => void;
+	deleteView: (view: FiltersView) => any;
+	renderMode?: FilterRenderMode | FilterRenderMode[];
+}
+
+interface ViewsMenuState {
+	showViewsMenu: boolean;
 }
 
 export default ViewsMenu;

--- a/src/components/Filters/index.tsx
+++ b/src/components/Filters/index.tsx
@@ -11,12 +11,12 @@ import * as React from 'react';
 import FaClose = require('react-icons/lib/fa/close');
 import FaFilter = require('react-icons/lib/fa/filter');
 import styled from 'styled-components';
-import { DefaultProps, EnhancedType } from '../../common-types';
+import { DefaultProps } from '../../common-types';
 import * as utils from '../../utils';
 import Button, { ButtonProps } from '../Button';
 import { getDataModel } from '../DataTypes';
 import { DropDownButtonProps } from '../DropDownButton';
-import { Box, BoxProps, Flex } from '../Grid';
+import { Box, Flex } from '../Grid';
 import Modal from '../Modal';
 import Search from '../Search';
 import Select from '../Select';
@@ -24,58 +24,6 @@ import Txt from '../Txt';
 import * as SchemaSieve from './SchemaSieve';
 import Summary from './Summary';
 import ViewsMenu from './ViewsMenu';
-
-export interface FilterInputProps {
-	schema: JSONSchema6;
-	value: any;
-	operator: string;
-	onUpdate: (value: any) => void;
-}
-
-export interface ViewScope {
-	slug: string;
-	name: string;
-	label?: string;
-}
-
-export interface FiltersView {
-	id: string;
-	name: string;
-	scope?: string | null;
-	filters: JSONSchema6[];
-}
-
-export interface FilterSignature {
-	field: string;
-	operator: string;
-	value: string | number | boolean | { [k: string]: string };
-}
-
-export type FilterRenderMode = 'all' | 'add' | 'search' | 'views' | 'summary';
-
-export interface DataTypeModel {
-	operators: {
-		[key: string]: {
-			getLabel: (schema: JSONSchema6) => string;
-		};
-	};
-	decodeFilter(filter: JSONSchema6): null | FilterSignature;
-	createFilter(
-		field: string,
-		operator: string,
-		value: any,
-		schema: JSONSchema6,
-	): JSONSchema6;
-	Edit(props: DataTypeEditProps): JSX.Element;
-}
-
-export interface DataTypeEditProps {
-	schema: JSONSchema6;
-	value?: any;
-	onUpdate: (value: string | number | boolean) => void;
-	operator: string;
-	slim?: boolean;
-}
 
 const FilterInput = (props: FilterInputProps) => {
 	const model = getDataModel(props.schema);
@@ -99,14 +47,14 @@ const FilterInput = (props: FilterInputProps) => {
 
 const RelativeBox = styled(Box)`
 	position: relative;
-` as React.ComponentType<EnhancedType<BoxProps>>;
+`;
 
 const DeleteButton = styled(Button)`
 	color: rgba(0, 0, 0, 0.4);
 	position: absolute;
 	bottom: 7px;
 	right: -35px;
-` as React.ComponentType<EnhancedType<ButtonProps>>;
+`;
 
 const SearchWrapper = styled.div`
 	flex-basis: 500px;
@@ -114,37 +62,7 @@ const SearchWrapper = styled.div`
 
 const FilterWrapper = styled(Box)`
 	position: relative;
-` as React.ComponentType<EnhancedType<BoxProps>>;
-
-export interface EditModel {
-	field: string;
-	operator: string;
-	value: string | number | { [k: string]: string };
-}
-
-export interface FiltersState {
-	showModal: boolean;
-	edit: EditModel[];
-	editingFilter: string | null;
-	searchString: string;
-	filters: JSONSchema6[];
-	views: FiltersView[];
-	schema: JSONSchema6;
-}
-
-export interface FiltersProps extends DefaultProps {
-	disabled?: boolean;
-	filters?: JSONSchema6[];
-	views?: FiltersView[];
-	viewScopes?: ViewScope[];
-	onFiltersUpdate?: (filters: JSONSchema6[]) => void;
-	onViewsUpdate?: (views: FiltersView[]) => void;
-	schema: JSONSchema6;
-	addFilterButtonProps?: ButtonProps;
-	viewsMenuButtonProps?: DropDownButtonProps;
-	renderMode?: FilterRenderMode | FilterRenderMode[];
-	dark?: boolean;
-}
+`;
 
 class Filters extends React.Component<FiltersProps, FiltersState> {
 	constructor(props: FiltersProps) {
@@ -588,6 +506,88 @@ class Filters extends React.Component<FiltersProps, FiltersState> {
 			</FilterWrapper>
 		);
 	}
+}
+
+export interface EditModel {
+	field: string;
+	operator: string;
+	value: string | number | { [k: string]: string };
+}
+
+export interface FilterInputProps {
+	schema: JSONSchema6;
+	value: any;
+	operator: string;
+	onUpdate: (value: any) => void;
+}
+
+export interface ViewScope {
+	slug: string;
+	name: string;
+	label?: string;
+}
+
+export interface FiltersView {
+	id: string;
+	name: string;
+	scope?: string | null;
+	filters: JSONSchema6[];
+}
+
+export interface FilterSignature {
+	field: string;
+	operator: string;
+	value: string | number | boolean | { [k: string]: string };
+}
+
+export type FilterRenderMode = 'all' | 'add' | 'search' | 'views' | 'summary';
+
+export interface DataTypeModel {
+	operators: {
+		[key: string]: {
+			getLabel: (schema: JSONSchema6) => string;
+		};
+	};
+	decodeFilter(filter: JSONSchema6): null | FilterSignature;
+	createFilter(
+		field: string,
+		operator: string,
+		value: any,
+		schema: JSONSchema6,
+	): JSONSchema6;
+	Edit(props: DataTypeEditProps): JSX.Element;
+}
+
+export interface DataTypeEditProps {
+	schema: JSONSchema6;
+	value?: any;
+	onUpdate: (value: string | number | boolean) => void;
+	operator: string;
+	slim?: boolean;
+}
+
+export interface FiltersState {
+	showModal: boolean;
+	edit: EditModel[];
+	editingFilter: string | null;
+	searchString: string;
+	filters: JSONSchema6[];
+	views: FiltersView[];
+	schema: JSONSchema6;
+}
+
+export interface FiltersProps extends DefaultProps {
+	disabled?: boolean;
+	filters?: JSONSchema6[];
+	views?: FiltersView[];
+	viewScopes?: ViewScope[];
+	onFiltersUpdate?: (filters: JSONSchema6[]) => void;
+	onViewsUpdate?: (views: FiltersView[]) => void;
+	schema: JSONSchema6;
+	addFilterButtonProps?: ButtonProps;
+	viewsMenuButtonProps?: DropDownButtonProps;
+	renderMode?: FilterRenderMode | FilterRenderMode[];
+	dark?: boolean;
 }
 
 export default Filters;

--- a/src/components/Fixed.tsx
+++ b/src/components/Fixed.tsx
@@ -2,25 +2,11 @@ import defaultTo = require('lodash/defaultTo');
 import { withProps } from 'recompose';
 import styled from 'styled-components';
 import asRendition from '../asRendition';
-import { DefaultProps, ResponsiveStyle } from '../common-types';
-
-export interface FixedProps extends DefaultProps {
-	top?: boolean | ResponsiveStyle;
-	right?: boolean | ResponsiveStyle;
-	bottom?: boolean | ResponsiveStyle;
-	left?: boolean | ResponsiveStyle;
-	z?: ResponsiveStyle;
-	bg?: string;
-}
-
-interface FixedBaseProps extends DefaultProps {
-	top?: ResponsiveStyle;
-	right?: ResponsiveStyle;
-	bottom?: ResponsiveStyle;
-	left?: ResponsiveStyle;
-	z?: ResponsiveStyle;
-	bg?: string;
-}
+import {
+	DefaultProps,
+	RenditionSystemProps,
+	ResponsiveStyle,
+} from '../common-types';
 
 const Base = styled.div<FixedBaseProps>`
 	position: fixed;
@@ -41,4 +27,28 @@ const dimensions = withProps((props: FixedProps) => {
 	};
 });
 
-export default asRendition<FixedProps>(Base, [dimensions], ['bg']);
+interface FixedBaseProps extends DefaultProps {
+	top?: ResponsiveStyle;
+	right?: ResponsiveStyle;
+	bottom?: ResponsiveStyle;
+	left?: ResponsiveStyle;
+	z?: ResponsiveStyle;
+	bg?: string;
+}
+
+export interface InternalFixedProps extends DefaultProps {
+	top?: boolean | ResponsiveStyle;
+	right?: boolean | ResponsiveStyle;
+	bottom?: boolean | ResponsiveStyle;
+	left?: boolean | ResponsiveStyle;
+	z?: ResponsiveStyle;
+	bg?: string;
+}
+
+export type FixedProps = InternalFixedProps & RenditionSystemProps;
+
+export default asRendition<
+	React.ForwardRefExoticComponent<
+		FixedProps & React.RefAttributes<HTMLDivElement>
+	>
+>(Base, [dimensions], ['bg']);

--- a/src/components/Grid.tsx
+++ b/src/components/Grid.tsx
@@ -1,4 +1,3 @@
-import { RefObject } from 'react';
 import styled from 'styled-components';
 import {
 	alignItems,
@@ -17,21 +16,20 @@ import {
 	OrderProps,
 } from 'styled-system';
 import asRendition from '../asRendition';
-import { DefaultProps, EnhancedType } from '../common-types';
+import { DefaultProps, RenditionSystemProps } from '../common-types';
 
 export interface BoxProps
 	extends DefaultProps,
 		StyledFlexProps,
 		OrderProps,
-		AlignSelfProps {
-	ref?:
-		| string
-		| ((instance: any | null) => void)
-		| RefObject<any>
-		| null
-		| undefined;
-}
-export const Box = asRendition<BoxProps>(
+		AlignSelfProps,
+		RenditionSystemProps {}
+
+export const Box = asRendition<
+	React.ForwardRefExoticComponent<
+		BoxProps & React.RefAttributes<HTMLDivElement>
+	>
+>(
 	styled.div<BoxProps>`
 		box-sizing: border-box;
 		${flex};
@@ -55,6 +53,6 @@ export const Flex = styled(Box)<FlexProps>`
 	${flexDirection};
 	${alignItems};
 	${justifyContent};
-` as React.ComponentType<EnhancedType<FlexProps>>;
+`;
 
 Flex.displayName = 'Flex';

--- a/src/components/Heading.tsx
+++ b/src/components/Heading.tsx
@@ -3,17 +3,16 @@ import * as React from 'react';
 import { withProps } from 'recompose';
 import styled from 'styled-components';
 import asRendition from '../asRendition';
-import { EnhancedType } from '../common-types';
+import { DefaultProps, RenditionSystemProps } from '../common-types';
 import { monospace } from '../utils';
 import { FlexProps } from './Grid';
 import { align, bold, caps } from './Txt';
 
-const Heading = styled.h3<FlexProps>`
+const Heading = styled.h3<InternalHeadingProps>`
 	${align}
-	${monospace as any};
-
+	${monospace};
 	${caps as any}
-	${bold as any}
+	${bold}
 `;
 
 Heading.displayName = 'Heading';
@@ -28,21 +27,32 @@ const setDefaultProps = withProps((props: FlexProps) => {
 });
 
 const Factory = (tag?: string) => {
-	return asRendition<FlexProps>(
-		(props: any) => {
+	return asRendition<React.FunctionComponent<InternalHeadingProps>>(
+		(props: InternalHeadingProps) => {
+			// Styled components v4 typing for `as` is not properly typed yet, so it needs to be ignored. https://github.com/DefinitelyTyped/DefinitelyTyped/blob/03186dbc08372aa1ca9689147386523588be6efd/types/styled-components/index.d.ts#L186
+			// @ts-ignore
 			return <Heading as={tag} {...props} />;
 		},
 		[setDefaultProps],
 	);
 };
 
-const Base = Factory() as React.ComponentType<EnhancedType<FlexProps>> & {
-	h1: React.ComponentType<EnhancedType<FlexProps>>;
-	h2: React.ComponentType<EnhancedType<FlexProps>>;
-	h3: React.ComponentType<EnhancedType<FlexProps>>;
-	h4: React.ComponentType<EnhancedType<FlexProps>>;
-	h5: React.ComponentType<EnhancedType<FlexProps>>;
-	h6: React.ComponentType<EnhancedType<FlexProps>>;
+interface InternalHeadingProps extends DefaultProps {
+	align?: boolean;
+	monospace?: boolean;
+	caps?: boolean;
+	bold?: boolean;
+}
+
+export type HeadingProps = InternalHeadingProps & RenditionSystemProps;
+
+const Base = Factory() as React.FunctionComponent<HeadingProps> & {
+	h1: React.FunctionComponent<HeadingProps>;
+	h2: React.FunctionComponent<HeadingProps>;
+	h3: React.FunctionComponent<HeadingProps>;
+	h4: React.FunctionComponent<HeadingProps>;
+	h5: React.FunctionComponent<HeadingProps>;
+	h6: React.FunctionComponent<HeadingProps>;
 };
 
 Base.h1 = Factory('h1');

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -1,35 +1,13 @@
 import styled from 'styled-components';
 import asRendition from '../asRendition';
-import { DefaultProps, Sizing, Theme } from '../common-types';
+import {
+	DefaultProps,
+	RenditionSystemProps,
+	Sizing,
+	Theme,
+} from '../common-types';
 import { radius } from '../theme';
 import { monospace, px } from '../utils';
-
-export interface InputProps extends DefaultProps, Sizing {
-	monospace?: boolean;
-	autoComplete?: string;
-	autoFocus?: boolean;
-	disabled?: boolean;
-	form?: string;
-	max?: number | string;
-	maxLength?: number;
-	min?: number | string;
-	minLength?: number;
-	name?: string;
-	placeholder?: string;
-	readOnly?: boolean;
-	required?: boolean;
-	type?: string;
-	value?: string | string[] | number;
-	pattern?: string;
-
-	invalid?: boolean;
-	valid?: boolean;
-	onChange?: React.ChangeEventHandler<HTMLInputElement>;
-}
-
-export interface ThemedInputProps extends InputProps {
-	theme: Theme;
-}
 
 const getColor = (props: ThemedInputProps): any => {
 	if (props.invalid) {
@@ -50,7 +28,7 @@ const getHeight = (props: ThemedInputProps) =>
 const getSpinButtonMargin = (props: ThemedInputProps) =>
 	(getHeight(props) - 2 - 20) / 2;
 
-const Base = styled.input<InputProps>`
+const Base = styled.input`
 	border-radius: ${px(radius)};
 	height: ${props => px(getHeight(props))};
 	font-size: inherit;
@@ -90,4 +68,37 @@ const Base = styled.input<InputProps>`
 	${monospace as any};
 `;
 
-export default asRendition<InputProps>(Base);
+export interface InternalInputProps extends DefaultProps, Sizing {
+	monospace?: boolean;
+	autoComplete?: string;
+	autoFocus?: boolean;
+	disabled?: boolean;
+	form?: string;
+	max?: number | string;
+	maxLength?: number;
+	min?: number | string;
+	minLength?: number;
+	name?: string;
+	placeholder?: string;
+	readOnly?: boolean;
+	required?: boolean;
+	type?: string;
+	value?: string | string[] | number;
+	pattern?: string;
+
+	invalid?: boolean;
+	valid?: boolean;
+	onChange?: React.ChangeEventHandler<HTMLInputElement>;
+}
+
+export interface ThemedInputProps extends InternalInputProps {
+	theme: Theme;
+}
+
+export type InputProps = InternalInputProps & RenditionSystemProps;
+
+export default asRendition<
+	React.ForwardRefExoticComponent<
+		InputProps & React.RefAttributes<HTMLInputElement>
+	>
+>(Base);

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -5,26 +5,11 @@ import * as React from 'react';
 import { withProps } from 'recompose';
 import styled from 'styled-components';
 import asRendition from '../asRendition';
-import { DefaultProps } from '../common-types';
+import { DefaultProps, RenditionSystemProps } from '../common-types';
 import { darken, monospace } from '../utils';
 import { align, bold, caps } from './Txt';
 
-export interface LinkProps extends DefaultProps {
-	blank?: boolean;
-	disabled?: boolean;
-	download?: any;
-	href?: string;
-	hrefLang?: string;
-	media?: string;
-	rel?: string;
-	target?: string;
-	type?: string;
-	is?: string;
-	decor?: string;
-	color?: string;
-}
-
-let Base = styled.a<LinkProps>`
+let Base = styled.a<InternalLinkProps>`
   ${align}
   ${monospace as any};
   ${caps as any}
@@ -45,7 +30,7 @@ let Base = styled.a<LinkProps>`
   }
 `;
 
-const Link = ({ is, blank, children, ...props }: LinkProps) => {
+const Link = ({ is, blank, children, ...props }: InternalLinkProps) => {
 	if (is) {
 		Base = Base.withComponent(is as any);
 	}
@@ -63,7 +48,7 @@ const Link = ({ is, blank, children, ...props }: LinkProps) => {
 	);
 };
 
-const setDefaultProps = withProps((props: LinkProps) => {
+const setDefaultProps = withProps((props: InternalLinkProps) => {
 	return assign(
 		{
 			color: `primary.main`,
@@ -72,4 +57,25 @@ const setDefaultProps = withProps((props: LinkProps) => {
 	);
 });
 
-export default asRendition<LinkProps>(Link, [setDefaultProps], ['color']);
+export interface InternalLinkProps extends DefaultProps {
+	blank?: boolean;
+	disabled?: boolean;
+	download?: any;
+	href?: string;
+	hrefLang?: string;
+	media?: string;
+	rel?: string;
+	target?: string;
+	type?: string;
+	is?: string;
+	decor?: string;
+	color?: string;
+}
+
+export type LinkProps = InternalLinkProps & RenditionSystemProps;
+
+export default asRendition<React.FunctionComponent<LinkProps>>(
+	Link,
+	[setDefaultProps],
+	['color'],
+);

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,36 +1,13 @@
 import assign = require('lodash/assign');
 import * as React from 'react';
 import styled, { createGlobalStyle, withTheme } from 'styled-components';
-import {
-	DefaultProps,
-	EnhancedType,
-	ResponsiveStyle,
-	Theme,
-} from '../common-types';
+import { DefaultProps, ResponsiveStyle, Theme } from '../common-types';
 import { stopPropagation } from '../utils';
 import { px } from '../utils';
 import Button, { ButtonAnchorProps, ButtonProps } from './Button';
-import Fixed, { FixedProps } from './Fixed';
-import { Box, BoxProps, Flex, FlexProps } from './Grid';
-import Txt, { TxtProps } from './Txt';
-
-export interface ModalProps extends DefaultProps {
-	title?: string;
-	width?: ResponsiveStyle;
-	titleElement?: string | JSX.Element;
-	titleDetails?: string | JSX.Element;
-	action?: string | JSX.Element;
-	cancel?: () => any;
-	done: () => any;
-	primaryButtonProps?: ButtonProps | ButtonAnchorProps;
-	secondaryButtonProps?: ButtonProps | ButtonAnchorProps;
-	cancelButtonProps?: ButtonProps | ButtonAnchorProps;
-	containerStyle?: React.CSSProperties;
-}
-
-export interface ThemedModalProps extends ModalProps {
-	theme: Theme;
-}
+import Fixed from './Fixed';
+import { Box, Flex } from './Grid';
+import Txt from './Txt';
 
 const bodyNoOverflowClass = `rendition-modal-open`;
 
@@ -49,23 +26,23 @@ const ModalWrapper = styled(Flex)`
 	bottom: 0;
 	z-index: 9999;
 	pointer-events: none;
-` as React.ComponentType<EnhancedType<FlexProps>>;
+`;
 
 const ModalBackdrop = styled(Fixed)`
 	pointer-events: auto;
-` as React.ComponentType<EnhancedType<FixedProps>>;
+`;
 
 const DEFAULT_MODAL_WIDTH = 700;
 
 const ModalHeader = styled(Txt)`
 	margin-bottom: 50px;
 	font-size: ${props => px(props.theme.fontSizes[4])};
-` as React.ComponentType<EnhancedType<TxtProps>>;
+`;
 
 const ModalTitleDetails = styled(Txt)`
 	color: ${props => props.theme.colors.text.light};
 	font-size: ${props => px(props.theme.fontSizes[2])};
-` as React.ComponentType<EnhancedType<TxtProps>>;
+`;
 
 const ModalSizer = styled(Box)`
 	position: relative;
@@ -76,7 +53,7 @@ const ModalSizer = styled(Box)`
 	background-color: transparent;
 	z-index: 9999;
 	pointer-events: auto;
-` as React.ComponentType<EnhancedType<BoxProps>>;
+`;
 
 const ModalPanel = styled(Box)`
 	max-width: 100%;
@@ -86,7 +63,7 @@ const ModalPanel = styled(Box)`
 	border-radius: 2px;
 	background-color: #ffffff;
 	box-shadow: 0px 0px 15px 1px rgba(0, 0, 0, 0.4);
-` as React.ComponentType<EnhancedType<BoxProps>>;
+`;
 
 const ModalButton = (props: ButtonProps | ButtonAnchorProps) => {
 	return 'href' in props && props.href ? (
@@ -217,4 +194,22 @@ class Modal extends React.Component<ThemedModalProps, any> {
 	}
 }
 
-export default withTheme(Modal) as React.ComponentType<ModalProps>;
+export interface ModalProps extends DefaultProps {
+	title?: string;
+	width?: ResponsiveStyle;
+	titleElement?: string | JSX.Element;
+	titleDetails?: string | JSX.Element;
+	action?: string | JSX.Element;
+	cancel?: () => any;
+	done: () => any;
+	primaryButtonProps?: ButtonProps | ButtonAnchorProps;
+	secondaryButtonProps?: ButtonProps | ButtonAnchorProps;
+	cancelButtonProps?: ButtonProps | ButtonAnchorProps;
+	containerStyle?: React.CSSProperties;
+}
+
+export interface ThemedModalProps extends ModalProps {
+	theme: Theme;
+}
+
+export default withTheme(Modal);

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -10,27 +10,23 @@ import {
 	maxHeight,
 	MaxHeightProps,
 } from 'styled-system';
-import { DefaultProps, EnhancedType } from '../common-types';
+import { DefaultProps } from '../common-types';
 import Container from './Container';
 import { Box, BoxProps, Flex, FlexProps } from './Grid';
-
-export interface NavbarProps extends DefaultProps {
-	brand?: JSX.Element;
-}
 
 const BrandBox = styled(Box)`
 	display: flex;
 	height: auto;
 	min-width: 150px;
 	align-self: center;
-` as React.ComponentType<EnhancedType<BoxProps>>;
+`;
 
-const IconBox = styled(Box)`
+const IconBox = styled(Box)<BoxProps & DisplayProps>`
 	${display} align-self: center;
 	cursor: pointer;
-` as React.ComponentType<EnhancedType<BoxProps & DisplayProps>>;
+`;
 
-const MenuBox = styled(Flex)`
+const MenuBox = styled(Flex)<FlexProps & MaxHeightProps & DisplayProps>`
 	${display}
 	${maxHeight};
 	text-align: center;
@@ -42,9 +38,7 @@ const MenuBox = styled(Flex)`
 		width: 100%;
 		display: inline-block;
 	}
-` as React.ComponentType<
-	EnhancedType<FlexProps & DisplayProps & MaxHeightProps>
->;
+`;
 
 interface NavbarState {
 	open: boolean;
@@ -123,6 +117,12 @@ const setDefaultProps = withProps((props: NavbarProps) => {
 	);
 });
 
-export default compose(setDefaultProps)(Navbar) as React.ComponentType<
-	NavbarProps
+export interface NavbarProps extends DefaultProps {
+	brand?: JSX.Element;
+}
+
+export default (compose(setDefaultProps)(
+	Navbar,
+) as unknown) as React.ForwardRefExoticComponent<
+	NavbarProps & React.RefAttributes<Navbar>
 >;

--- a/src/components/Pager.tsx
+++ b/src/components/Pager.tsx
@@ -2,18 +2,9 @@ import * as React from 'react';
 import FaChevronLeft = require('react-icons/lib/fa/chevron-left');
 import FaChevronRight = require('react-icons/lib/fa/chevron-right');
 import styled from 'styled-components';
-import { EnhancedType } from '../common-types';
 import Button from './Button';
-import { Box, BoxProps, Flex, FlexProps } from './Grid';
+import { Box, Flex, FlexProps } from './Grid';
 import Txt from './Txt';
-
-export interface PagerProps extends FlexProps {
-	totalItems: number;
-	itemsPerPage: number;
-	page: number;
-	nextPage: () => void;
-	prevPage: () => void;
-}
 
 const ButtonGroup = styled(Box)`
 	padding-right: 1px;
@@ -35,9 +26,9 @@ const ButtonGroup = styled(Box)`
 			border-bottom-right-radius: 3px;
 		}
 	}
-` as React.ComponentType<EnhancedType<BoxProps>>;
+`;
 
-export default ({
+const Pager = ({
 	totalItems,
 	itemsPerPage,
 	page,
@@ -45,7 +36,7 @@ export default ({
 	prevPage,
 	color,
 	...props
-}: EnhancedType<PagerProps>) => {
+}: PagerProps) => {
 	const lowerBound = page * itemsPerPage;
 	const upperBound = Math.min((page + 1) * itemsPerPage, totalItems);
 
@@ -84,3 +75,13 @@ export default ({
 		</Flex>
 	);
 };
+
+export interface PagerProps extends FlexProps {
+	totalItems: number;
+	itemsPerPage: number;
+	page: number;
+	nextPage: () => void;
+	prevPage: () => void;
+}
+
+export default Pager;

--- a/src/components/Pill.tsx
+++ b/src/components/Pill.tsx
@@ -1,14 +1,9 @@
 import * as React from 'react';
 import styled from 'styled-components';
 import asRendition from '../asRendition';
-import { Coloring, EnhancedType, Shading } from '../common-types';
+import { Coloring, RenditionSystemProps, Shading } from '../common-types';
 import { getColor } from '../utils';
 import Txt, { TxtProps } from './Txt';
-
-export interface PillProps extends Coloring, Shading, TxtProps {
-	small?: boolean;
-	style?: React.CSSProperties;
-}
 
 const BasePill = styled(Txt)<PillProps>`
 	display: inline-flex;
@@ -26,17 +21,24 @@ const BasePill = styled(Txt)<PillProps>`
 	color: #fff;
 	background-color: ${props =>
 		getColor(props, 'bg', props.shade || 'main') || props.bg || '#7e8085'};
-` as React.ComponentType<EnhancedType<PillProps>>;
+`;
 
 const SmallPill = styled(BasePill)`
 	padding: 1.4px 5.6px;
 	font-size: 8.4px;
 	line-height: 11px;
-` as React.ComponentType<EnhancedType<PillProps>>;
+`;
 
 const Pill = ({ small, children, ...props }: PillProps) => {
 	const PillComponent = !small ? BasePill : SmallPill;
 	return <PillComponent {...props}>{children}</PillComponent>;
 };
 
-export default asRendition<PillProps>(Pill);
+export interface InternalPillProps extends Coloring, Shading, TxtProps {
+	small?: boolean;
+	style?: React.CSSProperties;
+}
+
+export type PillProps = InternalPillProps & RenditionSystemProps;
+
+export default asRendition<React.FunctionComponent<PillProps>>(Pill);

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -5,27 +5,19 @@ import * as React from 'react';
 import { withProps } from 'recompose';
 import styled from 'styled-components';
 import asRendition from '../asRendition';
-import { Coloring, DefaultProps, Sizing, Theme } from '../common-types';
+import {
+	Coloring,
+	DefaultProps,
+	RenditionSystemProps,
+	Sizing,
+	Theme,
+} from '../common-types';
 import { radius } from '../theme';
 import { px } from '../utils';
 
-export interface ProgressBarProps extends DefaultProps, Coloring, Sizing {
-	value: number;
-	color?: string;
-	background?: string;
-}
-
-export interface ThemedProgressBarProps extends ProgressBarProps {
-	theme: Theme;
-}
-
 const transition = 'width linear 250ms';
 
-// TODO: Use "Exclude" type after upgrading to TypeScript 2.8+
-declare var { value, ...rest }: ProgressBarProps;
-type ProgressBarRestProps = typeof rest;
-
-const Bar = styled.div<ProgressBarRestProps & { bg?: string }>`
+const Bar = styled.div<{ bg?: string; emphasized?: boolean }>`
 	position: relative;
 	height: ${props =>
 		px(props.emphasized ? props.theme.space[5] : props.theme.space[4])};
@@ -56,7 +48,7 @@ const Content = styled.div`
 	transition: ${transition};
 `;
 
-const Sleeve = styled.div<ProgressBarRestProps>`
+const Sleeve = styled.div<{ emphasized?: boolean }>`
 	position: relative;
 	border-radius: ${px(radius)};
 	height: ${props =>
@@ -86,7 +78,12 @@ const setTypeProps = withProps(({ type, theme, background, color }) => {
 	};
 });
 
-const Base = ({ children, background, value, ...props }: ProgressBarProps) => {
+const Base = ({
+	children,
+	background,
+	value,
+	...props
+}: InternalProgressBarProps) => {
 	return (
 		<Sleeve {...props}>
 			<LoadingContent>{children}</LoadingContent>
@@ -99,7 +96,22 @@ const Base = ({ children, background, value, ...props }: ProgressBarProps) => {
 	);
 };
 
-export default asRendition<ProgressBarProps>(
+export interface InternalProgressBarProps
+	extends DefaultProps,
+		Coloring,
+		Sizing {
+	value: number;
+	color?: string;
+	background?: string;
+}
+
+export interface ThemedProgressBarProps extends InternalProgressBarProps {
+	theme: Theme;
+}
+
+export type ProgressBarProps = InternalProgressBarProps & RenditionSystemProps;
+
+export default asRendition<React.FunctionComponent<ProgressBarProps>>(
 	Base,
 	[getType, setTypeProps],
 	['color'],

--- a/src/components/Provider.tsx
+++ b/src/components/Provider.tsx
@@ -7,10 +7,6 @@ const Base = styled.div<ThemedProvider>`
 	font-family: ${props => props.theme.font};
 `;
 
-export interface ThemedProvider extends DefaultProps {
-	theme?: Theme;
-}
-
 const Provider = ({ theme, ...props }: ThemedProvider) => {
 	return (
 		<ThemeProvider theme={theme || defaultTheme}>
@@ -18,5 +14,9 @@ const Provider = ({ theme, ...props }: ThemedProvider) => {
 		</ThemeProvider>
 	);
 };
+
+export interface ThemedProvider extends DefaultProps {
+	theme?: Theme;
+}
 
 export default Provider;

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -2,15 +2,7 @@ import * as React from 'react';
 import FaSearch = require('react-icons/lib/fa/search');
 import styled from 'styled-components';
 import asRendition from '../asRendition';
-import { DefaultProps } from '../common-types';
-
-export interface SearchProps extends DefaultProps {
-	dark?: boolean;
-	disabled?: boolean;
-	placeholder?: string;
-	value: string;
-	onChange: (value: any) => void;
-}
+import { DefaultProps, RenditionSystemProps } from '../common-types';
 
 const Wrapper = styled.div`
 	position: relative;
@@ -52,7 +44,7 @@ const Search = ({
 	placeholder,
 	value,
 	onChange,
-}: SearchProps) => {
+}: InternalSearchProps) => {
 	return (
 		<Wrapper>
 			<input
@@ -67,4 +59,14 @@ const Search = ({
 	);
 };
 
-export default asRendition<SearchProps>(Search);
+export interface InternalSearchProps extends DefaultProps {
+	dark?: boolean;
+	disabled?: boolean;
+	placeholder?: string;
+	value: string;
+	onChange: (value: any) => void;
+}
+
+export type SearchProps = InternalSearchProps & RenditionSystemProps;
+
+export default asRendition<React.FunctionComponent<SearchProps>>(Search);

--- a/src/components/Select.tsx
+++ b/src/components/Select.tsx
@@ -1,15 +1,9 @@
 import * as React from 'react';
 import styled from 'styled-components';
 import asRendition from '../asRendition';
-import { DefaultProps, Sizing } from '../common-types';
+import { DefaultProps, RenditionSystemProps, Sizing } from '../common-types';
 import { radius } from '../theme';
 import { px } from '../utils';
-
-export interface SelectProps extends DefaultProps, Sizing {
-	value?: string | string[] | number | null;
-	disabled?: boolean;
-	onChange?: React.ChangeEventHandler<HTMLSelectElement>;
-}
 
 const Base = styled.select<
 	{ emphasized?: boolean } & React.HTMLProps<HTMLSelectElement>
@@ -34,7 +28,7 @@ const Base = styled.select<
 	}
 `;
 
-const Wrapper = styled.span<SelectProps>`
+const Wrapper = styled.span<{ emphasized?: boolean }>`
 	display: inline-block;
 	position: relative;
 
@@ -59,7 +53,7 @@ const Component = ({
 	onChange,
 	value,
 	...props
-}: SelectProps) => {
+}: InternalSelectProps) => {
 	return (
 		<Wrapper emphasized={emphasized} {...props}>
 			<Base
@@ -73,4 +67,12 @@ const Component = ({
 	);
 };
 
-export default asRendition<SelectProps>(Component);
+export interface InternalSelectProps extends DefaultProps, Sizing {
+	value?: string | string[] | number | null;
+	disabled?: boolean;
+	onChange?: React.ChangeEventHandler<HTMLSelectElement>;
+}
+
+export type SelectProps = InternalSelectProps & RenditionSystemProps;
+
+export default asRendition<React.FunctionComponent<SelectProps>>(Component);

--- a/src/components/Table/TableRow.tsx
+++ b/src/components/Table/TableRow.tsx
@@ -3,6 +3,18 @@ import isFunction = require('lodash/isFunction');
 import map = require('lodash/map');
 import * as React from 'react';
 
+/*
+ * Get the value specified by the `field` value
+ * If a `render` function is available, use it to get the display value.
+ */
+const renderField = <T extends {}>(row: T, column: TableColumn<T>): any => {
+	const value = get(row, column.field);
+	if (column.render) {
+		return column.render(value, row);
+	}
+	return value == null ? '' : value;
+};
+
 export type TableSortFunction<T> = (a: T, b: T) => number;
 
 export interface TableColumn<T> {
@@ -15,18 +27,6 @@ export interface TableColumn<T> {
 	render?: (value: any, row: T) => string | number | JSX.Element | null;
 	sortable?: boolean | TableSortFunction<T>;
 }
-
-/*
- * Get the value specified by the `field` value
- * If a `render` function is available, use it to get the display value.
- */
-const renderField = <T extends {}>(row: T, column: TableColumn<T>): any => {
-	const value = get(row, column.field);
-	if (column.render) {
-		return column.render(value, row);
-	}
-	return value == null ? '' : value;
-};
 
 export interface TableRowProps<T> {
 	className?: string;

--- a/src/components/Table/index.tsx
+++ b/src/components/Table/index.tsx
@@ -15,48 +15,10 @@ import FaSort = require('react-icons/lib/fa/sort');
 import styled from 'styled-components';
 
 // TODO: Remove explicit import and depend on provider instead.
-import { EnhancedType } from '../../common-types';
 import theme from '../../theme';
-import Button, { ButtonProps } from '../Button';
+import Button from '../Button';
 import Pager from '../Pager';
 import { TableColumn, TableRow } from './TableRow';
-
-export { TableColumn, TableRow };
-
-export interface TableSortOptions<T> {
-	reverse: boolean;
-	field: keyof T | null;
-}
-
-export interface TableProps<T> {
-	columns: Array<TableColumn<T>>;
-	data?: T[] | null;
-	getRowHref?: (row: T) => string;
-	// Only usable if a rowKey property is also provided.
-	// If an onCheck property is provided , then checkboxes will be renders,
-	// allowing rows to be selected.
-	onCheck?: (checkedItems: T[]) => void;
-	onRowClick?: (row: T, event: React.MouseEvent<HTMLAnchorElement>) => void;
-	onSort?: (sort: TableSortOptions<T>) => void;
-	sort?: TableSortOptions<T>;
-	rowAnchorAttributes?: React.AnchorHTMLAttributes<HTMLAnchorElement>;
-	rowCheckboxAttributes?: React.InputHTMLAttributes<HTMLInputElement>;
-	// Optionally provide a key that should be used as a unique identifier for each row
-	rowKey?: keyof T;
-	tbodyPrefix?: JSX.Element | JSX.Element[];
-	// Highlights a row. This property requires that you have provided a
-	// `rowKey` property: the row with a `rowKey` property that matches this
-	// value is highlighted.
-	highlightedRows?: any;
-	getRowClass?: (row: T) => string[];
-	// If true, a pager will be used when displaying items.
-	usePager?: boolean;
-	// The number of items to be shown per page. Only used if `usePager` is true. Defaults to `50`.
-	itemsPerPage?: number;
-	// Sets whether the pager is displayed at the top of the table, the bottom of the table or
-	// in both positions. Only used if `usePager` is true. Defaults to `top`.
-	pagerPosition?: 'top' | 'bottom' | 'both';
-}
 
 const highlightStyle = `
 	background-color: ${theme.colors.info.light};
@@ -138,7 +100,7 @@ const BaseTable = styled.div`
 
 const HeaderButton = styled(Button)`
 	display: block;
-` as React.ComponentType<EnhancedType<ButtonProps>>;
+`;
 
 interface TableState<T> {
 	allChecked: boolean;
@@ -150,10 +112,7 @@ interface TableState<T> {
 	page: number;
 }
 
-export default class Table<T> extends React.Component<
-	TableProps<T>,
-	TableState<T>
-> {
+class Table<T> extends React.Component<TableProps<T>, TableState<T>> {
 	constructor(props: TableProps<T>) {
 		super(props);
 
@@ -534,3 +493,42 @@ export default class Table<T> extends React.Component<
 		);
 	}
 }
+
+export interface TableSortOptions<T> {
+	reverse: boolean;
+	field: keyof T | null;
+}
+
+export interface TableProps<T> {
+	columns: Array<TableColumn<T>>;
+	data?: T[] | null;
+	getRowHref?: (row: T) => string;
+	// Only usable if a rowKey property is also provided.
+	// If an onCheck property is provided , then checkboxes will be renders,
+	// allowing rows to be selected.
+	onCheck?: (checkedItems: T[]) => void;
+	onRowClick?: (row: T, event: React.MouseEvent<HTMLAnchorElement>) => void;
+	onSort?: (sort: TableSortOptions<T>) => void;
+	sort?: TableSortOptions<T>;
+	rowAnchorAttributes?: React.AnchorHTMLAttributes<HTMLAnchorElement>;
+	rowCheckboxAttributes?: React.InputHTMLAttributes<HTMLInputElement>;
+	// Optionally provide a key that should be used as a unique identifier for each row
+	rowKey?: keyof T;
+	tbodyPrefix?: JSX.Element | JSX.Element[];
+	// Highlights a row. This property requires that you have provided a
+	// `rowKey` property: the row with a `rowKey` property that matches this
+	// value is highlighted.
+	highlightedRows?: any;
+	getRowClass?: (row: T) => string[];
+	// If true, a pager will be used when displaying items.
+	usePager?: boolean;
+	// The number of items to be shown per page. Only used if `usePager` is true. Defaults to `50`.
+	itemsPerPage?: number;
+	// Sets whether the pager is displayed at the top of the table, the bottom of the table or
+	// in both positions. Only used if `usePager` is true. Defaults to `top`.
+	pagerPosition?: 'top' | 'bottom' | 'both';
+}
+
+export { TableColumn, TableRow };
+
+export default Table;

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -1,20 +1,9 @@
 import map = require('lodash/map');
 import * as React from 'react';
 import styled from 'styled-components';
-import { EnhancedType } from '../common-types';
-import Button, { ButtonProps } from './Button';
-import { Box, BoxProps, Flex, FlexProps } from './Grid';
+import Button from './Button';
+import { Box, BoxProps, Flex } from './Grid';
 import Txt from './Txt';
-
-export interface TabsProps extends EnhancedType<BoxProps> {
-	tabs: string[];
-	help?: JSX.Element;
-	children: JSX.Element[];
-}
-
-export interface TabsState {
-	show: number;
-}
 
 const FlexTab = styled(Flex)`
 	${props => `border-bottom: ${props.theme.colors.gray.main};
@@ -23,7 +12,7 @@ const FlexTab = styled(Flex)`
 	border-style: hidden;
 	border-width: 1px;
 	border-bottom-style: solid;
-` as React.ComponentType<EnhancedType<FlexProps>>;
+`;
 
 const ButtonBase = styled(Button)<{ active: boolean }>`
 	padding: 4px 10px 2px;
@@ -51,7 +40,7 @@ const ButtonBase = styled(Button)<{ active: boolean }>`
 		`
 			: `
 		`}
-` as React.ComponentType<EnhancedType<ButtonProps & { active: boolean }>>;
+`;
 
 class Tabs extends React.Component<TabsProps, TabsState> {
 	constructor(props: TabsProps) {
@@ -100,6 +89,16 @@ class Tabs extends React.Component<TabsProps, TabsState> {
 			</Box>
 		);
 	}
+}
+
+export interface TabsState {
+	show: number;
+}
+
+export interface TabsProps extends BoxProps {
+	tabs: string[];
+	help?: JSX.Element;
+	children: JSX.Element[];
 }
 
 export default Tabs;

--- a/src/components/Terminal/index.tsx
+++ b/src/components/Terminal/index.tsx
@@ -4,19 +4,11 @@ import * as React from 'react';
 import styled from 'styled-components';
 import { ITerminalOptions, Terminal as Xterm } from 'xterm';
 import { fit as fitTerm } from 'xterm/lib/addons/fit/fit';
-import { EnhancedType, Theme as ThemeType } from '../../common-types';
-import Theme from '../../theme';
-import { Box, BoxProps } from '../Grid';
+import { Theme as ThemeType } from '../../common-types';
+// TODO: Remove explicit import and use withTheme. There are some issues with the resulting typings when using withTheme, therefore the current workaround.
+import theme from '../../theme';
+import { Box } from '../Grid';
 import defaultXtermStyle from './XTermDefaultStyle';
-
-export interface TerminalProps {
-	ttyInstance?: Xterm | null;
-	// Prevents tty instance from being destroyed when terminal unmounts
-	persistent?: boolean;
-	nonInteractive?: boolean;
-	color?: string;
-	config?: ITerminalOptions;
-}
 
 const TtyContainer = styled(Box)`
 	position: relative;
@@ -38,7 +30,7 @@ const TtyContainer = styled(Box)`
 	.xterm-viewport::-webkit-scrollbar-thumb {
 		background-color: #e9e9e9;
 	}
-` as React.ComponentType<EnhancedType<BoxProps>>;
+`;
 
 const TtyInner = styled.div`
 	position: absolute;
@@ -47,10 +39,6 @@ const TtyInner = styled.div`
 	right: 0;
 	bottom: 0;
 `;
-
-export interface ThemedTerminalProps extends TerminalProps {
-	theme: ThemeType;
-}
 
 class Terminal extends React.Component<ThemedTerminalProps, {}> {
 	readonly tty: Xterm;
@@ -65,7 +53,7 @@ class Terminal extends React.Component<ThemedTerminalProps, {}> {
 			cols: 80,
 			cursorBlink: false,
 			rows: 24,
-			fontFamily: Theme.monospace,
+			fontFamily: props.theme ? props.theme.monospace : theme.monospace,
 			lineHeight: 1.4,
 			theme: {
 				background: '#343434',
@@ -160,6 +148,19 @@ class Terminal extends React.Component<ThemedTerminalProps, {}> {
 			</TtyContainer>
 		);
 	}
+}
+
+export interface TerminalProps {
+	ttyInstance?: Xterm | null;
+	// Prevents tty instance from being destroyed when terminal unmounts
+	persistent?: boolean;
+	nonInteractive?: boolean;
+	color?: string;
+	config?: ITerminalOptions;
+}
+
+interface ThemedTerminalProps extends TerminalProps {
+	theme?: ThemeType;
 }
 
 export default Terminal;

--- a/src/components/TextWithCopy.tsx
+++ b/src/components/TextWithCopy.tsx
@@ -3,17 +3,12 @@ import * as React from 'react';
 import FaClipboard = require('react-icons/lib/fa/clipboard');
 import styled from 'styled-components';
 import asRendition from '../asRendition';
-import { DefaultProps, EnhancedType } from '../common-types';
+import { DefaultProps, RenditionSystemProps } from '../common-types';
 import { stopEvent } from '../utils';
 import { Box } from './Grid';
 import Txt, { TxtProps } from './Txt';
 
-export interface TextWithCopyProps extends DefaultProps, TxtProps {
-	copy: string;
-	showCopyButton?: 'hover' | 'always';
-}
-
-const Wrapper = styled(Txt.span)<TextWithCopyProps>`
+const Wrapper = styled(Txt.span)<InternalTextWithCopyProps>`
 	display: inline-block;
 	white-space: nowrap;
 
@@ -38,9 +33,9 @@ const Wrapper = styled(Txt.span)<TextWithCopyProps>`
 	&:hover .text-with-copy__copy {
 		visibility: visible;
 	}
-` as React.ComponentType<EnhancedType<TextWithCopyProps>>;
+`;
 
-const Base = ({ copy, ...props }: TextWithCopyProps) => (
+const Base = ({ copy, ...props }: InternalTextWithCopyProps) => (
 	<Wrapper copy={copy} title={copy} {...props} className="text-with-copy">
 		{!!props.children && (
 			<span className="text-with-copy__content">{props.children}</span>
@@ -58,4 +53,12 @@ const Base = ({ copy, ...props }: TextWithCopyProps) => (
 	</Wrapper>
 );
 
-export default asRendition<TextWithCopyProps>(Base);
+export interface InternalTextWithCopyProps extends DefaultProps, TxtProps {
+	copy: string;
+	showCopyButton?: 'hover' | 'always';
+}
+
+export type TextWithCopyProps = InternalTextWithCopyProps &
+	RenditionSystemProps;
+
+export default asRendition<React.FunctionComponent<TextWithCopyProps>>(Base);

--- a/src/components/Textarea.tsx
+++ b/src/components/Textarea.tsx
@@ -1,33 +1,9 @@
 import * as React from 'react';
 import styled from 'styled-components';
 import asRendition from '../asRendition';
-import { DefaultProps } from '../common-types';
+import { DefaultProps, RenditionSystemProps } from '../common-types';
 import { radius } from '../theme';
 import { monospace, px } from '../utils';
-
-export interface TextareaProps extends DefaultProps {
-	monospace?: boolean;
-	autoComplete?: string;
-	autoFocus?: boolean;
-	cols?: number;
-	dirName?: string;
-	disabled?: boolean;
-	form?: string;
-	maxLength?: number;
-	minLength?: number;
-	name?: string;
-	placeholder?: string;
-	readOnly?: boolean;
-	required?: boolean;
-	rows?: number;
-	value?: string;
-	wrap?: string;
-
-	onChange?: React.ChangeEventHandler<HTMLTextAreaElement>;
-	autoRows?: boolean;
-	maxRows?: number;
-	minRows?: number;
-}
 
 const Base = styled.textarea`
 	border-radius: ${px(radius)};
@@ -54,7 +30,7 @@ const Component = ({
 	minRows,
 	rows,
 	...props
-}: TextareaProps) => {
+}: InternalTextareaProps) => {
 	let rowsProp = rows;
 
 	if (autoRows && props.onChange) {
@@ -72,4 +48,30 @@ const Component = ({
 	return <Base rows={rowsProp} {...props} />;
 };
 
-export default asRendition<TextareaProps>(Component);
+export interface InternalTextareaProps extends DefaultProps {
+	monospace?: boolean;
+	autoComplete?: string;
+	autoFocus?: boolean;
+	cols?: number;
+	dirName?: string;
+	disabled?: boolean;
+	form?: string;
+	maxLength?: number;
+	minLength?: number;
+	name?: string;
+	placeholder?: string;
+	readOnly?: boolean;
+	required?: boolean;
+	rows?: number;
+	value?: string;
+	wrap?: string;
+
+	onChange?: React.ChangeEventHandler<HTMLTextAreaElement>;
+	autoRows?: boolean;
+	maxRows?: number;
+	minRows?: number;
+}
+
+export type TextareaProps = InternalTextareaProps & RenditionSystemProps;
+
+export default asRendition<React.FunctionComponent<TextareaProps>>(Component);

--- a/src/components/Txt.tsx
+++ b/src/components/Txt.tsx
@@ -2,41 +2,8 @@ import * as React from 'react';
 import styled from 'styled-components';
 import { style } from 'styled-system';
 import asRendition from '../asRendition';
-import { DefaultProps, EnhancedType, Theme } from '../common-types';
+import { DefaultProps, RenditionSystemProps, Theme } from '../common-types';
 import { monospace } from '../utils';
-
-type Whitespace =
-	| 'normal'
-	| 'nowrap'
-	| 'pre'
-	| 'pre-line'
-	| 'pre-wrap'
-	| 'initial'
-	| 'inherit';
-type Align =
-	| 'left'
-	| 'right'
-	| 'center'
-	| 'justify'
-	| 'justify-all'
-	| 'start'
-	| 'end'
-	| 'match-parent'
-	| 'inherit'
-	| 'initial'
-	| 'unset';
-
-export interface TxtProps extends DefaultProps {
-	monospace?: boolean;
-	bold?: boolean;
-	caps?: boolean;
-	whitespace?: Whitespace;
-	align?: Align;
-}
-
-export interface ThemedTxtProps extends TxtProps {
-	theme: Theme;
-}
 
 export const whitespace = (props: ThemedTxtProps) =>
 	props.whitespace ? { whiteSpace: props.whitespace } : null;
@@ -65,15 +32,50 @@ const Txt = styled.div<TxtProps>`
 `;
 
 const Factory = (tag?: string) => {
-	return asRendition<TxtProps>((props: any) => {
+	return asRendition<React.FunctionComponent<TxtProps>>((props: any) => {
 		return <Txt as={tag} {...props} />;
 	});
 };
 
-const Base = Factory() as React.ComponentType<EnhancedType<TxtProps>> & {
-	p: React.ComponentType<EnhancedType<TxtProps>>;
-	span: React.ComponentType<EnhancedType<TxtProps>>;
+const Base = Factory() as React.FunctionComponent<TxtProps> & {
+	p: React.FunctionComponent<TxtProps>;
+	span: React.FunctionComponent<TxtProps>;
 };
+
+export type Whitespace =
+	| 'normal'
+	| 'nowrap'
+	| 'pre'
+	| 'pre-line'
+	| 'pre-wrap'
+	| 'initial'
+	| 'inherit';
+export type Align =
+	| 'left'
+	| 'right'
+	| 'center'
+	| 'justify'
+	| 'justify-all'
+	| 'start'
+	| 'end'
+	| 'match-parent'
+	| 'inherit'
+	| 'initial'
+	| 'unset';
+
+export interface InternalTxtProps extends DefaultProps {
+	monospace?: boolean;
+	bold?: boolean;
+	caps?: boolean;
+	whitespace?: Whitespace;
+	align?: Align;
+}
+
+export interface ThemedTxtProps extends InternalTxtProps {
+	theme: Theme;
+}
+
+export type TxtProps = InternalTxtProps & RenditionSystemProps;
 
 Base.displayName = 'Txt';
 Base.span = Factory('span');

--- a/src/extra/Markdown.tsx
+++ b/src/extra/Markdown.tsx
@@ -2,10 +2,9 @@ import memoize = require('lodash/memoize');
 import * as marked from 'marked';
 import * as React from 'react';
 import styled from 'styled-components';
-import { EnhancedType } from '../common-types';
 import Txt, { TxtProps } from '../components/Txt';
 
-type MarkdownProps = EnhancedType<TxtProps> & {
+type MarkdownProps = TxtProps & {
 	children: string;
 };
 
@@ -721,7 +720,7 @@ const GitHubMarkdown = styled(Txt)`
 	hr {
 		border-bottom-color: #eee;
 	}
-` as React.ComponentType<EnhancedType<TxtProps>>;
+`;
 
 export const Markdown = ({ children, ...props }: MarkdownProps) => {
 	return (

--- a/src/extra/Mermaid.tsx
+++ b/src/extra/Mermaid.tsx
@@ -1,11 +1,10 @@
 import { mermaidAPI } from 'mermaid';
 import * as React from 'react';
 import uuid = require('uuid/v4');
-import { EnhancedType } from '../common-types';
 import { DefaultProps } from '../common-types';
 import { Box, BoxProps } from '../components/Grid';
 
-interface MermaidProps extends DefaultProps, EnhancedType<BoxProps> {
+interface MermaidProps extends DefaultProps, BoxProps {
 	value: string;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,6 +70,9 @@ export { default as Tabs, TabsProps } from './components/Tabs';
 
 export { Flex, Box, FlexProps, BoxProps } from './components/Grid';
 export { default as Theme } from './theme';
+export { Theme as ThemeType } from './common-types';
+export { v3 } from './migration-types';
+
 export {
 	default as asRendition,
 	withStyledSystem,
@@ -99,5 +102,5 @@ export {
 	TooltipPlacement,
 	TooltipProps,
 	Tooltip,
-	EnhancedType,
+	RenditionSystemProps,
 } from './common-types';

--- a/src/unstable/components/Form/fields/PatternPropertiesField.tsx
+++ b/src/unstable/components/Form/fields/PatternPropertiesField.tsx
@@ -6,8 +6,6 @@ import FaClose = require('react-icons/lib/fa/close');
 import { FormValidation } from 'react-jsonschema-form';
 import styled from 'styled-components';
 import { Button, Input } from '../../../..';
-import { EnhancedType } from '../../../../common-types';
-import { ButtonProps } from '../../../../components/Button';
 
 interface PatternPropertiesFieldProps {
 	onKeyChange: (
@@ -38,7 +36,7 @@ interface ChangeTargetHandlerParams {
 
 const ActionButton = styled(Button)`
 	color: ${({ theme }) => theme.colors.text.light};
-` as React.ComponentType<EnhancedType<ButtonProps>>;
+`;
 
 const handleChange = (
 	func: (value: string, errorSchema?: FormValidation) => void,

--- a/src/unstable/components/Form/index.tsx
+++ b/src/unstable/components/Form/index.tsx
@@ -5,9 +5,8 @@ import omit = require('lodash/omit');
 import * as React from 'react';
 import Form, { IChangeEvent } from 'react-jsonschema-form';
 import styled from 'styled-components';
-import { EnhancedType } from '../../../common-types';
 import Button from '../../../components/Button';
-import { Box, BoxProps } from '../../../components/Grid';
+import { Box } from '../../../components/Grid';
 import * as utils from '../../../utils';
 import { FormProps } from '../../unstable-typings';
 import { DescriptionField } from './fields/DescriptionField';
@@ -62,7 +61,7 @@ const FormWrapper = styled(Box)`
 		margin-bottom: ${props => utils.px(get(props, 'theme.space[1]', 4))};
 		color: ${props => get(props, 'theme.colors.danger.main', '#a94442')};
 	}
-` as React.ComponentType<EnhancedType<BoxProps>>;
+`;
 
 export default class FormHOC extends React.Component<
 	FormProps,

--- a/src/unstable/components/Form/templates/ArrayFieldTemplate.tsx
+++ b/src/unstable/components/Form/templates/ArrayFieldTemplate.tsx
@@ -6,8 +6,6 @@ import FaPlus = require('react-icons/lib/fa/plus');
 import { ArrayFieldTemplateProps } from 'react-jsonschema-form';
 import styled from 'styled-components';
 import { Box, Button, Flex } from '../../../../';
-import { EnhancedType } from '../../../../common-types';
-import { ButtonProps } from '../../../../components/Button';
 import { WarningField } from '../WarningField';
 
 interface ArrayFieldTitleProps {
@@ -50,7 +48,7 @@ const ArrayFieldDescription = ({
 
 const ActionButton = styled(Button)`
 	color: ${({ theme }) => theme.colors.text.light};
-` as React.ComponentType<EnhancedType<ButtonProps>>;
+`;
 
 export default (props: ArrayFieldTemplateProps) => {
 	const warning = props.uiSchema['ui:warning'];

--- a/src/unstable/unstable-typings.ts
+++ b/src/unstable/unstable-typings.ts
@@ -1,6 +1,5 @@
 import { JSONSchema6 } from 'json-schema';
 import { IChangeEvent } from 'react-jsonschema-form';
-import { EnhancedType } from '../common-types';
 import { ButtonProps } from '../components/Button';
 import { BoxProps } from '../components/Grid';
 
@@ -67,7 +66,7 @@ export interface RenditionUiSchema {
 export interface BaseFormProps extends BoxProps {
 	submitButtonText?: string | JSX.Element;
 	hideSubmitButton?: boolean;
-	submitButtonProps?: EnhancedType<ButtonProps>;
+	submitButtonProps?: ButtonProps;
 	value?: number | string | boolean | AnyObject | any[] | null;
 	onFormChange?: (result: IChangeEvent) => void;
 	onFormSubmit?: (result: any) => void;


### PR DESCRIPTION
Because user-facing prop typings are often different from what
is used internally in components, the two were split. Also,
all exports were refactored and moved to the bottom so typings
exports and component exports are collocated.

Another point is `FunctionComponent` doesn't have a `ref` property (previously all
components were exported as `ComponentClass` which was wrong), so each component
is exported appropriately.

Change-type: patch
Signed-off-by: Stevche Radevski <stevche@balena.io>