### PR TITLE
Remove resin-semver unused dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2529,14 +2529,6 @@
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.106.tgz",
       "integrity": "sha512-tOSvCVrvSqFZ4A/qrqqm6p37GZoawsZtoR0SJhlF7EonNZUgrn8FfT+RNQ11h+NUpMt6QVe36033f3qEKBwfWA=="
     },
-    "@types/lodash.memoize": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@types/lodash.memoize/-/lodash.memoize-4.1.4.tgz",
-      "integrity": "sha512-3u6RDBxMGQ+XM8lOD+Of5D1c4UZNwo5GmrYAIar6bruSpNb3feECCmG2Dr23/uZTCcEoGrMe/r84nelum3NpUQ==",
-      "requires": {
-        "@types/lodash": "*"
-      }
-    },
     "@types/log-symbols": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@types/log-symbols/-/log-symbols-2.0.0.tgz",
@@ -2660,11 +2652,6 @@
       "resolved": "https://registry.npmjs.org/@types/sanitize-filename/-/sanitize-filename-1.1.28.tgz",
       "integrity": "sha1-uqGPXOQzD8uz6nti9lVQlj2aqgc=",
       "dev": true
-    },
-    "@types/semver": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-5.5.0.tgz",
-      "integrity": "sha512-41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ=="
     },
     "@types/sizzle": {
       "version": "2.3.2",
@@ -12264,7 +12251,8 @@
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
-      "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4="
+      "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
+      "dev": true
     },
     "lodash.some": {
       "version": "4.6.0",
@@ -16804,17 +16792,6 @@
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
       "dev": true
     },
-    "resin-semver": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/resin-semver/-/resin-semver-1.4.0.tgz",
-      "integrity": "sha512-7hvdM8waBxJiZcV7wqvCGG4SPp+PNpg43A6PCwiJTIIw07TgP4+/tlTmumT1MpSOn5o+w/0lt8wc3dJSsItwPQ==",
-      "requires": {
-        "@types/lodash.memoize": "^4.1.2",
-        "@types/semver": "^5.4.0",
-        "lodash.memoize": "^4.1.2",
-        "semver": "^5.3.0"
-      }
-    },
     "resolve": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.0.tgz",
@@ -17113,7 +17090,8 @@
     "semver": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+      "dev": true
     },
     "send": {
       "version": "0.16.2",

--- a/package.json
+++ b/package.json
@@ -124,7 +124,6 @@
     "react-jsonschema-form": "^1.3.0",
     "recompose": "0.26.0",
     "regex-parser": "^2.2.7",
-    "resin-semver": "^1.4.0",
     "styled-components": "^4.2.0",
     "styled-system": "^4.1.0",
     "uuid": "^3.2.1",


### PR DESCRIPTION
The 3.x -> 4.x migration guide states that we removed the semver filters and "resin-semver" can't be found to be imported anywhere in the sources, but it's still in the package.json & lock.
See: https://github.com/balena-io-modules/rendition/blob/master/docs/migrating_3x-4x.md#filters
See: https://github.com/balena-io-modules/rendition/search?q=semver&unscoped_q=semver

Resolves: #836
Change-type: patch
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have rebuilt the README with `npm run build:docs`
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
