### PR TITLE
Pass the "id" and "className" props to the Modal wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -540,7 +540,6 @@ are rendered inside the modal.
 | `secondaryButtonProps` | `object` | - | - | If provided, will cause a secondary button to appear on the modal. These properties that are passed to that button, these are the same props used for the [`Button`](#button) component |
 | `cancelButtonProps` | `object` | - | - | Properties that are passed to the cancel button, these are the same props used for the [`Button`](#button) component |
 | style | `object` | - | - |  Apply custom styles to Modal, the object is applied as a [`style` attribute](https://reactjs.org/docs/dom-elements.html#style) |
-| containerStyle | `object` | - | - | Apply custom styles to the container of the Modal, the object is applied as a [`style` attribute](https://reactjs.org/docs/dom-elements.html#style) |
 ### Navbar
 
 A component used to render a navigation bar.

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -129,6 +129,8 @@ class Modal extends React.Component<ThemedModalProps, any> {
 					width={width || DEFAULT_MODAL_WIDTH}
 					onClick={stopPropagation}
 					style={props.style}
+					id={props.id}
+					className={props.className}
 				>
 					{props.titleElement ? (
 						<ModalHeader>{props.titleElement}</ModalHeader>
@@ -173,7 +175,6 @@ export interface ModalProps extends DefaultProps {
 	primaryButtonProps?: ButtonProps;
 	secondaryButtonProps?: ButtonProps;
 	cancelButtonProps?: ButtonProps;
-	containerStyle?: React.CSSProperties;
 }
 
 export interface ThemedModalProps extends ModalProps {

--- a/src/stories/README/Modal.md
+++ b/src/stories/README/Modal.md
@@ -20,4 +20,3 @@ are rendered inside the modal.
 | `secondaryButtonProps` | `object` | - | - | If provided, will cause a secondary button to appear on the modal. These properties that are passed to that button, these are the same props used for the [`Button`](#button) component |
 | `cancelButtonProps` | `object` | - | - | Properties that are passed to the cancel button, these are the same props used for the [`Button`](#button) component |
 | style | `object` | - | - |  Apply custom styles to Modal, the object is applied as a [`style` attribute](https://reactjs.org/docs/dom-elements.html#style) |
-| containerStyle | `object` | - | - | Apply custom styles to the container of the Modal, the object is applied as a [`style` attribute](https://reactjs.org/docs/dom-elements.html#style) |


### PR DESCRIPTION
Change-type: minor
Signed-off-by: Stevche Radevski <stevche@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have rebuilt the README with `npm run build:docs`
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
