### PR TITLE
Add missing tslib dependency for esm5 build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19039,10 +19039,9 @@
       }
     },
     "tslib": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
-      "integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==",
-      "dev": true
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
     },
     "tslint": {
       "version": "5.13.1",

--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
     "sanitize-html": "^1.20.1",
     "styled-components": "^4.2.0",
     "styled-system": "^4.1.0",
+    "tslib": "^1.10.0",
     "uuid": "^3.2.1",
     "xterm": "^3.12.2"
   },


### PR DESCRIPTION
By using the importHelpers in the esm5 build, all
helpers like __makeTemplateObject, __assign, __rest,
__importStar & __importDefault are imported from
the treeshakable tslib package. Doing so allows the
final combined build to be smaller, since otherwise
those helpers would be re-defined in the js file of
each rendition component. (You can check how it
looks by inspecting the files in the dist forlder, since
the importHelpers option is disabled for that output.)

If we bump the compilation target for the modules
build to es2015 (preferably along with another
breaking change), then the combined modules build
will become smaller, since it will need less helpers to
import (eg it will not need __makeTemplateObject,
__assign).

Resolves: #874
Change-type: patch
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

<!-- You can remove tags that do not apply. -->
Connects-to: # <!-- waffle convention to track a PR's status through its connected, open issue -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->
Change-type: major|minor|patch <!-- The change type of this PR -->

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have rebuilt the README with `npm run build:docs`
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
