### PR TITLE
Tabs: Export the Tab component instead of using a tabs prop

### DIFF
--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -1,29 +1,10 @@
-import {
-	Tab as GrommetTab,
-	Tabs as GrommetTabs,
-	TabsProps as GrommetTabsProps,
-} from 'grommet';
-import map from 'lodash/map';
+import { Tabs as GrommetTabs, TabsProps } from 'grommet';
+export { Tab, TabProps, TabsProps } from 'grommet';
 import * as React from 'react';
 import asRendition from '../asRendition';
 
-export interface TabsProps extends GrommetTabsProps {
-	tabs: string[];
-	children: JSX.Element[];
-}
-
-const TabsBase = ({ children, tabs, ...props }: TabsProps) => {
-	return (
-		<GrommetTabs justify="start" {...props}>
-			{map(children, (child, index) => {
-				return (
-					<GrommetTab key={tabs[index]} title={tabs[index]}>
-						{child}
-					</GrommetTab>
-				);
-			})}
-		</GrommetTabs>
-	);
+const TabsBase = ({ ...props }: TabsProps) => {
+	return <GrommetTabs justify="start" {...props} />;
 };
 
-export default asRendition(TabsBase) as React.FunctionComponent<TabsProps>;
+export const Tabs = asRendition(TabsBase) as React.FunctionComponent<TabsProps>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,7 +63,7 @@ export {
 } from './components/DropDownButton';
 export { default as Navbar, NavbarProps } from './components/Navbar';
 export { default as Link, LinkProps } from './components/Link';
-export { default as Tabs, TabsProps } from './components/Tabs';
+export { Tab, TabProps, Tabs, TabsProps } from './components/Tabs';
 
 export { Flex, Box, FlexProps, BoxProps } from './components/Grid';
 export { default as Theme } from './theme';

--- a/src/stories/Tabs.js
+++ b/src/stories/Tabs.js
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { storiesOf } from '@storybook/react'
 import { withScreenshot } from 'storybook-chrome-screenshot'
 import withReadme from 'storybook-readme/with-readme'
-import { Provider, Tabs, Txt } from '..'
+import { Provider, Tab, Tabs, Txt } from '..'
 import Readme from './README/Tabs.md'
 
 storiesOf('Next/Tabs', module)
@@ -11,9 +11,13 @@ storiesOf('Next/Tabs', module)
   .add('Standard', () => {
     return (
       <Provider>
-        <Tabs p={3} tabs={['Tab 1', 'Tab 2']}>
-          <Txt>Here is tab #1</Txt>
-          <Txt>Here is tab #2</Txt>
+        <Tabs p={3}>
+          <Tab title='Tab 1'>
+            <Txt>Here is tab #1</Txt>
+          </Tab>
+          <Tab title='Tab 2'>
+            <Txt>Here is tab #2</Txt>
+          </Tab>
         </Tabs>
       </Provider>
     )


### PR DESCRIPTION
This change makes the Tabs component behave in a much more similar
fashion to the Grommet base and fixes a bug where you can't populate
tabs using a `map` function.

Change-type: major
Signed-off-by: Lucian <lucian.buzzo@gmail.com>

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
