### PR TITLE
Add build step when updating jest snapshots

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @lucianbuzzo
+* @lucianbuzzo @sradevski @dimitrisnl

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "build:docs": "node ./scripts/generateDocs.js",
     "build": "npm run tsify:xterm-css && npm run build:cjs && npm run build:esm5 && npm run build:docs",
     "generate-screenshots": "./scripts/generate-screenshots.sh",
+    "update-snapshots": "npm run build && npm run jest -- -u",
     "build:storybook": "build-storybook -o .out",
     "catch-uncommitted": "catch-uncommitted --catch-no-git --skip-node-versionbot-changes",
     "test:fast": "npm run lint && TZ='Etc/UTC' npm run jest",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "build:docs": "node ./scripts/generateDocs.js",
     "build": "npm run tsify:xterm-css && npm run build:cjs && npm run build:esm5 && npm run build:docs",
     "generate-screenshots": "./scripts/generate-screenshots.sh",
-    "update-snapshots": "npm run build && npm run jest -- -u",
+    "generate-snapshots": "npm run build && npm run jest -- -u",
     "build:storybook": "build-storybook -o .out",
     "catch-uncommitted": "catch-uncommitted --catch-no-git --skip-node-versionbot-changes",
     "test:fast": "npm run lint && TZ='Etc/UTC' npm run jest",


### PR DESCRIPTION
I have been annoyed multiple times where I update everything, and the build fails when I open the PR just because I forgot to build the project before updating the snapshots. I think this wasn't necessary before [this PR](https://github.com/balena-io-modules/rendition/commit/f848e43ec48e0570090b17e52f390b449002dd38).

Change-type: patch
Signed-off-by: Stevche Radevski <stevche@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have rebuilt the README with `npm run build:docs`
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
