### PR TITLE
Replace classes with css in jest snapshot tests

### DIFF
--- a/__tests__/components/Markdown/__snapshots__/Markdown.spec.js.snap
+++ b/__tests__/components/Markdown/__snapshots__/Markdown.spec.js.snap
@@ -1,11 +1,738 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Markdown component should match the stored snapshot 1`] = `
+.c1 {
+  font-family: 'Nunito',Arial,sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c0 {
+  font-family: 'Nunito',Arial,sans-serif;
+}
+
+.c0 h1,
+.c0 h2,
+.c0 h3,
+.c0 h4,
+.c0 h5,
+.c0 h6,
+.c0 label,
+.c0 button {
+  font-family: CircularStd,Arial,sans-serif;
+}
+
+.c2 {
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  font-size: inherit;
+  word-wrap: break-word;
+}
+
+.c2 .pl-c {
+  color: #6a737d;
+}
+
+.c2 .pl-c1,
+.c2 .pl-s .pl-v {
+  color: #005cc5;
+}
+
+.c2 .pl-e,
+.c2 .pl-en {
+  color: #6f42c1;
+}
+
+.c2 .pl-smi,
+.c2 .pl-s .pl-s1 {
+  color: #24292e;
+}
+
+.c2 .pl-ent {
+  color: #22863a;
+}
+
+.c2 .pl-k {
+  color: #d73a49;
+}
+
+.c2 .pl-s,
+.c2 .pl-pds,
+.c2 .pl-s .pl-pse .pl-s1,
+.c2 .pl-sr,
+.c2 .pl-sr .pl-cce,
+.c2 .pl-sr .pl-sre,
+.c2 .pl-sr .pl-sra {
+  color: #032f62;
+}
+
+.c2 .pl-v,
+.c2 .pl-smw {
+  color: #e36209;
+}
+
+.c2 .pl-bu {
+  color: #b31d28;
+}
+
+.c2 .pl-ii {
+  color: #fafbfc;
+  background-color: #b31d28;
+}
+
+.c2 .pl-c2 {
+  color: #fafbfc;
+  background-color: #d73a49;
+}
+
+.c2 .pl-c2::before {
+  content: '^M';
+}
+
+.c2 .pl-sr .pl-cce {
+  font-weight: bold;
+  color: #22863a;
+}
+
+.c2 .pl-ml {
+  color: #735c0f;
+}
+
+.c2 .pl-mh,
+.c2 .pl-mh .pl-en,
+.c2 .pl-ms {
+  font-weight: bold;
+  color: #005cc5;
+}
+
+.c2 .pl-mi {
+  font-style: italic;
+  color: #24292e;
+}
+
+.c2 .pl-mb {
+  font-weight: bold;
+  color: #24292e;
+}
+
+.c2 .pl-md {
+  color: #b31d28;
+  background-color: #ffeef0;
+}
+
+.c2 .pl-mi1 {
+  color: #22863a;
+  background-color: #f0fff4;
+}
+
+.c2 .pl-mc {
+  color: #e36209;
+  background-color: #ffebda;
+}
+
+.c2 .pl-mi2 {
+  color: #f6f8fa;
+  background-color: #005cc5;
+}
+
+.c2 .pl-mdr {
+  font-weight: bold;
+  color: #6f42c1;
+}
+
+.c2 .pl-ba {
+  color: #586069;
+}
+
+.c2 .pl-sg {
+  color: #959da5;
+}
+
+.c2 .pl-corl {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  color: #032f62;
+}
+
+.c2 .octicon {
+  display: inline-block;
+  vertical-align: text-top;
+  fill: currentColor;
+}
+
+.c2 a {
+  background-color: transparent;
+  -webkit-text-decoration-skip: objects;
+}
+
+.c2 a:active,
+.c2 a:hover {
+  outline-width: 0;
+}
+
+.c2 strong {
+  font-weight: inherit;
+}
+
+.c2 strong {
+  font-weight: bolder;
+}
+
+.c2 h1 {
+  font-size: 2em;
+  margin: 0.67em 0;
+}
+
+.c2 img {
+  border-style: none;
+}
+
+.c2 svg:not(:root) {
+  overflow: hidden;
+}
+
+.c2 code,
+.c2 kbd,
+.c2 pre {
+  font-family: 'Ubuntu Mono','Courier New',monospace;
+  font-size: 1em;
+}
+
+.c2 hr {
+  box-sizing: content-box;
+  height: 0;
+  overflow: visible;
+}
+
+.c2 input {
+  font: inherit;
+  margin: 0;
+}
+
+.c2 input {
+  overflow: visible;
+}
+
+.c2 [type='checkbox'] {
+  box-sizing: border-box;
+  padding: 0;
+}
+
+.c2 * {
+  box-sizing: border-box;
+}
+
+.c2 input {
+  font-family: inherit;
+  font-size: inherit;
+  line-height: inherit;
+}
+
+.c2 a {
+  color: #0366d6;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2 a:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c2 strong {
+  font-weight: 600;
+}
+
+.c2 hr {
+  height: 0;
+  margin: 15px 0;
+  overflow: hidden;
+  background: transparent;
+  border: 0;
+  border-bottom: 1px solid #dfe2e5;
+}
+
+.c2 hr::before {
+  display: table;
+  content: '';
+}
+
+.c2 hr::after {
+  display: table;
+  clear: both;
+  content: '';
+}
+
+.c2 table {
+  border-spacing: 0;
+  border-collapse: collapse;
+}
+
+.c2 td,
+.c2 th {
+  padding: 0;
+}
+
+.c2 h1,
+.c2 h2,
+.c2 h3,
+.c2 h4,
+.c2 h5,
+.c2 h6 {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.c2 h1 {
+  font-size: 32px;
+  font-weight: 600;
+}
+
+.c2 h2 {
+  font-size: 24px;
+  font-weight: 600;
+}
+
+.c2 h3 {
+  font-size: 20px;
+  font-weight: 600;
+}
+
+.c2 h4 {
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.c2 h5 {
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c2 h6 {
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.c2 p {
+  margin-top: 0;
+  margin-bottom: 10px;
+}
+
+.c2 blockquote {
+  margin: 0;
+}
+
+.c2 ul,
+.c2 ol {
+  padding-left: 0;
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.c2 ol ol,
+.c2 ul ol {
+  list-style-type: lower-roman;
+}
+
+.c2 ul ul ol,
+.c2 ul ol ol,
+.c2 ol ul ol,
+.c2 ol ol ol {
+  list-style-type: lower-alpha;
+}
+
+.c2 dd {
+  margin-left: 0;
+}
+
+.c2 code {
+  font-family: 'Ubuntu Mono','Courier New',monospace;
+  font-size: 1em;
+}
+
+.c2 pre {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 1em;
+  font-family: 'Ubuntu Mono','Courier New',monospace;
+}
+
+.c2 .octicon {
+  vertical-align: text-bottom;
+}
+
+.c2 .pl-0 {
+  padding-left: 0 !important;
+}
+
+.c2 .pl-1 {
+  padding-left: 4px !important;
+}
+
+.c2 .pl-2 {
+  padding-left: 8px !important;
+}
+
+.c2 .pl-3 {
+  padding-left: 16px !important;
+}
+
+.c2 .pl-4 {
+  padding-left: 24px !important;
+}
+
+.c2 .pl-5 {
+  padding-left: 32px !important;
+}
+
+.c2 .pl-6 {
+  padding-left: 40px !important;
+}
+
+.c2 .markdown-body::before {
+  display: table;
+  content: '';
+}
+
+.c2 .markdown-body::after {
+  display: table;
+  clear: both;
+  content: '';
+}
+
+.c2 > *:first-child {
+  margin-top: 0 !important;
+}
+
+.c2 > *:last-child {
+  margin-bottom: 0 !important;
+}
+
+.c2 a:not([href]) {
+  color: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2 .anchor {
+  float: left;
+  padding-right: 4px;
+  margin-left: -20px;
+  line-height: 1;
+}
+
+.c2 .anchor:focus {
+  outline: none;
+}
+
+.c2 p,
+.c2 blockquote,
+.c2 ul,
+.c2 ol,
+.c2 dl,
+.c2 table,
+.c2 pre {
+  margin-top: 0;
+  margin-bottom: 16px;
+}
+
+.c2 hr {
+  height: 0.25em;
+  padding: 0;
+  margin: 24px 0;
+  background-color: #e1e4e8;
+  border: 0;
+}
+
+.c2 blockquote {
+  padding: 0 1em;
+  color: #6a737d;
+  border-left: 0.25em solid #dfe2e5;
+}
+
+.c2 blockquote > :first-child {
+  margin-top: 0;
+}
+
+.c2 blockquote > :last-child {
+  margin-bottom: 0;
+}
+
+.c2 kbd {
+  display: inline-block;
+  padding: 3px 5px;
+  font-size: 11px;
+  line-height: 10px;
+  color: #444d56;
+  vertical-align: middle;
+  background-color: #fafbfc;
+  border: solid 1px #c6cbd1;
+  border-bottom-color: #959da5;
+  border-radius: 3px;
+  box-shadow: inset 0 -1px 0 #959da5;
+}
+
+.c2 h1,
+.c2 h2,
+.c2 h3,
+.c2 h4,
+.c2 h5,
+.c2 h6 {
+  margin-top: 24px;
+  margin-bottom: 16px;
+  font-weight: 600;
+  line-height: 1.25;
+}
+
+.c2 h1 .octicon-link,
+.c2 h2 .octicon-link,
+.c2 h3 .octicon-link,
+.c2 h4 .octicon-link,
+.c2 h5 .octicon-link,
+.c2 h6 .octicon-link {
+  color: #1b1f23;
+  vertical-align: middle;
+  visibility: hidden;
+}
+
+.c2 h1:hover .anchor,
+.c2 h2:hover .anchor,
+.c2 h3:hover .anchor,
+.c2 h4:hover .anchor,
+.c2 h5:hover .anchor,
+.c2 h6:hover .anchor {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2 h1:hover .anchor .octicon-link,
+.c2 h2:hover .anchor .octicon-link,
+.c2 h3:hover .anchor .octicon-link,
+.c2 h4:hover .anchor .octicon-link,
+.c2 h5:hover .anchor .octicon-link,
+.c2 h6:hover .anchor .octicon-link {
+  visibility: visible;
+}
+
+.c2 h1 {
+  padding-bottom: 0.3em;
+  font-size: 2em;
+  border-bottom: 1px solid #eaecef;
+}
+
+.c2 h2 {
+  padding-bottom: 0.3em;
+  font-size: 1.5em;
+  border-bottom: 1px solid #eaecef;
+}
+
+.c2 h3 {
+  font-size: 1.25em;
+}
+
+.c2 h4 {
+  font-size: 1em;
+}
+
+.c2 h5 {
+  font-size: 0.875em;
+}
+
+.c2 h6 {
+  font-size: 0.85em;
+  color: #6a737d;
+}
+
+.c2 ul,
+.c2 ol {
+  padding-left: 2em;
+}
+
+.c2 ul ul,
+.c2 ul ol,
+.c2 ol ol,
+.c2 ol ul {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.c2 li > p {
+  margin-top: 16px;
+}
+
+.c2 li + li {
+  margin-top: 0.25em;
+}
+
+.c2 dl {
+  padding: 0;
+}
+
+.c2 dl dt {
+  padding: 0;
+  margin-top: 16px;
+  font-size: 1em;
+  font-style: italic;
+  font-weight: 600;
+}
+
+.c2 dl dd {
+  padding: 0 16px;
+  margin-bottom: 16px;
+}
+
+.c2 table {
+  display: block;
+  width: 100%;
+  overflow: auto;
+}
+
+.c2 table th {
+  font-weight: 600;
+}
+
+.c2 table th,
+.c2 table td {
+  padding: 6px 13px;
+  border: 1px solid #dfe2e5;
+}
+
+.c2 table tr {
+  background-color: #fff;
+  border-top: 1px solid #c6cbd1;
+}
+
+.c2 table tr:nth-child(2n) {
+  background-color: #f6f8fa;
+}
+
+.c2 img {
+  max-width: 100%;
+  box-sizing: content-box;
+  background-color: #fff;
+}
+
+.c2 code {
+  padding: 0;
+  padding-top: 0.2em;
+  padding-bottom: 0.2em;
+  margin: 0;
+  background-color: rgba(27,31,35,0.05);
+  border-radius: 3px;
+}
+
+.c2 code::before,
+.c2 code::after {
+  -webkit-letter-spacing: -0.2em;
+  -moz-letter-spacing: -0.2em;
+  -ms-letter-spacing: -0.2em;
+  letter-spacing: -0.2em;
+  content: '\\00a0';
+}
+
+.c2 pre {
+  word-wrap: normal;
+}
+
+.c2 pre > code {
+  padding: 0;
+  margin: 0;
+  font-size: 100%;
+  word-break: normal;
+  white-space: pre;
+  background: transparent;
+  border: 0;
+}
+
+.c2 .highlight {
+  margin-bottom: 16px;
+}
+
+.c2 .highlight pre {
+  margin-bottom: 0;
+  word-break: normal;
+}
+
+.c2 .highlight pre,
+.c2 pre {
+  padding: 16px;
+  overflow: auto;
+  font-size: 95%;
+  line-height: 1.45;
+  background-color: #f6f8fa;
+  border-radius: 3px;
+}
+
+.c2 pre code {
+  display: inline;
+  max-width: auto;
+  padding: 0;
+  margin: 0;
+  overflow: visible;
+  line-height: inherit;
+  word-wrap: normal;
+  background-color: transparent;
+  border: 0;
+}
+
+.c2 pre code::before,
+.c2 pre code::after {
+  content: normal;
+}
+
+.c2 .full-commit .btn-outline:not(:disabled):hover {
+  color: #005cc5;
+  border-color: #005cc5;
+}
+
+.c2 kbd {
+  display: inline-block;
+  padding: 3px 5px;
+  font-size: 11px;
+  font-family: 'Ubuntu Mono','Courier New',monospace;
+  line-height: 10px;
+  color: #444d56;
+  vertical-align: middle;
+  background-color: #fafbfc;
+  border: solid 1px #d1d5da;
+  border-bottom-color: #c6cbd1;
+  border-radius: 3px;
+  box-shadow: inset 0 -1px 0 #c6cbd1;
+}
+
+.c2:checked + .radio-label {
+  position: relative;
+  z-index: 1;
+  border-color: #0366d6;
+}
+
+.c2 .task-list-item {
+  list-style-type: none;
+}
+
+.c2 .task-list-item + .task-list-item {
+  margin-top: 3px;
+}
+
+.c2 .task-list-item input {
+  margin: 0 0.2em 0.25em -1.6em;
+  vertical-align: middle;
+}
+
+.c2 hr {
+  border-bottom-color: #eee;
+}
+
 <div
-  className="sc-btzYZH jBDBBH StyledGrommet-sc-19lkkz7-0 bBubtL"
+  className="c0 c1"
 >
   <div
-    className="sc-epnACN beqwcJ sc-kGXeez giCiqz sc-kgoBCf kRuyZZ"
+    className="c2 "
     dangerouslySetInnerHTML={
       Object {
         "__html": "<p>Hello world</p>

--- a/__tests__/components/__snapshots__/Alert.spec.js.snap
+++ b/__tests__/components/__snapshots__/Alert.spec.js.snap
@@ -1,11 +1,76 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Alert renders correctly 1`] = `
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: normal;
+  -webkit-justify-content: normal;
+  -ms-flex-pack: normal;
+  justify-content: normal;
+  position: relative;
+  min-height: 36px;
+  padding: 8px 32px;
+  margin: 0;
+  border-radius: 3px;
+  font-family: inherit;
+  font-size: 16px;
+  font-kerning: none;
+  font-weight: 400;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+  line-height: 1.1;
+  padding-left: 19px;
+  border: 1px solid;
+  color: #3c3e42;
+}
+
+.c2 .c3,
+.c2 .sc-iwsKbI > .sc-gZMcBi {
+  font-weight: 700;
+}
+
+.c1 {
+  font-family: 'Nunito',Arial,sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c0 {
+  font-family: 'Nunito',Arial,sans-serif;
+}
+
+.c0 h1,
+.c0 h2,
+.c0 h3,
+.c0 h4,
+.c0 h5,
+.c0 h6,
+.c0 label,
+.c0 button {
+  font-family: CircularStd,Arial,sans-serif;
+}
+
 <div
-  className="sc-btzYZH jBDBBH StyledGrommet-sc-19lkkz7-0 bBubtL"
+  className="c0 c1"
 >
   <div
-    className="sc-gqjmRU sc-jzJRlG chuvNI sc-VigVT gJMZjz"
+    className="c2"
   >
     <div>
       

--- a/__tests__/components/__snapshots__/ArcSlider.spec.js.snap
+++ b/__tests__/components/__snapshots__/ArcSlider.spec.js.snap
@@ -1,14 +1,75 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ArcSlider component should match the stored snapshot 1`] = `
+.c3 {
+  box-sizing: border-box;
+}
+
+.c4 {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.c2 {
+  position: relative;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  text-align: center;
+  pointer-events: none;
+}
+
+.c1 {
+  font-family: 'Nunito',Arial,sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c0 {
+  font-family: 'Nunito',Arial,sans-serif;
+}
+
+.c0 h1,
+.c0 h2,
+.c0 h3,
+.c0 h4,
+.c0 h5,
+.c0 h6,
+.c0 label,
+.c0 button {
+  font-family: CircularStd,Arial,sans-serif;
+}
+
 <div
-  className="sc-btzYZH jBDBBH StyledGrommet-sc-19lkkz7-0 bBubtL"
+  className="c0 c1"
 >
   <div
-    className="sc-kAzzGY dMfzxP sc-gzVnrw pznRG sc-bZQynM kMvugX"
+    className="c2 c3"
   >
     <svg
-      className="sc-cSHVUG fhdDsO"
+      className="c4"
       onMouseDown={[Function]}
       onTouchStart={[Function]}
       style={
@@ -88,7 +149,7 @@ exports[`ArcSlider component should match the stored snapshot 1`] = `
       />
     </svg>
     <div
-      className="sc-htoDjs sc-chPdSV NULXb sc-gzVnrw pznRG sc-bZQynM kMvugX"
+      className="c5 c3"
     />
   </div>
 </div>

--- a/__tests__/components/__snapshots__/Badge.spec.js.snap
+++ b/__tests__/components/__snapshots__/Badge.spec.js.snap
@@ -1,11 +1,58 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Badge renders correctly 1`] = `
+.c3 {
+  padding: 2px 5px;
+  font-size: 16px;
+  color: #fff;
+  background-color: #8dc587;
+}
+
+.c2 {
+  border-radius: 3px;
+  display: inline-block;
+  min-width: 40px;
+  text-align: center;
+  font-weight: 800;
+  font-style: normal;
+  font-stretch: normal;
+  -webkit-letter-spacing: 0.5px;
+  -moz-letter-spacing: 0.5px;
+  -ms-letter-spacing: 0.5px;
+  letter-spacing: 0.5px;
+}
+
+.c1 {
+  font-family: 'Nunito',Arial,sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c0 {
+  font-family: 'Nunito',Arial,sans-serif;
+}
+
+.c0 h1,
+.c0 h2,
+.c0 h3,
+.c0 h4,
+.c0 h5,
+.c0 h6,
+.c0 label,
+.c0 button {
+  font-family: CircularStd,Arial,sans-serif;
+}
+
 <div
-  className="sc-btzYZH jBDBBH StyledGrommet-sc-19lkkz7-0 bBubtL"
+  className="c0 c1"
 >
   <div
-    className="sc-jKJlTe gKSgKv sc-ckVGcZ ligfVN sc-kGXeez iDsUmx sc-kgoBCf kRuyZZ"
+    className="c2 c3 "
   >
     Badge
   </div>

--- a/__tests__/components/__snapshots__/Banner.spec.js.snap
+++ b/__tests__/components/__snapshots__/Banner.spec.js.snap
@@ -1,11 +1,70 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Banner renders correctly 1`] = `
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  min-height: 80vh;
+  background-size: cover;
+  background-position: center;
+  background-image: none;
+}
+
+.c2 {
+  padding: 16px;
+  color: white;
+}
+
+.c1 {
+  font-family: 'Nunito',Arial,sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c0 {
+  font-family: 'Nunito',Arial,sans-serif;
+}
+
+.c0 h1,
+.c0 h2,
+.c0 h3,
+.c0 h4,
+.c0 h5,
+.c0 h6,
+.c0 label,
+.c0 button {
+  font-family: CircularStd,Arial,sans-serif;
+}
+
+@media screen and (min-width:32em) {
+  .c2 {
+    padding: 36px;
+  }
+}
+
 <div
-  className="sc-btzYZH jBDBBH StyledGrommet-sc-19lkkz7-0 bBubtL"
+  className="c0 c1"
 >
   <div
-    className="sc-hMqMXs gjygcY sc-eNQAEJ hMNAxB"
+    className="c2 c3"
   >
     <h1>
       balena

--- a/__tests__/components/__snapshots__/Box.spec.js.snap
+++ b/__tests__/components/__snapshots__/Box.spec.js.snap
@@ -1,11 +1,41 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Box renders correctly 1`] = `
+.c2 {
+  box-sizing: border-box;
+}
+
+.c1 {
+  font-family: 'Nunito',Arial,sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c0 {
+  font-family: 'Nunito',Arial,sans-serif;
+}
+
+.c0 h1,
+.c0 h2,
+.c0 h3,
+.c0 h4,
+.c0 h5,
+.c0 h6,
+.c0 label,
+.c0 button {
+  font-family: CircularStd,Arial,sans-serif;
+}
+
 <div
-  className="sc-btzYZH jBDBBH StyledGrommet-sc-19lkkz7-0 bBubtL"
+  className="c0 c1"
 >
   <div
-    className="sc-gzVnrw pznRG sc-bZQynM kMvugX"
+    className="c2"
   >
     A box
   </div>

--- a/__tests__/components/__snapshots__/Button.spec.js.snap
+++ b/__tests__/components/__snapshots__/Button.spec.js.snap
@@ -1,11 +1,102 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Button renders correctly 1`] = `
+.c3 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  outline: none;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: 1px solid #3c3e42;
+  border-radius: 20px;
+  color: #444444;
+  padding: 4px 30px;
+  font-size: 14px;
+  line-height: 1.5;
+  -webkit-transition: 0.1s ease-in-out;
+  transition: 0.1s ease-in-out;
+}
+
+.c3:hover {
+  box-shadow: 0px 0px 0px 2px #3c3e42;
+}
+
+.c1 {
+  font-family: 'Nunito',Arial,sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c2 {
+  font-family: CircularStd,Arial,sans-serif;
+  font-weight: 400;
+  height: 36px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  color: #3c3e42;
+  border-color: #3c3e42;
+}
+
+.c2 svg {
+  color: inherit !important;
+  font-size: 0.875em;
+}
+
+.c2:disabled {
+  cursor: not-allowed;
+}
+
+.c2:hover:enabled,
+.c2:focus:enabled,
+.c2:active:enabled {
+  box-shadow: none;
+  background: #3c3e42;
+  border-color: #3c3e42;
+  color: white;
+  opacity: undefined;
+}
+
+.c0 {
+  font-family: 'Nunito',Arial,sans-serif;
+}
+
+.c0 h1,
+.c0 h2,
+.c0 h3,
+.c0 h4,
+.c0 h5,
+.c0 h6,
+.c0 label,
+.c0 button {
+  font-family: CircularStd,Arial,sans-serif;
+}
+
 <div
-  className="sc-btzYZH jBDBBH StyledGrommet-sc-19lkkz7-0 bBubtL"
+  className="c0 c1"
 >
   <button
-    className="sc-kEYyzF sc-brqgnP fjrEUv sc-iAyFgw hgxYpe StyledButton-sc-323bzc-0 djTlJn"
+    className="c2 c3"
     onBlur={[Function]}
     onFocus={[Function]}
     onMouseOut={[Function]}
@@ -18,11 +109,106 @@ exports[`Button renders correctly 1`] = `
 `;
 
 exports[`Styled Anchor Button renders correctly 1`] = `
+.c4 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  outline: none;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: 1px solid #3c3e42;
+  border-radius: 20px;
+  color: #444444;
+  padding: 4px 30px;
+  font-size: 14px;
+  line-height: 1.5;
+  -webkit-transition: 0.1s ease-in-out;
+  transition: 0.1s ease-in-out;
+}
+
+.c4:hover {
+  box-shadow: 0px 0px 0px 2px #3c3e42;
+}
+
+.c1 {
+  font-family: 'Nunito',Arial,sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c3 {
+  font-family: CircularStd,Arial,sans-serif;
+  font-weight: 400;
+  height: 36px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  color: #3c3e42;
+  border-color: #3c3e42;
+}
+
+.c3 svg {
+  color: inherit !important;
+  font-size: 0.875em;
+}
+
+.c3:disabled {
+  cursor: not-allowed;
+}
+
+.c3:hover:enabled,
+.c3:focus:enabled,
+.c3:active:enabled {
+  box-shadow: none;
+  background: #3c3e42;
+  border-color: #3c3e42;
+  color: white;
+  opacity: undefined;
+}
+
+.c2 {
+  margin: 8px;
+}
+
+.c0 {
+  font-family: 'Nunito',Arial,sans-serif;
+}
+
+.c0 h1,
+.c0 h2,
+.c0 h3,
+.c0 h4,
+.c0 h5,
+.c0 h6,
+.c0 label,
+.c0 button {
+  font-family: CircularStd,Arial,sans-serif;
+}
+
 <div
-  className="sc-btzYZH jBDBBH StyledGrommet-sc-19lkkz7-0 bBubtL"
+  className="c0 c1"
 >
   <a
-    className="sc-kEYyzF sc-brqgnP kHRNhU sc-iAyFgw hgxYpe StyledButton-sc-323bzc-0 djTlJn"
+    className="c2 c3 c4"
     href="#"
     onBlur={[Function]}
     onFocus={[Function]}
@@ -35,11 +221,106 @@ exports[`Styled Anchor Button renders correctly 1`] = `
 `;
 
 exports[`Styled Button renders correctly 1`] = `
+.c4 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  outline: none;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: 1px solid #3c3e42;
+  border-radius: 20px;
+  color: #444444;
+  padding: 4px 30px;
+  font-size: 14px;
+  line-height: 1.5;
+  -webkit-transition: 0.1s ease-in-out;
+  transition: 0.1s ease-in-out;
+}
+
+.c4:hover {
+  box-shadow: 0px 0px 0px 2px #3c3e42;
+}
+
+.c1 {
+  font-family: 'Nunito',Arial,sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c3 {
+  font-family: CircularStd,Arial,sans-serif;
+  font-weight: 400;
+  height: 36px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  color: #3c3e42;
+  border-color: #3c3e42;
+}
+
+.c3 svg {
+  color: inherit !important;
+  font-size: 0.875em;
+}
+
+.c3:disabled {
+  cursor: not-allowed;
+}
+
+.c3:hover:enabled,
+.c3:focus:enabled,
+.c3:active:enabled {
+  box-shadow: none;
+  background: #3c3e42;
+  border-color: #3c3e42;
+  color: white;
+  opacity: undefined;
+}
+
+.c2 {
+  margin: 8px;
+}
+
+.c0 {
+  font-family: 'Nunito',Arial,sans-serif;
+}
+
+.c0 h1,
+.c0 h2,
+.c0 h3,
+.c0 h4,
+.c0 h5,
+.c0 h6,
+.c0 label,
+.c0 button {
+  font-family: CircularStd,Arial,sans-serif;
+}
+
 <div
-  className="sc-btzYZH jBDBBH StyledGrommet-sc-19lkkz7-0 bBubtL"
+  className="c0 c1"
 >
   <button
-    className="sc-kEYyzF sc-brqgnP kHRNhU sc-iAyFgw hgxYpe StyledButton-sc-323bzc-0 djTlJn"
+    className="c2 c3 c4"
     onBlur={[Function]}
     onFocus={[Function]}
     onMouseOut={[Function]}

--- a/__tests__/components/__snapshots__/ButtonGroup.spec.js.snap
+++ b/__tests__/components/__snapshots__/ButtonGroup.spec.js.snap
@@ -1,14 +1,134 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ButtonGroup renders correctly 1`] = `
+.c3 {
+  box-sizing: border-box;
+}
+
+.c5 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  outline: none;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: 1px solid #3c3e42;
+  border-radius: 20px;
+  color: #444444;
+  padding: 4px 30px;
+  font-size: 14px;
+  line-height: 1.5;
+  -webkit-transition: 0.1s ease-in-out;
+  transition: 0.1s ease-in-out;
+}
+
+.c5:hover {
+  box-shadow: 0px 0px 0px 2px #3c3e42;
+}
+
+.c1 {
+  font-family: 'Nunito',Arial,sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c4 {
+  font-family: CircularStd,Arial,sans-serif;
+  font-weight: 400;
+  height: 36px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  color: #3c3e42;
+  border-color: #3c3e42;
+}
+
+.c4 svg {
+  color: inherit !important;
+  font-size: 0.875em;
+}
+
+.c4:disabled {
+  cursor: not-allowed;
+}
+
+.c4:hover:enabled,
+.c4:focus:enabled,
+.c4:active:enabled {
+  box-shadow: none;
+  background: #3c3e42;
+  border-color: #3c3e42;
+  color: white;
+  opacity: undefined;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c2 > *:first-child {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c2 > *:last-child {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c2 > *:not(:last-child):not(:first-child) {
+  border-radius: 0;
+}
+
+.c2 > *:hover {
+  z-index: 1;
+}
+
+.c0 {
+  font-family: 'Nunito',Arial,sans-serif;
+}
+
+.c0 h1,
+.c0 h2,
+.c0 h3,
+.c0 h4,
+.c0 h5,
+.c0 h6,
+.c0 label,
+.c0 button {
+  font-family: CircularStd,Arial,sans-serif;
+}
+
 <div
-  className="sc-btzYZH jBDBBH StyledGrommet-sc-19lkkz7-0 bBubtL"
+  className="c0 c1"
 >
   <div
-    className="sc-htoDjs sc-cMljjf dQmdry sc-gzVnrw pznRG sc-bZQynM kMvugX"
+    className="c2 c3"
   >
     <button
-      className="sc-kEYyzF sc-brqgnP fjrEUv sc-iAyFgw hgxYpe StyledButton-sc-323bzc-0 djTlJn"
+      className="c4 c5"
       onBlur={[Function]}
       onFocus={[Function]}
       onMouseOut={[Function]}
@@ -18,7 +138,7 @@ exports[`ButtonGroup renders correctly 1`] = `
       First
     </button>
     <button
-      className="sc-kEYyzF sc-brqgnP fjrEUv sc-iAyFgw hgxYpe StyledButton-sc-323bzc-0 djTlJn"
+      className="c4 c5"
       onBlur={[Function]}
       onFocus={[Function]}
       onMouseOut={[Function]}
@@ -28,7 +148,7 @@ exports[`ButtonGroup renders correctly 1`] = `
       Second
     </button>
     <button
-      className="sc-kEYyzF sc-brqgnP fjrEUv sc-iAyFgw hgxYpe StyledButton-sc-323bzc-0 djTlJn"
+      className="c4 c5"
       onBlur={[Function]}
       onFocus={[Function]}
       onMouseOut={[Function]}

--- a/__tests__/components/__snapshots__/Card.js.snap
+++ b/__tests__/components/__snapshots__/Card.js.snap
@@ -1,14 +1,57 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Search renders correctly 1`] = `
+.c4 {
+  box-sizing: border-box;
+}
+
+.c3 {
+  margin-top: 0;
+}
+
+.c1 {
+  font-family: 'Nunito',Arial,sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c2 {
+  border: solid 1px #dfdede;
+  border-radius: 3px;
+  box-shadow: 0 1px 4px 0 rgba(0,0,0,0.14);
+  padding: 20px;
+  background-color: #ffffff;
+  min-height: auto;
+}
+
+.c0 {
+  font-family: 'Nunito',Arial,sans-serif;
+}
+
+.c0 h1,
+.c0 h2,
+.c0 h3,
+.c0 h4,
+.c0 h5,
+.c0 h6,
+.c0 label,
+.c0 button {
+  font-family: CircularStd,Arial,sans-serif;
+}
+
 <div
-  className="sc-btzYZH jBDBBH StyledGrommet-sc-19lkkz7-0 bBubtL"
+  className="c0 c1"
 >
   <div
-    className="sc-iRbamj fcGLpU sc-gPEVay iZWcVf"
+    className="c2"
   >
     <div
-      className="sc-gzVnrw hZnCYl sc-bZQynM kMvugX"
+      className="c3 c4"
     >
       Lorem ipsum dolor so ammet
     </div>

--- a/__tests__/components/__snapshots__/Container.spec.js.snap
+++ b/__tests__/components/__snapshots__/Container.spec.js.snap
@@ -1,11 +1,66 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Container renders correctly 1`] = `
+.c1 {
+  font-family: 'Nunito',Arial,sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c0 {
+  font-family: 'Nunito',Arial,sans-serif;
+}
+
+.c0 h1,
+.c0 h2,
+.c0 h3,
+.c0 h4,
+.c0 h5,
+.c0 h6,
+.c0 label,
+.c0 button {
+  font-family: CircularStd,Arial,sans-serif;
+}
+
+.c3 {
+  max-width: calc(32em - 0em);
+}
+
+.c2 {
+  margin-left: auto;
+  margin-right: auto;
+  padding-left: 16px;
+  padding-right: 16px;
+}
+
+@media screen and (min-width:32em) {
+  .c3 {
+    max-width: calc(48em - 4em);
+  }
+}
+
+@media screen and (min-width:48em) {
+  .c3 {
+    max-width: calc(64em - 8em);
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c3 {
+    max-width: calc(80em - 16em);
+  }
+}
+
 <div
-  className="sc-btzYZH jBDBBH StyledGrommet-sc-19lkkz7-0 bBubtL"
+  className="c0 c1"
 >
   <div
-    className="sc-RefOD ixKJeS sc-ibxdXY cjaQli"
+    className="c2 c3"
   >
     Container
   </div>

--- a/__tests__/components/__snapshots__/Divider.spec.js.snap
+++ b/__tests__/components/__snapshots__/Divider.spec.js.snap
@@ -1,11 +1,43 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Divider renders correctly 1`] = `
+.c1 {
+  font-family: 'Nunito',Arial,sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c2 {
+  border: none;
+  height: 2px;
+  background-color: #333;
+}
+
+.c0 {
+  font-family: 'Nunito',Arial,sans-serif;
+}
+
+.c0 h1,
+.c0 h2,
+.c0 h3,
+.c0 h4,
+.c0 h5,
+.c0 h6,
+.c0 label,
+.c0 button {
+  font-family: CircularStd,Arial,sans-serif;
+}
+
 <div
-  className="sc-btzYZH jBDBBH StyledGrommet-sc-19lkkz7-0 bBubtL"
+  className="c0 c1"
 >
   <hr
-    className="sc-jDwBTQ fIjELo sc-jAaTju goPlGf"
+    className="c2"
   />
 </div>
 `;

--- a/__tests__/components/__snapshots__/DropDownButton.spec.js.snap
+++ b/__tests__/components/__snapshots__/DropDownButton.spec.js.snap
@@ -1,15 +1,169 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DropDownButton renders correctly 1`] = `
+.c3 {
+  box-sizing: border-box;
+}
+
+.c6 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  outline: none;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: 1px solid #00AEEF;
+  border-radius: 20px;
+  color: #444444;
+  padding: 4px 30px;
+  font-size: 14px;
+  line-height: 1.5;
+  background: #00AEEF;
+  color: #444444;
+  border-radius: 20px;
+  -webkit-transition: 0.1s ease-in-out;
+  transition: 0.1s ease-in-out;
+}
+
+.c6:hover {
+  box-shadow: 0px 0px 0px 2px #00AEEF;
+}
+
+.c8 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  outline: none;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: 1px solid #00AEEF;
+  border-radius: 20px;
+  color: #444444;
+  padding: 4px 30px;
+  font-size: 14px;
+  line-height: 1.5;
+  background: #00AEEF;
+  color: #444444;
+  border-radius: 20px;
+  -webkit-transition: 0.1s ease-in-out;
+  transition: 0.1s ease-in-out;
+  line-height: 0;
+  padding: 12px;
+}
+
+.c8:hover {
+  box-shadow: 0px 0px 0px 2px #00AEEF;
+}
+
+.c1 {
+  font-family: 'Nunito',Arial,sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c5 {
+  font-family: CircularStd,Arial,sans-serif;
+  font-weight: 400;
+  height: 36px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  color: white;
+}
+
+.c5 svg {
+  color: inherit !important;
+  font-size: 0.875em;
+}
+
+.c5:disabled {
+  cursor: not-allowed;
+}
+
+.c5:hover:enabled,
+.c5:focus:enabled,
+.c5:active:enabled {
+  box-shadow: none;
+  background: hsl(196.29999999999995,100%,37.5%);
+  border-color: hsl(196.29999999999995,100%,37.5%);
+  color: white;
+  opacity: undefined;
+}
+
+.c7 {
+  min-width: 0;
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+  border-left: 0;
+  margin: 0;
+  vertical-align: top;
+  padding: 0 16px;
+  width: 44px;
+}
+
+.c4 {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+  border-right: 0;
+  margin: 0;
+  width: calc(100% - 44px);
+}
+
+.c2 {
+  display: inline-block;
+  border-radius: 3px;
+  vertical-align: top;
+  position: relative;
+}
+
+.c0 {
+  font-family: 'Nunito',Arial,sans-serif;
+}
+
+.c0 h1,
+.c0 h2,
+.c0 h3,
+.c0 h4,
+.c0 h5,
+.c0 h6,
+.c0 label,
+.c0 button {
+  font-family: CircularStd,Arial,sans-serif;
+}
+
 <div
-  className="sc-btzYZH jBDBBH StyledGrommet-sc-19lkkz7-0 bBubtL"
+  className="c0 c1"
 >
   <div
-    className="sc-dNLxif iEMwxC sc-frDJqD dCYbIk sc-gzVnrw pznRG sc-bZQynM kMvugX"
+    className="c2 c3"
   >
     <span>
       <button
-        className="sc-kEYyzF sc-ksYbfQ Pxrgi sc-brqgnP fjrEUv sc-kkGfuU gYcgar StyledButton-sc-323bzc-0 jfOEyc"
+        className="c4 c5 c6"
         onBlur={[Function]}
         onFocus={[Function]}
         onMouseOut={[Function]}
@@ -21,7 +175,7 @@ exports[`DropDownButton renders correctly 1`] = `
         </div>
       </button>
       <button
-        className="sc-kEYyzF sc-cJSrbW hVWOgQ sc-brqgnP fjrEUv sc-kkGfuU gYcgar StyledButton-sc-323bzc-0 dQGtHJ"
+        className="c7 c5 c8"
         onBlur={[Function]}
         onClick={[Function]}
         onFocus={[Function]}
@@ -55,15 +209,205 @@ exports[`DropDownButton renders correctly 1`] = `
 `;
 
 exports[`Opened DropDownButton renders correctly 1`] = `
+.c3 {
+  box-sizing: border-box;
+}
+
+.c6 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  outline: none;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: 1px solid #00AEEF;
+  border-radius: 20px;
+  color: #444444;
+  padding: 4px 30px;
+  font-size: 14px;
+  line-height: 1.5;
+  background: #00AEEF;
+  color: #444444;
+  border-radius: 20px;
+  -webkit-transition: 0.1s ease-in-out;
+  transition: 0.1s ease-in-out;
+}
+
+.c6:hover {
+  box-shadow: 0px 0px 0px 2px #00AEEF;
+}
+
+.c8 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  outline: none;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: 1px solid #00AEEF;
+  border-radius: 20px;
+  color: #444444;
+  padding: 4px 30px;
+  font-size: 14px;
+  line-height: 1.5;
+  background: #00AEEF;
+  color: #444444;
+  border-radius: 20px;
+  -webkit-transition: 0.1s ease-in-out;
+  transition: 0.1s ease-in-out;
+  line-height: 0;
+  padding: 12px;
+}
+
+.c8:hover {
+  box-shadow: 0px 0px 0px 2px #00AEEF;
+}
+
+.c1 {
+  font-family: 'Nunito',Arial,sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c5 {
+  font-family: CircularStd,Arial,sans-serif;
+  font-weight: 400;
+  height: 36px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  color: white;
+}
+
+.c5 svg {
+  color: inherit !important;
+  font-size: 0.875em;
+}
+
+.c5:disabled {
+  cursor: not-allowed;
+}
+
+.c5:hover:enabled,
+.c5:focus:enabled,
+.c5:active:enabled {
+  box-shadow: none;
+  background: hsl(196.29999999999995,100%,37.5%);
+  border-color: hsl(196.29999999999995,100%,37.5%);
+  color: white;
+  opacity: undefined;
+}
+
+.c9 {
+  position: fixed;
+  top: auto;
+  right: auto;
+  bottom: auto;
+  left: auto;
+  z-index: 0;
+  background: none;
+}
+
+.c7 {
+  min-width: 0;
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+  border-left: 0;
+  margin: 0;
+  vertical-align: top;
+  padding: 0 16px;
+  width: 44px;
+}
+
+.c4 {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+  border-right: 0;
+  margin: 0;
+  width: calc(100% - 44px);
+}
+
+.c10 {
+  background: white;
+  position: absolute;
+  min-width: 0px;
+  box-shadow: 1px 1px 5px#f4f4f4;
+  border-radius: 3px;
+  border: 1px solid #c6c8c9;
+  z-index: 1;
+  margin-top: 2px;
+  left: 0;
+  right: auto;
+  white-space: nowrap;
+  max-height: auto;
+  overflow-y: auto;
+}
+
+.c2 {
+  display: inline-block;
+  border-radius: 3px;
+  vertical-align: top;
+  position: relative;
+}
+
+.c11 {
+  padding: 5px 16px;
+  border-top: 0;
+  border-radius: 3px;
+}
+
+.c11:hover:enabled {
+  background: #f4f4f4;
+}
+
+.c0 {
+  font-family: 'Nunito',Arial,sans-serif;
+}
+
+.c0 h1,
+.c0 h2,
+.c0 h3,
+.c0 h4,
+.c0 h5,
+.c0 h6,
+.c0 label,
+.c0 button {
+  font-family: CircularStd,Arial,sans-serif;
+}
+
 <div
-  className="sc-btzYZH jBDBBH StyledGrommet-sc-19lkkz7-0 bBubtL"
+  className="c0 c1"
 >
   <div
-    className="sc-dNLxif iEMwxC sc-frDJqD dCYbIk sc-gzVnrw pznRG sc-bZQynM kMvugX"
+    className="c2 c3"
   >
     <span>
       <button
-        className="sc-kEYyzF sc-ksYbfQ Pxrgi sc-brqgnP fjrEUv sc-kkGfuU gYcgar StyledButton-sc-323bzc-0 jfOEyc"
+        className="c4 c5 c6"
         onBlur={[Function]}
         onFocus={[Function]}
         onMouseOut={[Function]}
@@ -75,7 +419,7 @@ exports[`Opened DropDownButton renders correctly 1`] = `
         </div>
       </button>
       <button
-        className="sc-kEYyzF sc-cJSrbW hVWOgQ sc-brqgnP fjrEUv sc-kkGfuU gYcgar StyledButton-sc-323bzc-0 dQGtHJ"
+        className="c7 c5 c8"
         onBlur={[Function]}
         onClick={[Function]}
         onFocus={[Function]}
@@ -105,36 +449,36 @@ exports[`Opened DropDownButton renders correctly 1`] = `
       </button>
     </span>
     <div
-      className="sc-kgAjT tjUKB sc-TOsTZ fawkKM"
+      className="c9"
       onClick={[Function]}
     />
     <div
-      className="sc-hmzhuo htQDKu"
+      className="c10"
       onClick={[Function]}
     >
       <div
-        className="sc-kvZOFW ONkyr"
+        className="c11"
       >
         <div>
           Item
         </div>
       </div>
       <div
-        className="sc-kvZOFW ONkyr"
+        className="c11"
       >
         <div>
           Item
         </div>
       </div>
       <div
-        className="sc-kvZOFW ONkyr"
+        className="c11"
       >
         <div>
           Item
         </div>
       </div>
       <div
-        className="sc-kvZOFW ONkyr"
+        className="c11"
       >
         <div>
           Item

--- a/__tests__/components/__snapshots__/Filters.spec.js.snap
+++ b/__tests__/components/__snapshots__/Filters.spec.js.snap
@@ -1,17 +1,306 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Filters component should match the stored snapshot 1`] = `
+.c4 {
+  box-sizing: border-box;
+}
+
+.c3 {
+  margin-bottom: 16px;
+}
+
+.c18 {
+  margin-top: 1px;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c17 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c8 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  outline: none;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: 1px solid #00AEEF;
+  border-radius: 20px;
+  color: #444444;
+  padding: 4px 30px;
+  font-size: 14px;
+  line-height: 1.5;
+  background: #00AEEF;
+  color: #444444;
+  border-radius: 20px;
+  -webkit-transition: 0.1s ease-in-out;
+  transition: 0.1s ease-in-out;
+}
+
+.c8:hover {
+  box-shadow: 0px 0px 0px 2px #00AEEF;
+}
+
+.c16 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  outline: none;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: 1px solid #00AEEF;
+  border-radius: 20px;
+  color: #444444;
+  padding: 4px 30px;
+  font-size: 14px;
+  line-height: 1.5;
+  -webkit-transition: 0.1s ease-in-out;
+  transition: 0.1s ease-in-out;
+}
+
+.c16:hover {
+  box-shadow: 0px 0px 0px 2px #00AEEF;
+}
+
+.c1 {
+  font-family: 'Nunito',Arial,sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c7 {
+  font-family: CircularStd,Arial,sans-serif;
+  font-weight: 400;
+  height: 36px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  color: white;
+}
+
+.c7 svg {
+  color: inherit !important;
+  font-size: 0.875em;
+}
+
+.c7:disabled {
+  cursor: not-allowed;
+}
+
+.c7:hover:enabled,
+.c7:focus:enabled,
+.c7:active:enabled {
+  box-shadow: none;
+  background: hsl(196.29999999999995,100%,37.5%);
+  border-color: hsl(196.29999999999995,100%,37.5%);
+  color: white;
+  opacity: undefined;
+}
+
+.c15 {
+  font-family: CircularStd,Arial,sans-serif;
+  font-weight: 400;
+  height: 36px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  color: #00AEEF;
+  border-color: #00AEEF;
+}
+
+.c15 svg {
+  color: inherit !important;
+  font-size: 0.875em;
+}
+
+.c15:disabled {
+  cursor: not-allowed;
+}
+
+.c15:hover:enabled,
+.c15:focus:enabled,
+.c15:active:enabled {
+  box-shadow: none;
+  background: #00AEEF;
+  border-color: #00AEEF;
+  color: white;
+  opacity: undefined;
+}
+
+.c6 {
+  margin-right: 30px;
+}
+
+.c14 {
+  padding-left: 16px;
+  padding-right: 0;
+}
+
+.c10 {
+  position: relative;
+  width: 100%;
+  border-bottom: 1px solid #c6c8c9;
+  padding-left: 24px;
+  padding-top: 3px;
+}
+
+.c10 .search-icon {
+  color: #c6c8c9;
+  font-size: 0.9em;
+  position: absolute;
+  top: 50%;
+  left: 4px;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+}
+
+.c10 input {
+  outline: none;
+  background: transparent;
+  box-shadow: none;
+  border: none;
+  width: 100%;
+  font-size: inherit;
+  padding: 5px 5px 8px;
+  height: auto;
+}
+
+.c10 input:hover {
+  box-shadow: none;
+}
+
+.c10 input::-webkit-input-placeholder {
+  color: #c6c8c9;
+  font-weight: 300;
+}
+
+.c10 input::-moz-placeholder {
+  color: #c6c8c9;
+  font-weight: 300;
+}
+
+.c10 input:-ms-input-placeholder {
+  color: #c6c8c9;
+  font-weight: 300;
+}
+
+.c10 input::placeholder {
+  color: #c6c8c9;
+  font-weight: 300;
+}
+
+.c12 {
+  display: inline-block;
+  border-radius: 3px;
+  vertical-align: top;
+  position: relative;
+}
+
+.c19 {
+  width: 28px;
+}
+
+.c13 {
+  margin: 0;
+  width: 100%;
+}
+
+.c11 {
+  margin-left: 30px;
+}
+
+.c9 {
+  -webkit-flex-basis: 500px;
+  -ms-flex-preferred-size: 500px;
+  flex-basis: 500px;
+}
+
+.c2 {
+  position: relative;
+}
+
+.c0 {
+  font-family: 'Nunito',Arial,sans-serif;
+}
+
+.c0 h1,
+.c0 h2,
+.c0 h3,
+.c0 h4,
+.c0 h5,
+.c0 h6,
+.c0 label,
+.c0 button {
+  font-family: CircularStd,Arial,sans-serif;
+}
+
 <div
-  className="sc-btzYZH jBDBBH StyledGrommet-sc-19lkkz7-0 bBubtL"
+  className="c0 c1"
 >
   <div
-    className="sc-cIShpX bMeIVo sc-gzVnrw cFgNtB sc-bZQynM kMvugX"
+    className="c2 c3 c4"
   >
     <div
-      className="sc-htoDjs hqveFW sc-gzVnrw pznRG sc-bZQynM kMvugX"
+      className="c5 c4"
     >
       <button
-        className="sc-kEYyzF sc-brqgnP cGdyOb sc-kkGfuU gYcgar StyledButton-sc-323bzc-0 jfOEyc"
+        className="c6 c7 c8"
         onBlur={[Function]}
         onClick={[Function]}
         onFocus={[Function]}
@@ -42,10 +331,10 @@ exports[`Filters component should match the stored snapshot 1`] = `
         Add filter
       </button>
       <div
-        className="sc-ktHwxA bUnSFl"
+        className="c9"
       >
         <div
-          className="sc-eqIVtm itPwrV"
+          className="c10"
         >
           <input
             onChange={[Function]}
@@ -81,13 +370,13 @@ exports[`Filters component should match the stored snapshot 1`] = `
         </div>
       </div>
       <div
-        className="sc-jqCOkK heXNii"
+        className=""
       >
         <div
-          className="sc-dNLxif bDVbLF sc-frDJqD dCYbIk sc-gzVnrw pznRG sc-bZQynM kMvugX"
+          className="c11 c12 c4"
         >
           <button
-            className="sc-kEYyzF sc-jbKcbu gPeakb sc-brqgnP hQPokf sc-iAyFgw jHRzkA StyledButton-sc-323bzc-0 gDxBx"
+            className="c13 c14 c15 c16"
             onBlur={[Function]}
             onClick={[Function]}
             onFocus={[Function]}
@@ -96,10 +385,10 @@ exports[`Filters component should match the stored snapshot 1`] = `
             type="button"
           >
             <div
-              className="sc-htoDjs gWgOBU sc-gzVnrw pznRG sc-bZQynM kMvugX"
+              className="c17 c4"
             >
               <div
-                className="sc-gzVnrw ecmscU sc-bZQynM kMvugX"
+                className="c18 c4"
               >
                 <span>
                   <svg
@@ -126,7 +415,7 @@ exports[`Filters component should match the stored snapshot 1`] = `
                 </span>
               </div>
               <span
-                className="sc-hqyNC jKVNEu"
+                className="c19"
               >
                 <svg
                   fill="currentColor"

--- a/__tests__/components/__snapshots__/Fixed.spec.js.snap
+++ b/__tests__/components/__snapshots__/Fixed.spec.js.snap
@@ -1,11 +1,47 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Fixed renders correctly 1`] = `
+.c1 {
+  font-family: 'Nunito',Arial,sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c2 {
+  position: fixed;
+  top: auto;
+  right: auto;
+  bottom: auto;
+  left: auto;
+  z-index: 0;
+  background: none;
+}
+
+.c0 {
+  font-family: 'Nunito',Arial,sans-serif;
+}
+
+.c0 h1,
+.c0 h2,
+.c0 h3,
+.c0 h4,
+.c0 h5,
+.c0 h6,
+.c0 label,
+.c0 button {
+  font-family: CircularStd,Arial,sans-serif;
+}
+
 <div
-  className="sc-btzYZH jBDBBH StyledGrommet-sc-19lkkz7-0 bBubtL"
+  className="c0 c1"
 >
   <div
-    className="sc-kgAjT tjUKB sc-TOsTZ fawkKM"
+    className="c2"
   >
     Fixed
   </div>

--- a/__tests__/components/__snapshots__/Flex.spec.js.snap
+++ b/__tests__/components/__snapshots__/Flex.spec.js.snap
@@ -1,11 +1,48 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Flex renders correctly 1`] = `
+.c3 {
+  box-sizing: border-box;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c1 {
+  font-family: 'Nunito',Arial,sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c0 {
+  font-family: 'Nunito',Arial,sans-serif;
+}
+
+.c0 h1,
+.c0 h2,
+.c0 h3,
+.c0 h4,
+.c0 h5,
+.c0 h6,
+.c0 label,
+.c0 button {
+  font-family: CircularStd,Arial,sans-serif;
+}
+
 <div
-  className="sc-btzYZH jBDBBH StyledGrommet-sc-19lkkz7-0 bBubtL"
+  className="c0 c1"
 >
   <div
-    className="sc-htoDjs cimPsI sc-gzVnrw pznRG sc-bZQynM kMvugX"
+    className="c2 c3"
   >
     Flex
   </div>

--- a/__tests__/components/__snapshots__/Form.spec.js.snap
+++ b/__tests__/components/__snapshots__/Form.spec.js.snap
@@ -1,11 +1,190 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Form component should match the stored snapshot 1`] = `
+.c9 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  outline: none;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: 1px solid #00AEEF;
+  border-radius: 20px;
+  color: #444444;
+  padding: 4px 30px;
+  font-size: 14px;
+  line-height: 1.5;
+  background: #00AEEF;
+  color: #444444;
+  border-radius: 20px;
+  -webkit-transition: 0.1s ease-in-out;
+  transition: 0.1s ease-in-out;
+}
+
+.c9:hover {
+  box-shadow: 0px 0px 0px 2px #00AEEF;
+}
+
+.c1 {
+  font-family: 'Nunito',Arial,sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c8 {
+  font-family: CircularStd,Arial,sans-serif;
+  font-weight: 400;
+  height: 36px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  color: white;
+}
+
+.c8 svg {
+  color: inherit !important;
+  font-size: 0.875em;
+}
+
+.c8:disabled {
+  cursor: not-allowed;
+}
+
+.c8:hover:enabled,
+.c8:focus:enabled,
+.c8:active:enabled {
+  box-shadow: none;
+  background: hsl(196.29999999999995,100%,37.5%);
+  border-color: hsl(196.29999999999995,100%,37.5%);
+  color: white;
+  opacity: undefined;
+}
+
+.c3 {
+  box-sizing: border-box;
+}
+
+.c4 {
+  margin-bottom: 8px;
+}
+
+.c7 {
+  border-radius: 3px;
+  height: 36px;
+  font-size: inherit;
+  border: 1px solid #c6c8c9;
+  padding: 0px 16px;
+  box-sizing: border-box;
+}
+
+.c7[disabled] {
+  background-color: #f4f4f4;
+  cursor: not-allowed;
+}
+
+.c7:focus:enabled {
+  border-color: #2A506F;
+}
+
+.c7:hover:enabled {
+  box-shadow: 0 0 4px 1px rgba(0,0,0,0.1);
+}
+
+.c7::-webkit-input-placeholder {
+  color: #c6c8c9;
+}
+
+.c7::-moz-placeholder {
+  color: #c6c8c9;
+}
+
+.c7:-ms-input-placeholder {
+  color: #c6c8c9;
+}
+
+.c7::placeholder {
+  color: #c6c8c9;
+}
+
+.c7[type='checkbox'] {
+  height: auto;
+  font-size: 14px;
+}
+
+.c7[type='date' i]::-webkit-inner-spin-button,
+.c7[type='datetime-local' i]::-webkit-inner-spin-button,
+.c7[type='month' i]::-webkit-inner-spin-button,
+.c7[type='time' i]::-webkit-inner-spin-button,
+.c7[type='week' i]::-webkit-inner-spin-button {
+  height: 20px;
+  margin-top: 7px;
+}
+
+.c6 {
+  width: 100%;
+}
+
+.c0 {
+  font-family: 'Nunito',Arial,sans-serif;
+}
+
+.c0 h1,
+.c0 h2,
+.c0 h3,
+.c0 h4,
+.c0 h5,
+.c0 h6,
+.c0 label,
+.c0 button {
+  font-family: CircularStd,Arial,sans-serif;
+}
+
+.c5 {
+  font-size: 11px;
+  color: #252629;
+  text-transform: uppercase;
+  display: inline-block;
+  margin-bottom: 6px;
+}
+
+.c2 fieldset {
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.c2 .panel-danger,
+.c2 .error-detail {
+  font-size: 14px;
+  margin-top: 4px;
+  margin-bottom: 4px;
+  color: #FF423D;
+}
+
 <div
-  className="sc-lhVmIH imhZTm StyledGrommet-sc-19lkkz7-0 bBubtL"
+  className="c0 c1"
 >
   <div
-    className="sc-esOvli gEemTu sc-fjdhpX bWPfWm sc-jTzLTM cCyBWy"
+    className="c2 c3"
   >
     <form
       className="rjsf"
@@ -13,21 +192,21 @@ exports[`Form component should match the stored snapshot 1`] = `
       onSubmit={[Function]}
     >
       <div
-        className="form-group field field-object rendition-form__field--root sc-fjdhpX jMCnOO sc-jTzLTM cCyBWy"
+        className="form-group field field-object rendition-form__field--root c4 c3"
       >
         <fieldset>
           <div
-            className="form-group field field-string rendition-form__field--root_Name sc-fjdhpX jMCnOO sc-jTzLTM cCyBWy"
+            className="form-group field field-string rendition-form__field--root_Name c4 c3"
           >
             <label
-              className="control-label sc-iuJeZd gkgfBa"
+              className="control-label c5"
               htmlFor="root_Name"
             >
               Pokemon Name
             </label>
             <input
               autoFocus={false}
-              className="sc-csuQGl hTSSyH sc-gipzik iEttxk"
+              className="c6 c7"
               disabled={false}
               id="root_Name"
               label="Pokemon Name"
@@ -46,7 +225,7 @@ exports[`Form component should match the stored snapshot 1`] = `
         <div />
       </div>
       <button
-        className="sc-bZQynM sc-VigVT dzpHnm sc-gzVnrw iHVwFV StyledButton-sc-323bzc-0 jfOEyc"
+        className="c8 c9"
         onBlur={[Function]}
         onFocus={[Function]}
         onMouseOut={[Function]}

--- a/__tests__/components/__snapshots__/Heading.spec.js.snap
+++ b/__tests__/components/__snapshots__/Heading.spec.js.snap
@@ -1,11 +1,42 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Heading renders correctly 1`] = `
+.c1 {
+  font-family: 'Nunito',Arial,sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c0 {
+  font-family: 'Nunito',Arial,sans-serif;
+}
+
+.c0 h1,
+.c0 h2,
+.c0 h3,
+.c0 h4,
+.c0 h5,
+.c0 h6,
+.c0 label,
+.c0 button {
+  font-family: CircularStd,Arial,sans-serif;
+}
+
+.c2 {
+  margin: 0;
+  font-size: 24px;
+}
+
 <div
-  className="sc-btzYZH jBDBBH StyledGrommet-sc-19lkkz7-0 bBubtL"
+  className="c0 c1"
 >
   <h3
-    className="sc-iyvyFf bxMpAf sc-gzOgki fLRopM"
+    className="c2 "
   >
     Heading
   </h3>

--- a/__tests__/components/__snapshots__/Img.spec.js.snap
+++ b/__tests__/components/__snapshots__/Img.spec.js.snap
@@ -1,11 +1,43 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Img renders correctly 1`] = `
+.c1 {
+  font-family: 'Nunito',Arial,sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c0 {
+  font-family: 'Nunito',Arial,sans-serif;
+}
+
+.c0 h1,
+.c0 h2,
+.c0 h3,
+.c0 h4,
+.c0 h5,
+.c0 h6,
+.c0 label,
+.c0 button {
+  font-family: CircularStd,Arial,sans-serif;
+}
+
+.c2 {
+  display: block;
+  max-width: 100%;
+  height: auto;
+}
+
 <div
-  className="sc-btzYZH jBDBBH StyledGrommet-sc-19lkkz7-0 bBubtL"
+  className="c0 c1"
 >
   <img
-    className="sc-dfVpRl ibQpos"
+    className="c2"
   />
 </div>
 `;

--- a/__tests__/components/__snapshots__/Input.spec.js.snap
+++ b/__tests__/components/__snapshots__/Input.spec.js.snap
@@ -1,11 +1,89 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Input renders correctly 1`] = `
+.c1 {
+  font-family: 'Nunito',Arial,sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c2 {
+  border-radius: 3px;
+  height: 36px;
+  font-size: inherit;
+  border: 1px solid #c6c8c9;
+  padding: 0px 16px;
+  box-sizing: border-box;
+}
+
+.c2[disabled] {
+  background-color: #f4f4f4;
+  cursor: not-allowed;
+}
+
+.c2:focus:enabled {
+  border-color: #2A506F;
+}
+
+.c2:hover:enabled {
+  box-shadow: 0 0 4px 1px rgba(0,0,0,0.1);
+}
+
+.c2::-webkit-input-placeholder {
+  color: #c6c8c9;
+}
+
+.c2::-moz-placeholder {
+  color: #c6c8c9;
+}
+
+.c2:-ms-input-placeholder {
+  color: #c6c8c9;
+}
+
+.c2::placeholder {
+  color: #c6c8c9;
+}
+
+.c2[type='checkbox'] {
+  height: auto;
+  font-size: 14px;
+}
+
+.c2[type='date' i]::-webkit-inner-spin-button,
+.c2[type='datetime-local' i]::-webkit-inner-spin-button,
+.c2[type='month' i]::-webkit-inner-spin-button,
+.c2[type='time' i]::-webkit-inner-spin-button,
+.c2[type='week' i]::-webkit-inner-spin-button {
+  height: 20px;
+  margin-top: 7px;
+}
+
+.c0 {
+  font-family: 'Nunito',Arial,sans-serif;
+}
+
+.c0 h1,
+.c0 h2,
+.c0 h3,
+.c0 h4,
+.c0 h5,
+.c0 h6,
+.c0 label,
+.c0 button {
+  font-family: CircularStd,Arial,sans-serif;
+}
+
 <div
-  className="sc-btzYZH jBDBBH StyledGrommet-sc-19lkkz7-0 bBubtL"
+  className="c0 c1"
 >
   <input
-    className="sc-gipzik hcsWGl sc-jlyJG cmjebS"
+    className="c2"
     placeholder="Placeholder Text"
   />
 </div>

--- a/__tests__/components/__snapshots__/JellyForm.spec.js.snap
+++ b/__tests__/components/__snapshots__/JellyForm.spec.js.snap
@@ -1,11 +1,199 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`JellyForm component should match the stored snapshot 1`] = `
+.c3 {
+  box-sizing: border-box;
+}
+
+.c4 {
+  margin-bottom: 8px;
+}
+
+.c10 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  outline: none;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: 1px solid #00AEEF;
+  border-radius: 20px;
+  color: #444444;
+  padding: 4px 30px;
+  font-size: 14px;
+  line-height: 1.5;
+  background: #00AEEF;
+  color: #444444;
+  border-radius: 20px;
+  -webkit-transition: 0.1s ease-in-out;
+  transition: 0.1s ease-in-out;
+}
+
+.c10:hover {
+  box-shadow: 0px 0px 0px 2px #00AEEF;
+}
+
+.c1 {
+  font-family: 'Nunito',Arial,sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c9 {
+  font-family: CircularStd,Arial,sans-serif;
+  font-weight: 400;
+  height: 36px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  color: white;
+}
+
+.c9 svg {
+  color: inherit !important;
+  font-size: 0.875em;
+}
+
+.c9:disabled {
+  cursor: not-allowed;
+}
+
+.c9:hover:enabled,
+.c9:focus:enabled,
+.c9:active:enabled {
+  box-shadow: none;
+  background: hsl(196.29999999999995,100%,37.5%);
+  border-color: hsl(196.29999999999995,100%,37.5%);
+  color: white;
+  opacity: undefined;
+}
+
+.c8 {
+  border-radius: 3px;
+  height: 36px;
+  font-size: inherit;
+  border: 1px solid #c6c8c9;
+  padding: 0px 16px;
+  box-sizing: border-box;
+}
+
+.c8[disabled] {
+  background-color: #f4f4f4;
+  cursor: not-allowed;
+}
+
+.c8:focus:enabled {
+  border-color: #2A506F;
+}
+
+.c8:hover:enabled {
+  box-shadow: 0 0 4px 1px rgba(0,0,0,0.1);
+}
+
+.c8::-webkit-input-placeholder {
+  color: #c6c8c9;
+}
+
+.c8::-moz-placeholder {
+  color: #c6c8c9;
+}
+
+.c8:-ms-input-placeholder {
+  color: #c6c8c9;
+}
+
+.c8::placeholder {
+  color: #c6c8c9;
+}
+
+.c8[type='checkbox'] {
+  height: auto;
+  font-size: 14px;
+}
+
+.c8[type='date' i]::-webkit-inner-spin-button,
+.c8[type='datetime-local' i]::-webkit-inner-spin-button,
+.c8[type='month' i]::-webkit-inner-spin-button,
+.c8[type='time' i]::-webkit-inner-spin-button,
+.c8[type='week' i]::-webkit-inner-spin-button {
+  height: 20px;
+  margin-top: 7px;
+}
+
+.c7 {
+  width: 100%;
+}
+
+.c0 {
+  font-family: 'Nunito',Arial,sans-serif;
+}
+
+.c0 h1,
+.c0 h2,
+.c0 h3,
+.c0 h4,
+.c0 h5,
+.c0 h6,
+.c0 label,
+.c0 button {
+  font-family: CircularStd,Arial,sans-serif;
+}
+
+.c5 {
+  font-size: 20px;
+  color: #252629;
+  margin-top: 16px;
+  margin-bottom: 8px;
+  border-bottom: 1px solid #f4f4f4;
+  width: 100%;
+}
+
+.c6 {
+  font-size: 11px;
+  color: #252629;
+  text-transform: uppercase;
+  display: inline-block;
+  margin-bottom: 6px;
+}
+
+.c2 fieldset {
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.c2 .panel-danger,
+.c2 .error-detail {
+  font-size: 14px;
+  margin-top: 4px;
+  margin-bottom: 4px;
+  color: #FF423D;
+}
+
 <div
-  className="sc-btzYZH jBDBBH StyledGrommet-sc-19lkkz7-0 bBubtL"
+  className="c0 c1"
 >
   <div
-    className="sc-esOvli gEemTu sc-gzVnrw pznRG sc-bZQynM kMvugX"
+    className="c2 c3"
   >
     <form
       className="rjsf"
@@ -13,20 +201,20 @@ exports[`JellyForm component should match the stored snapshot 1`] = `
       onSubmit={[Function]}
     >
       <div
-        className="form-group field field-object rendition-form__field--root sc-gzVnrw fcRkeO sc-bZQynM kMvugX"
+        className="form-group field field-object rendition-form__field--root c4 c3"
       >
         <fieldset>
           <legend
-            className="sc-bsbRJL iVsEFF"
+            className="c5"
             id="root__title"
           >
             Pokèmon
           </legend>
           <div
-            className="form-group field field-string rendition-form__field--root_Name sc-gzVnrw fcRkeO sc-bZQynM kMvugX"
+            className="form-group field field-string rendition-form__field--root_Name c4 c3"
           >
             <label
-              className="control-label sc-iuJeZd gkgfBa"
+              className="control-label c6"
               htmlFor="root_Name"
             >
               Name
@@ -38,7 +226,7 @@ exports[`JellyForm component should match the stored snapshot 1`] = `
             </label>
             <input
               autoFocus={false}
-              className="sc-gipzik jGrCwz sc-jlyJG cmjebS"
+              className="c7 c8"
               disabled={false}
               id="root_Name"
               label="Name"
@@ -57,7 +245,7 @@ exports[`JellyForm component should match the stored snapshot 1`] = `
         <div />
       </div>
       <button
-        className="sc-kEYyzF sc-brqgnP fjrEUv sc-kkGfuU gYcgar StyledButton-sc-323bzc-0 jfOEyc"
+        className="c9 c10"
         onBlur={[Function]}
         onFocus={[Function]}
         onMouseOut={[Function]}

--- a/__tests__/components/__snapshots__/Link.spec.js.snap
+++ b/__tests__/components/__snapshots__/Link.spec.js.snap
@@ -1,11 +1,54 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Link component Should match the stored snapshot 1`] = `
+.c1 {
+  font-family: 'Nunito',Arial,sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c0 {
+  font-family: 'Nunito',Arial,sans-serif;
+}
+
+.c0 h1,
+.c0 h2,
+.c0 h3,
+.c0 h4,
+.c0 h5,
+.c0 h6,
+.c0 label,
+.c0 button {
+  font-family: CircularStd,Arial,sans-serif;
+}
+
+.c3 {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  cursor: pointer;
+  opacity: 1;
+  display: inline-block;
+}
+
+.c3:active,
+.c3:hover {
+  color: hsl(196.29999999999995,100%,37.5%);
+}
+
+.c2 {
+  color: #00AEEF;
+}
+
 <div
-  className="sc-btzYZH jBDBBH StyledGrommet-sc-19lkkz7-0 bBubtL"
+  className="c0 c1"
 >
   <a
-    className="sc-gwVKww jLCiFX sc-eTuwsz hbAeAP"
+    className="c2 c3"
     color="primary.main"
   >
     Link

--- a/__tests__/components/__snapshots__/Modal.spec.js.snap
+++ b/__tests__/components/__snapshots__/Modal.spec.js.snap
@@ -1,39 +1,245 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Modal renders correctly 1`] = `
+.c8 {
+  box-sizing: border-box;
+}
+
+.c7 {
+  padding: 16px;
+  width: 700px;
+}
+
+.c10 {
+  margin-top: 50px;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+}
+
+.c12 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  outline: none;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: 1px solid #00AEEF;
+  border-radius: 20px;
+  color: #444444;
+  padding: 4px 30px;
+  font-size: 14px;
+  line-height: 1.5;
+  background: #00AEEF;
+  color: #444444;
+  border-radius: 20px;
+  -webkit-transition: 0.1s ease-in-out;
+  transition: 0.1s ease-in-out;
+}
+
+.c12:hover {
+  box-shadow: 0px 0px 0px 2px #00AEEF;
+}
+
+.c1 {
+  font-family: 'Nunito',Arial,sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c2 {
+  font-family: 'Nunito',Arial,sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  background: unset;
+  position: relative;
+  z-index: 30;
+  pointer-events: none;
+  outline: none;
+  position: fixed;
+  top: 0px;
+  left: 0px;
+  right: 0px;
+  bottom: 0px;
+  width: 100vw;
+  height: 100vh;
+}
+
+.c3 {
+  position: absolute;
+  top: 0px;
+  left: 0px;
+  right: 0px;
+  bottom: 0px;
+  background: rgba(0,0,0,0.5);
+  color: #f8f8f8;
+  pointer-events: all;
+}
+
+.c4 {
+  font-family: 'Nunito',Arial,sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  min-height: 48px;
+  background: #FFFFFF;
+  color: #444444;
+  outline: none;
+  pointer-events: all;
+  z-index: 40;
+  position: fixed;
+  max-height: calc(100% - 12px - 12px);
+  max-width: calc(100% - 12px - 12px);
+  border-radius: 4px;
+  top: 50%;
+  left: 50%;
+  -webkit-transform: translate(-50%,-50%);
+  -ms-transform: translate(-50%,-50%);
+  transform: translate(-50%,-50%);
+}
+
+.c5 {
+  width: 0;
+  height: 0;
+  overflow: hidden;
+  position: absolute;
+}
+
+.c11 {
+  font-family: CircularStd,Arial,sans-serif;
+  font-weight: 400;
+  height: 36px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  color: white;
+}
+
+.c11 svg {
+  color: inherit !important;
+  font-size: 0.875em;
+}
+
+.c11:disabled {
+  cursor: not-allowed;
+}
+
+.c11:hover:enabled,
+.c11:focus:enabled,
+.c11:active:enabled {
+  box-shadow: none;
+  background: hsl(196.29999999999995,100%,37.5%);
+  border-color: hsl(196.29999999999995,100%,37.5%);
+  color: white;
+  opacity: undefined;
+}
+
+.c6 {
+  max-width: 100%;
+  overflow-y: auto;
+}
+
+.c0 {
+  font-family: 'Nunito',Arial,sans-serif;
+}
+
+.c0 h1,
+.c0 h2,
+.c0 h3,
+.c0 h4,
+.c0 h5,
+.c0 h6,
+.c0 label,
+.c0 button {
+  font-family: CircularStd,Arial,sans-serif;
+}
+
+@media screen and (min-width:32em) {
+  .c7 {
+    padding: 40px 50px 30px;
+  }
+}
+
 <div
-  className="sc-btzYZH jBDBBH StyledGrommet-sc-19lkkz7-0 bBubtL"
+  className="c0 c1"
 >
   <div
     aria-hidden={false}
   >
     <div
-      className="StyledLayer-rmtehz-0 hISvz"
+      className="c2"
       onKeyDown={[Function]}
       tabIndex="-1"
     >
       <div
-        className="StyledLayer__StyledOverlay-rmtehz-1 jDYYNt"
+        className="c3"
         onMouseDown={[Function]}
       />
       <div
-        className="StyledLayer__StyledContainer-rmtehz-2 ergMLu"
+        className="c4"
       >
         <a
           aria-hidden="true"
-          className="LayerContainer__HiddenAnchor-sc-1srj14c-0 LMZHJ"
+          className="c5"
           tabIndex="-1"
         />
         <div
-          className="sc-dVhcbM hgqudO sc-gzVnrw iVQgQP sc-bZQynM kMvugX"
+          className="c6 c7 c8"
           onClick={[Function]}
         >
           Modal
           <div
-            className="sc-htoDjs iWrvzc sc-gzVnrw PpHOL sc-bZQynM kMvugX"
+            className="c9 c10 c8"
           >
             <button
-              className="sc-kEYyzF sc-brqgnP fjrEUv sc-kkGfuU gYcgar StyledButton-sc-323bzc-0 jfOEyc"
+              className="c11 c12"
               onBlur={[Function]}
               onFocus={[Function]}
               onMouseOut={[Function]}

--- a/__tests__/components/__snapshots__/Navbar.spec.js.snap
+++ b/__tests__/components/__snapshots__/Navbar.spec.js.snap
@@ -1,26 +1,237 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Navbar renders correctly with a single children prop 1`] = `
+.c17 {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  cursor: pointer;
+  opacity: 1;
+  display: inline-block;
+}
+
+.c17:active,
+.c17:hover {
+  color: hsl(0,0%,80%);
+}
+
+.c16 {
+  color: white;
+}
+
+.c3 {
+  box-sizing: border-box;
+}
+
+.c2 {
+  color: white;
+  background-color: #9f9f9f;
+}
+
+.c9 {
+  padding: 8px;
+}
+
+.c11 {
+  margin-left: auto;
+  padding: 8px;
+}
+
+.c13 {
+  margin-left: 0;
+  width: 100%;
+}
+
+.c14 {
+  width: 100%;
+}
+
+.c15 {
+  padding: 8px;
+  width: 100%;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c1 {
+  font-family: 'Nunito',Arial,sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c0 {
+  font-family: 'Nunito',Arial,sans-serif;
+}
+
+.c0 h1,
+.c0 h2,
+.c0 h3,
+.c0 h4,
+.c0 h5,
+.c0 h6,
+.c0 label,
+.c0 button {
+  font-family: CircularStd,Arial,sans-serif;
+}
+
+.c5 {
+  max-width: calc(32em - 0em);
+}
+
+.c4 {
+  margin-left: auto;
+  margin-right: auto;
+  padding-left: 16px;
+  padding-right: 16px;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: auto;
+  min-width: 150px;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+}
+
+.c10 {
+  display: block;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  cursor: pointer;
+}
+
+.c12 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  max-height: 0vh;
+  text-align: center;
+  -webkit-transition: max-height 0.4s ease-in-out;
+  transition: max-height 0.4s ease-in-out;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  overflow: hidden;
+}
+
+.c12 a {
+  width: 100%;
+  display: inline-block;
+}
+
+@media screen and (min-width:32em) {
+  .c11 {
+    margin-left: 0;
+  }
+}
+
+@media screen and (min-width:32em) {
+  .c13 {
+    margin-left: auto;
+  }
+}
+
+@media screen and (min-width:32em) {
+  .c13 {
+    width: auto;
+  }
+}
+
+@media screen and (min-width:32em) {
+  .c14 {
+    width: auto;
+  }
+}
+
+@media screen and (min-width:32em) {
+  .c15 {
+    width: auto;
+  }
+}
+
+@media screen and (min-width:32em) {
+  .c6 {
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
+  }
+}
+
+@media screen and (min-width:32em) {
+  .c5 {
+    max-width: calc(48em - 4em);
+  }
+}
+
+@media screen and (min-width:48em) {
+  .c5 {
+    max-width: calc(64em - 8em);
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c5 {
+    max-width: calc(80em - 16em);
+  }
+}
+
+@media screen and (min-width:32em) {
+  .c10 {
+    display: none;
+  }
+}
+
+@media screen and (min-width:32em) {
+  .c12 {
+    max-height: none;
+  }
+}
+
 <div
-  className="sc-kPVwWT jlRNvi StyledGrommet-sc-19lkkz7-0 bBubtL"
+  className="c0 c1"
 >
   <div
-    className="sc-chPdSV GFDdw sc-kAzzGY dLnIPy"
+    className="c2 c3"
   >
     <div
-      className="sc-iuJeZd gSRwAy sc-cMhqgX iRVSHK"
+      className="c4 c5"
     >
       <div
-        className="sc-kgoBCf kqLfuS sc-chPdSV jpfrZo sc-kAzzGY dLnIPy"
+        className="c6 c3"
       >
         <div
-          className="sc-kgoBCf cRCsAq sc-chPdSV jpfrZo sc-kAzzGY dLnIPy"
+          className="c7 c3"
         >
           <div
-            className="sc-esOvli Abxwx sc-chPdSV gwIGaM sc-kAzzGY dLnIPy"
+            className="c8 c9 c3"
           />
           <div
-            className="sc-cmthru iKdrXs sc-chPdSV yrOiB sc-kAzzGY dLnIPy"
+            className="c10 c11 c3"
             display={
               Array [
                 "block",
@@ -51,17 +262,17 @@ exports[`Navbar renders correctly with a single children prop 1`] = `
           </div>
         </div>
         <div
-          className="sc-kgoBCf sc-hMFtBS bfgFqv sc-chPdSV jgcBzP sc-kAzzGY dLnIPy"
+          className="c12 c13 c3"
         >
           <div
-            className="sc-kgoBCf kqLfuS sc-chPdSV kDIXHv sc-kAzzGY dLnIPy"
+            className="c6 c14 c3"
           >
             <div
-              className="sc-chPdSV kDQfPd sc-kAzzGY dLnIPy"
+              className="c15 c3"
               onClick={[Function]}
             >
               <a
-                className="sc-gZMcBi krgeid sc-iwsKbI jkCyoU"
+                className="c16 c17"
                 color="white"
                 href="/docs/"
               >
@@ -77,26 +288,237 @@ exports[`Navbar renders correctly with a single children prop 1`] = `
 `;
 
 exports[`Navbar renders correctly with more than one children prop 1`] = `
+.c17 {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  cursor: pointer;
+  opacity: 1;
+  display: inline-block;
+}
+
+.c17:active,
+.c17:hover {
+  color: hsl(0,0%,80%);
+}
+
+.c16 {
+  color: white;
+}
+
+.c3 {
+  box-sizing: border-box;
+}
+
+.c2 {
+  color: white;
+  background-color: #9f9f9f;
+}
+
+.c9 {
+  padding: 8px;
+}
+
+.c11 {
+  margin-left: auto;
+  padding: 8px;
+}
+
+.c13 {
+  margin-left: 0;
+  width: 100%;
+}
+
+.c14 {
+  width: 100%;
+}
+
+.c15 {
+  padding: 8px;
+  width: 100%;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c1 {
+  font-family: 'Nunito',Arial,sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c0 {
+  font-family: 'Nunito',Arial,sans-serif;
+}
+
+.c0 h1,
+.c0 h2,
+.c0 h3,
+.c0 h4,
+.c0 h5,
+.c0 h6,
+.c0 label,
+.c0 button {
+  font-family: CircularStd,Arial,sans-serif;
+}
+
+.c5 {
+  max-width: calc(32em - 0em);
+}
+
+.c4 {
+  margin-left: auto;
+  margin-right: auto;
+  padding-left: 16px;
+  padding-right: 16px;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: auto;
+  min-width: 150px;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+}
+
+.c10 {
+  display: block;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  cursor: pointer;
+}
+
+.c12 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  max-height: 0vh;
+  text-align: center;
+  -webkit-transition: max-height 0.4s ease-in-out;
+  transition: max-height 0.4s ease-in-out;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  overflow: hidden;
+}
+
+.c12 a {
+  width: 100%;
+  display: inline-block;
+}
+
+@media screen and (min-width:32em) {
+  .c11 {
+    margin-left: 0;
+  }
+}
+
+@media screen and (min-width:32em) {
+  .c13 {
+    margin-left: auto;
+  }
+}
+
+@media screen and (min-width:32em) {
+  .c13 {
+    width: auto;
+  }
+}
+
+@media screen and (min-width:32em) {
+  .c14 {
+    width: auto;
+  }
+}
+
+@media screen and (min-width:32em) {
+  .c15 {
+    width: auto;
+  }
+}
+
+@media screen and (min-width:32em) {
+  .c6 {
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
+  }
+}
+
+@media screen and (min-width:32em) {
+  .c5 {
+    max-width: calc(48em - 4em);
+  }
+}
+
+@media screen and (min-width:48em) {
+  .c5 {
+    max-width: calc(64em - 8em);
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c5 {
+    max-width: calc(80em - 16em);
+  }
+}
+
+@media screen and (min-width:32em) {
+  .c10 {
+    display: none;
+  }
+}
+
+@media screen and (min-width:32em) {
+  .c12 {
+    max-height: none;
+  }
+}
+
 <div
-  className="sc-kPVwWT jlRNvi StyledGrommet-sc-19lkkz7-0 bBubtL"
+  className="c0 c1"
 >
   <div
-    className="sc-chPdSV GFDdw sc-kAzzGY dLnIPy"
+    className="c2 c3"
   >
     <div
-      className="sc-iuJeZd gSRwAy sc-cMhqgX iRVSHK"
+      className="c4 c5"
     >
       <div
-        className="sc-kgoBCf kqLfuS sc-chPdSV jpfrZo sc-kAzzGY dLnIPy"
+        className="c6 c3"
       >
         <div
-          className="sc-kgoBCf cRCsAq sc-chPdSV jpfrZo sc-kAzzGY dLnIPy"
+          className="c7 c3"
         >
           <div
-            className="sc-esOvli Abxwx sc-chPdSV gwIGaM sc-kAzzGY dLnIPy"
+            className="c8 c9 c3"
           />
           <div
-            className="sc-cmthru iKdrXs sc-chPdSV yrOiB sc-kAzzGY dLnIPy"
+            className="c10 c11 c3"
             display={
               Array [
                 "block",
@@ -127,17 +549,17 @@ exports[`Navbar renders correctly with more than one children prop 1`] = `
           </div>
         </div>
         <div
-          className="sc-kgoBCf sc-hMFtBS bfgFqv sc-chPdSV jgcBzP sc-kAzzGY dLnIPy"
+          className="c12 c13 c3"
         >
           <div
-            className="sc-kgoBCf kqLfuS sc-chPdSV kDIXHv sc-kAzzGY dLnIPy"
+            className="c6 c14 c3"
           >
             <div
-              className="sc-chPdSV kDQfPd sc-kAzzGY dLnIPy"
+              className="c15 c3"
               onClick={[Function]}
             >
               <a
-                className="sc-gZMcBi krgeid sc-iwsKbI jkCyoU"
+                className="c16 c17"
                 color="white"
                 href="/docs/"
               >
@@ -145,11 +567,11 @@ exports[`Navbar renders correctly with more than one children prop 1`] = `
               </a>
             </div>
             <div
-              className="sc-chPdSV kDQfPd sc-kAzzGY dLnIPy"
+              className="c15 c3"
               onClick={[Function]}
             >
               <a
-                className="sc-gZMcBi krgeid sc-iwsKbI jkCyoU"
+                className="c16 c17"
                 color="white"
                 href="/changelog/"
               >
@@ -157,11 +579,11 @@ exports[`Navbar renders correctly with more than one children prop 1`] = `
               </a>
             </div>
             <div
-              className="sc-chPdSV kDQfPd sc-kAzzGY dLnIPy"
+              className="c15 c3"
               onClick={[Function]}
             >
               <a
-                className="sc-gZMcBi krgeid sc-iwsKbI jkCyoU"
+                className="c16 c17"
                 color="white"
                 href="/gitter/"
               >
@@ -177,26 +599,199 @@ exports[`Navbar renders correctly with more than one children prop 1`] = `
 `;
 
 exports[`Navbar renders correctly with no children prop 1`] = `
+.c3 {
+  box-sizing: border-box;
+}
+
+.c2 {
+  color: white;
+  background-color: #9f9f9f;
+}
+
+.c9 {
+  padding: 8px;
+}
+
+.c11 {
+  margin-left: auto;
+  padding: 8px;
+}
+
+.c13 {
+  margin-left: 0;
+  width: 100%;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c1 {
+  font-family: 'Nunito',Arial,sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c0 {
+  font-family: 'Nunito',Arial,sans-serif;
+}
+
+.c0 h1,
+.c0 h2,
+.c0 h3,
+.c0 h4,
+.c0 h5,
+.c0 h6,
+.c0 label,
+.c0 button {
+  font-family: CircularStd,Arial,sans-serif;
+}
+
+.c5 {
+  max-width: calc(32em - 0em);
+}
+
+.c4 {
+  margin-left: auto;
+  margin-right: auto;
+  padding-left: 16px;
+  padding-right: 16px;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: auto;
+  min-width: 150px;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+}
+
+.c10 {
+  display: block;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  cursor: pointer;
+}
+
+.c12 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  max-height: 0vh;
+  text-align: center;
+  -webkit-transition: max-height 0.4s ease-in-out;
+  transition: max-height 0.4s ease-in-out;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  overflow: hidden;
+}
+
+.c12 a {
+  width: 100%;
+  display: inline-block;
+}
+
+@media screen and (min-width:32em) {
+  .c11 {
+    margin-left: 0;
+  }
+}
+
+@media screen and (min-width:32em) {
+  .c13 {
+    margin-left: auto;
+  }
+}
+
+@media screen and (min-width:32em) {
+  .c13 {
+    width: auto;
+  }
+}
+
+@media screen and (min-width:32em) {
+  .c6 {
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
+  }
+}
+
+@media screen and (min-width:32em) {
+  .c5 {
+    max-width: calc(48em - 4em);
+  }
+}
+
+@media screen and (min-width:48em) {
+  .c5 {
+    max-width: calc(64em - 8em);
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c5 {
+    max-width: calc(80em - 16em);
+  }
+}
+
+@media screen and (min-width:32em) {
+  .c10 {
+    display: none;
+  }
+}
+
+@media screen and (min-width:32em) {
+  .c12 {
+    max-height: none;
+  }
+}
+
 <div
-  className="sc-kPVwWT jlRNvi StyledGrommet-sc-19lkkz7-0 bBubtL"
+  className="c0 c1"
 >
   <div
-    className="sc-chPdSV GFDdw sc-kAzzGY dLnIPy"
+    className="c2 c3"
   >
     <div
-      className="sc-iuJeZd gSRwAy sc-cMhqgX iRVSHK"
+      className="c4 c5"
     >
       <div
-        className="sc-kgoBCf kqLfuS sc-chPdSV jpfrZo sc-kAzzGY dLnIPy"
+        className="c6 c3"
       >
         <div
-          className="sc-kgoBCf cRCsAq sc-chPdSV jpfrZo sc-kAzzGY dLnIPy"
+          className="c7 c3"
         >
           <div
-            className="sc-esOvli Abxwx sc-chPdSV gwIGaM sc-kAzzGY dLnIPy"
+            className="c8 c9 c3"
           />
           <div
-            className="sc-cmthru iKdrXs sc-chPdSV yrOiB sc-kAzzGY dLnIPy"
+            className="c10 c11 c3"
             display={
               Array [
                 "block",
@@ -227,7 +822,7 @@ exports[`Navbar renders correctly with no children prop 1`] = `
           </div>
         </div>
         <div
-          className="sc-kgoBCf sc-hMFtBS bfgFqv sc-chPdSV jgcBzP sc-kAzzGY dLnIPy"
+          className="c12 c13 c3"
         />
       </div>
     </div>

--- a/__tests__/components/__snapshots__/Pager.spec.js.snap
+++ b/__tests__/components/__snapshots__/Pager.spec.js.snap
@@ -1,14 +1,188 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Pager component should match the stored snapshot 1`] = `
+.c3 {
+  box-sizing: border-box;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c4 {
+  margin-right: 8px;
+}
+
+.c8 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  outline: none;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: 1px solid #3c3e42;
+  border-radius: 20px;
+  color: #444444;
+  padding: 4px 30px;
+  font-size: 14px;
+  line-height: 1.5;
+  opacity: 0.4;
+  cursor: default;
+  -webkit-transition: 0.1s ease-in-out;
+  transition: 0.1s ease-in-out;
+  line-height: 0;
+  padding: 12px;
+}
+
+.c9 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  outline: none;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: 1px solid #3c3e42;
+  border-radius: 20px;
+  color: #444444;
+  padding: 4px 30px;
+  font-size: 14px;
+  line-height: 1.5;
+  -webkit-transition: 0.1s ease-in-out;
+  transition: 0.1s ease-in-out;
+  line-height: 0;
+  padding: 12px;
+}
+
+.c9:hover {
+  box-shadow: 0px 0px 0px 2px #3c3e42;
+}
+
+.c1 {
+  font-family: 'Nunito',Arial,sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c7 {
+  font-family: CircularStd,Arial,sans-serif;
+  font-weight: 400;
+  height: 36px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  color: #3c3e42;
+  border-color: #3c3e42;
+}
+
+.c7 svg {
+  color: inherit !important;
+  font-size: 0.875em;
+}
+
+.c7:disabled {
+  cursor: not-allowed;
+}
+
+.c7:hover:enabled,
+.c7:focus:enabled,
+.c7:active:enabled {
+  box-shadow: none;
+  background: #3c3e42;
+  border-color: #3c3e42;
+  color: white;
+  opacity: undefined;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c6 > *:first-child {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c6 > *:last-child {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c6 > *:not(:last-child):not(:first-child) {
+  border-radius: 0;
+}
+
+.c6 > *:hover {
+  z-index: 1;
+}
+
+.c0 {
+  font-family: 'Nunito',Arial,sans-serif;
+}
+
+.c0 h1,
+.c0 h2,
+.c0 h3,
+.c0 h4,
+.c0 h5,
+.c0 h6,
+.c0 label,
+.c0 button {
+  font-family: CircularStd,Arial,sans-serif;
+}
+
 <div
-  className="sc-btzYZH jBDBBH StyledGrommet-sc-19lkkz7-0 bBubtL"
+  className="c0 c1"
 >
   <div
-    className="sc-htoDjs iWrvzc sc-gzVnrw pznRG sc-bZQynM kMvugX"
+    className="c2 c3"
   >
     <div
-      className="sc-kGXeez gKOuJr sc-kgoBCf kRuyZZ"
+      className="c4 "
     >
       <strong>
         1
@@ -22,13 +196,13 @@ exports[`Pager component should match the stored snapshot 1`] = `
       </strong>
     </div>
     <div
-      className="sc-htoDjs cimPsI sc-gzVnrw pznRG sc-bZQynM kMvugX"
+      className="c5 c3"
     >
       <div
-        className="sc-htoDjs sc-cMljjf dQmdry sc-gzVnrw pznRG sc-bZQynM kMvugX"
+        className="c6 c3"
       >
         <button
-          className="sc-kEYyzF rendition-pager__btn--prev sc-brqgnP fjrEUv sc-iAyFgw hgxYpe StyledButton-sc-323bzc-0 hIKTNd"
+          className="rendition-pager__btn--prev c7 c8"
           disabled={true}
           onBlur={[Function]}
           onClick={[Function]}
@@ -58,7 +232,7 @@ exports[`Pager component should match the stored snapshot 1`] = `
           </svg>
         </button>
         <button
-          className="sc-kEYyzF rendition-pager__btn--next sc-brqgnP fjrEUv sc-iAyFgw hgxYpe StyledButton-sc-323bzc-0 kTZdmm"
+          className="rendition-pager__btn--next c7 c9"
           disabled={false}
           onBlur={[Function]}
           onClick={[Function]}

--- a/__tests__/components/__snapshots__/ProgressBar.spec.js.snap
+++ b/__tests__/components/__snapshots__/ProgressBar.spec.js.snap
@@ -1,21 +1,93 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ProgressBar renders correctly 1`] = `
+.c1 {
+  font-family: 'Nunito',Arial,sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c5 {
+  position: relative;
+  height: 36px;
+  overflow: hidden;
+  background: #00AEEF;
+  -webkit-transition: width linear 250ms;
+  transition: width linear 250ms;
+  text-align: center;
+}
+
+.c4 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  text-align: center;
+  color: #000;
+  text-shadow: 0 0 3px rgba(255,255,255,0.5);
+}
+
+.c6 {
+  text-align: center;
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  top: 0;
+  text-shadow: 0 0 3px rgba(0,0,0,0.5);
+  -webkit-transition: width linear 250ms;
+  transition: width linear 250ms;
+}
+
+.c3 {
+  position: relative;
+  border-radius: 3px;
+  height: 16px;
+  line-height: 16px;
+  background: #F8F9FD;
+  font-size: 0.6em;
+  overflow: hidden;
+}
+
+.c2 {
+  color: #fff;
+}
+
+.c0 {
+  font-family: 'Nunito',Arial,sans-serif;
+}
+
+.c0 h1,
+.c0 h2,
+.c0 h3,
+.c0 h4,
+.c0 h5,
+.c0 h6,
+.c0 label,
+.c0 button {
+  font-family: CircularStd,Arial,sans-serif;
+}
+
 <div
-  className="sc-btzYZH jBDBBH StyledGrommet-sc-19lkkz7-0 bBubtL"
+  className="c0 c1"
 >
   <div
-    className="sc-jwKygS ZWfuR sc-cmTdod jjxkIy"
+    className="c2 c3"
     color="#fff"
   >
     <div
-      className="sc-feJyhm hBdPTU"
+      className="c4"
     >
       50
       %
     </div>
     <div
-      className="sc-kafWEX bsITjK"
+      className="c5"
       style={
         Object {
           "width": "50%",
@@ -23,7 +95,7 @@ exports[`ProgressBar renders correctly 1`] = `
       }
     >
       <div
-        className="sc-iELTvK hnTcXc"
+        className="c6"
         style={
           Object {
             "width": "200%",

--- a/__tests__/components/__snapshots__/Search.spec.js.snap
+++ b/__tests__/components/__snapshots__/Search.spec.js.snap
@@ -1,11 +1,91 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Search renders correctly 1`] = `
+.c1 {
+  font-family: 'Nunito',Arial,sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c2 {
+  position: relative;
+  width: 100%;
+  border-bottom: 1px solid #c6c8c9;
+  padding-left: 24px;
+  padding-top: 3px;
+}
+
+.c2 .search-icon {
+  color: #c6c8c9;
+  font-size: 0.9em;
+  position: absolute;
+  top: 50%;
+  left: 4px;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+}
+
+.c2 input {
+  outline: none;
+  background: transparent;
+  box-shadow: none;
+  border: none;
+  width: 100%;
+  font-size: inherit;
+  padding: 5px 5px 8px;
+  height: auto;
+}
+
+.c2 input:hover {
+  box-shadow: none;
+}
+
+.c2 input::-webkit-input-placeholder {
+  color: #c6c8c9;
+  font-weight: 300;
+}
+
+.c2 input::-moz-placeholder {
+  color: #c6c8c9;
+  font-weight: 300;
+}
+
+.c2 input:-ms-input-placeholder {
+  color: #c6c8c9;
+  font-weight: 300;
+}
+
+.c2 input::placeholder {
+  color: #c6c8c9;
+  font-weight: 300;
+}
+
+.c0 {
+  font-family: 'Nunito',Arial,sans-serif;
+}
+
+.c0 h1,
+.c0 h2,
+.c0 h3,
+.c0 h4,
+.c0 h5,
+.c0 h6,
+.c0 label,
+.c0 button {
+  font-family: CircularStd,Arial,sans-serif;
+}
+
 <div
-  className="sc-btzYZH jBDBBH StyledGrommet-sc-19lkkz7-0 bBubtL"
+  className="c0 c1"
 >
   <div
-    className="sc-eqIVtm itPwrV"
+    className="c2"
   >
     <input
       placeholder="Placeholder Text"

--- a/__tests__/components/__snapshots__/Select.spec.js.snap
+++ b/__tests__/components/__snapshots__/Select.spec.js.snap
@@ -1,14 +1,78 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Select component should match the stored snapshot 1`] = `
+.c1 {
+  font-family: 'Nunito',Arial,sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c3 {
+  border-radius: 3px;
+  height: 36px;
+  font-size: inherit;
+  border: 1px solid #c6c8c9;
+  padding-top: 0px;
+  padding-bottom: 0px;
+  padding-left: 16px;
+  padding-right: 36px;
+  background-color: white;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  width: 100%;
+  min-width: 90px;
+}
+
+.c3:hover:enabled {
+  box-shadow: 0 0 4px 1px rgba(0,0,0,0.1);
+}
+
+.c2 {
+  display: inline-block;
+  position: relative;
+}
+
+.c2::after {
+  content: '';
+  width: 0;
+  height: 0;
+  border-left: 4px solid transparent;
+  border-right: 4px solid transparent;
+  border-top: 5px solid #9f9f9f;
+  position: absolute;
+  right: 16px;
+  top: 16px;
+}
+
+.c0 {
+  font-family: 'Nunito',Arial,sans-serif;
+}
+
+.c0 h1,
+.c0 h2,
+.c0 h3,
+.c0 h4,
+.c0 h5,
+.c0 h6,
+.c0 label,
+.c0 button {
+  font-family: CircularStd,Arial,sans-serif;
+}
+
 <div
-  className="sc-btzYZH jBDBBH StyledGrommet-sc-19lkkz7-0 bBubtL"
+  className="c0 c1"
 >
   <span
-    className="sc-jhAzac eNEMZP sc-hzDkRC jWTBTG"
+    className="c2"
   >
     <select
-      className="sc-bRBYWo jMUPDA"
+      className="c3"
     >
       <option
         value={1}

--- a/__tests__/components/__snapshots__/Table.spec.js.snap
+++ b/__tests__/components/__snapshots__/Table.spec.js.snap
@@ -1,14 +1,114 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Table component should match the stored snapshot 1`] = `
+.c1 {
+  font-family: 'Nunito',Arial,sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c0 {
+  font-family: 'Nunito',Arial,sans-serif;
+}
+
+.c0 h1,
+.c0 h2,
+.c0 h3,
+.c0 h4,
+.c0 h5,
+.c0 h6,
+.c0 label,
+.c0 button {
+  font-family: CircularStd,Arial,sans-serif;
+}
+
+.c2 {
+  overflow-x: auto;
+  max-width: 100%;
+}
+
+.c3 {
+  display: table;
+  width: 100%;
+  border-spacing: 0;
+}
+
+.c3 > [data-display='table-head'] {
+  display: table-header-group;
+  background-color: #f2f2f2;
+}
+
+.c3 > [data-display='table-head'] > [data-display='table-row'] {
+  display: table-row;
+}
+
+.c3 > [data-display='table-head'] > [data-display='table-row'] > [data-display='table-cell'] {
+  display: table-cell;
+  text-align: left;
+  padding-left: 40px;
+  padding-top: 10px;
+  padding-bottom: 10px;
+  font-size: 16px;
+}
+
+.c3 > [data-display='table-body'] {
+  display: table-row-group;
+}
+
+.c3 > [data-display='table-body'] > [data-display='table-row'] {
+  display: table-row;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: inherit;
+}
+
+.c3 > [data-display='table-body'] > [data-display='table-row'] > [data-display='table-cell'] {
+  display: table-cell;
+  font-size: 14px;
+  text-align: left;
+  padding-top: 14px;
+  padding-bottom: 14px;
+  padding-left: 40px;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: inherit;
+}
+
+.c3 > [data-display='table-body'] > [data-display='table-row'] > a[data-display='table-cell'] {
+  cursor: auto;
+}
+
+.c3 > [data-display='table-body'] > [data-display='table-row']:nth-of-type(even) {
+  background-color: #f8f8f8;
+}
+
+.c3 > [data-display='table-body'] > [data-display='table-row']:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: inherit;
+}
+
+.c3 > [data-display='table-body'] > [data-display='table-row'][data-highlight='true'] {
+  background-color: #EDF7FD;
+}
+
+.c3 > [data-display='table-body'] > [data-display='table-row'][data-highlight='true'] > [data-display="table-cell"]:first-child {
+  box-shadow: inset 3px 0px 0 #1496E1;
+}
+
 <div
-  className="sc-btzYZH jBDBBH StyledGrommet-sc-19lkkz7-0 bBubtL"
+  className="c0 c1"
 >
   <div
-    className="sc-lhVmIH fuwFDy"
+    className="c2"
   >
     <div
-      className="sc-bYSBpT hTqmcI"
+      className="c3"
     >
       <div
         data-display="table-head"

--- a/__tests__/components/__snapshots__/Terminal.spec.js.snap
+++ b/__tests__/components/__snapshots__/Terminal.spec.js.snap
@@ -1,14 +1,189 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Terminal renders correctly 1`] = `
+.c3 {
+  box-sizing: border-box;
+}
+
+.c1 {
+  font-family: 'Nunito',Arial,sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c0 {
+  font-family: 'Nunito',Arial,sans-serif;
+}
+
+.c0 h1,
+.c0 h2,
+.c0 h3,
+.c0 h4,
+.c0 h5,
+.c0 h6,
+.c0 label,
+.c0 button {
+  font-family: CircularStd,Arial,sans-serif;
+}
+
+.c2 {
+  position: relative;
+  height: 100%;
+}
+
+.c2 .xterm {
+  font-feature-settings: "liga" 0;
+  position: relative;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -ms-user-select: none;
+  -webkit-user-select: none;
+}
+
+.c2 .xterm.focus,
+.c2 .xterm:focus {
+  outline: none;
+}
+
+.c2 .xterm .xterm-helpers {
+  position: absolute;
+  top: 0;
+  z-index: 10;
+}
+
+.c2 .xterm .xterm-helper-textarea {
+  position: absolute;
+  opacity: 0;
+  left: -9999em;
+  top: 0;
+  width: 0;
+  height: 0;
+  z-index: -10;
+  white-space: nowrap;
+  overflow: hidden;
+  resize: none;
+}
+
+.c2 .xterm .composition-view {
+  background: #000;
+  color: #fff;
+  display: none;
+  position: absolute;
+  white-space: nowrap;
+  z-index: 1;
+}
+
+.c2 .xterm .composition-view.active {
+  display: block;
+}
+
+.c2 .xterm .xterm-viewport {
+  background-color: #000;
+  overflow-y: scroll;
+  cursor: default;
+  position: absolute;
+  right: 0;
+  left: 0;
+  top: 0;
+  bottom: 0;
+}
+
+.c2 .xterm .xterm-screen {
+  position: relative;
+}
+
+.c2 .xterm .xterm-screen canvas {
+  position: absolute;
+  left: 0;
+  top: 0;
+}
+
+.c2 .xterm .xterm-scroll-area {
+  visibility: hidden;
+}
+
+.c2 .xterm-char-measure-element {
+  display: inline-block;
+  visibility: hidden;
+  position: absolute;
+  top: 0;
+  left: -9999em;
+  line-height: normal;
+}
+
+.c2 .xterm {
+  cursor: text;
+}
+
+.c2 .xterm.enable-mouse-events {
+  cursor: default;
+}
+
+.c2 .xterm.xterm-cursor-pointer {
+  cursor: pointer;
+}
+
+.c2 .xterm.column-select.focus {
+  cursor: crosshair;
+}
+
+.c2 .xterm .xterm-accessibility,
+.c2 .xterm .xterm-message {
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  z-index: 100;
+  color: transparent;
+}
+
+.c2 .xterm .live-region {
+  position: absolute;
+  left: -9999px;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}
+
+.c2 .xterm-viewport::-webkit-scrollbar-track {
+  background-color: transparent;
+  border-bottom-right-radius: 0;
+}
+
+.c2 .xterm-viewport::-webkit-scrollbar {
+  width: 10px;
+  background-color: transparent;
+  border-radius: 0;
+}
+
+.c2 .xterm-viewport::-webkit-scrollbar-thumb {
+  background-color: #e9e9e9;
+}
+
+.c4 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+}
+
 <div
-  className="sc-btzYZH jBDBBH StyledGrommet-sc-19lkkz7-0 bBubtL"
+  className="c0 c1"
 >
   <div
-    className="sc-jtRfpW gVnVFb sc-gzVnrw pznRG sc-bZQynM kMvugX"
+    className="c2 c3"
   >
     <div
-      className="sc-kTUwUJ ejEWUb"
+      className="c4"
     />
   </div>
 </div>

--- a/__tests__/components/__snapshots__/Textarea.spec.js.snap
+++ b/__tests__/components/__snapshots__/Textarea.spec.js.snap
@@ -1,11 +1,67 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Textarea component should match the stored snapshot 1`] = `
+.c1 {
+  font-family: 'Nunito',Arial,sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c2 {
+  border-radius: 3px;
+  font-size: inherit;
+  border: 1px solid #c6c8c9;
+  padding: 8px 16px;
+  resize: vertical;
+  display: block;
+  width: 100%;
+}
+
+.c2:hover {
+  box-shadow: 0 0 4px 1px rgba(0,0,0,0.1);
+}
+
+.c2::-webkit-input-placeholder {
+  color: #c6c8c9;
+}
+
+.c2::-moz-placeholder {
+  color: #c6c8c9;
+}
+
+.c2:-ms-input-placeholder {
+  color: #c6c8c9;
+}
+
+.c2::placeholder {
+  color: #c6c8c9;
+}
+
+.c0 {
+  font-family: 'Nunito',Arial,sans-serif;
+}
+
+.c0 h1,
+.c0 h2,
+.c0 h3,
+.c0 h4,
+.c0 h5,
+.c0 h6,
+.c0 label,
+.c0 button {
+  font-family: CircularStd,Arial,sans-serif;
+}
+
 <div
-  className="sc-btzYZH jBDBBH StyledGrommet-sc-19lkkz7-0 bBubtL"
+  className="c0 c1"
 >
   <textarea
-    className="sc-Rmtcm jQBcBr sc-csuQGl kmDVgM"
+    className="c2"
   />
 </div>
 `;

--- a/__tests__/components/__snapshots__/Txt.spec.js.snap
+++ b/__tests__/components/__snapshots__/Txt.spec.js.snap
@@ -1,11 +1,37 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Txt renders correctly 1`] = `
+.c1 {
+  font-family: 'Nunito',Arial,sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c0 {
+  font-family: 'Nunito',Arial,sans-serif;
+}
+
+.c0 h1,
+.c0 h2,
+.c0 h3,
+.c0 h4,
+.c0 h5,
+.c0 h6,
+.c0 label,
+.c0 button {
+  font-family: CircularStd,Arial,sans-serif;
+}
+
 <div
-  className="sc-btzYZH jBDBBH StyledGrommet-sc-19lkkz7-0 bBubtL"
+  className="c0 c1"
 >
   <div
-    className="sc-kGXeez giCiqz sc-kgoBCf kRuyZZ"
+    className=""
   >
     Hello world
   </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8768,7 +8768,7 @@
     "grommet": {
       "version": "2.6.6",
       "resolved": "https://registry.npmjs.org/grommet/-/grommet-2.6.6.tgz",
-      "integrity": "sha512-NeHYTG2ROBB9DWfih2YAvsG9Q2U9PQOVPSQ0RGPsDJ8o9yfrbDFSpGmfam58oE+MC/5Hx5iBvlUrGVg+VXQgEw==",
+      "integrity": "sha1-028ruf/SIq7JWCVbYaiqxfA3A30=",
       "requires": {
         "css": "^2.2.3",
         "grommet-icons": "^4.2.0",
@@ -8784,7 +8784,7 @@
         "hoist-non-react-statics": {
           "version": "3.3.0",
           "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
-          "integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
+          "integrity": "sha1-sJF48BIhhPuVrPUl2q7LTY9FlYs=",
           "requires": {
             "react-is": "^16.7.0"
           }
@@ -11417,6 +11417,15 @@
         }
       }
     },
+    "jest-styled-components": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/jest-styled-components/-/jest-styled-components-6.3.1.tgz",
+      "integrity": "sha512-zie3ajvJbwlbHCAq8/Bv5jdbcYCz0ZMRNNX6adL7wSRpkCVPQtiJigv1140JN1ZOJIODPn8VKrjeFCN+jlPa7w==",
+      "dev": true,
+      "requires": {
+        "css": "^2.2.4"
+      }
+    },
     "jest-util": {
       "version": "24.0.0",
       "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-24.0.0.tgz",
@@ -12899,6 +12908,7 @@
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
       "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
@@ -12908,13 +12918,15 @@
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -20013,7 +20025,7 @@
     "xterm": {
       "version": "3.12.2",
       "resolved": "https://registry.npmjs.org/xterm/-/xterm-3.12.2.tgz",
-      "integrity": "sha512-FSXovDdsqIKqoayC6+zFzhaHi+A3NSceM5rgTW88DH7sS96HdwMToB2p1rW+FyNsSqfAgFwlXDRQk+fh/aHvPQ=="
+      "integrity": "sha1-7IVjhXx7CYlzurTb9Tfxp8ankMg="
     },
     "y18n": {
       "version": "3.2.1",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "husky": "^0.14.3",
     "jest": "^24.1.0",
     "jest-canvas-mock": "^1.1.0",
+    "jest-styled-components": "^6.3.1",
     "jsdom": "^11.6.2",
     "lint-staged": "^4.1.1",
     "match-media-mock": "^0.1.1",
@@ -158,6 +159,9 @@
     "setupFiles": [
       "jest-canvas-mock",
       "<rootDir>scripts/setupTests.js"
+    ],
+    "setupFilesAfterEnv": [
+      "<rootDir>scripts/setupTestsAfterEnv.js"
     ],
     "moduleFileExtensions": [
       "ts",

--- a/scripts/setupTestsAfterEnv.js
+++ b/scripts/setupTestsAfterEnv.js
@@ -1,0 +1,1 @@
+import 'jest-styled-components'


### PR DESCRIPTION
This fixes the issue of useless jest snapshots for styled components, and it should not cause any changes to the classnames due to different environments, change in component ordering, etc.

Fixes #668
Change-type: patch
Signed-off-by: Stevche Radevski <stevche@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have rebuilt the README with `npm run build:docs`
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
