### PR TITLE
Increase modal default z-index

### DIFF
--- a/__tests__/components/__snapshots__/Modal.spec.js.snap
+++ b/__tests__/components/__snapshots__/Modal.spec.js.snap
@@ -8,7 +8,7 @@ exports[`Modal renders correctly 1`] = `
     aria-hidden={false}
   >
     <div
-      className="StyledLayer-rmtehz-0 exVYop"
+      className="StyledLayer-rmtehz-0 hISvz"
       onKeyDown={[Function]}
       tabIndex="-1"
     >
@@ -17,7 +17,7 @@ exports[`Modal renders correctly 1`] = `
         onMouseDown={[Function]}
       />
       <div
-        className="StyledLayer__StyledContainer-rmtehz-2 hWJDps"
+        className="StyledLayer__StyledContainer-rmtehz-2 ergMLu"
       >
         <a
           aria-hidden="true"

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -161,6 +161,12 @@ export default {
 			horizontal: '30px',
 		},
 	},
+	layer: {
+		container: {
+			zIndex: 40,
+		},
+		zIndex: 30,
+	},
 	text: {
 		medium: {
 			size: '14px',


### PR DESCRIPTION
This leaves a bit more leeway for setting zIndex on other components
that should appear "under" the modal.

Change-type: patch
Signed-off-by: Stevche Radevski <stevche@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have rebuilt the README with `npm run build:docs`
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
