### PR TITLE
Remove acorn direct dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,8 +61,6 @@
     "@types/jest": "^23.3.2",
     "@types/react": "^16.8.8",
     "@types/react-dom": "^16.8.3",
-    "acorn": "^6.0.7",
-    "acorn-dynamic-import": "^4.0.0",
     "babel-eslint": "^10.0.1",
     "babel-loader": "^8.0.0-beta.6",
     "catch-uncommitted": "^1.3.0",
@@ -104,7 +102,7 @@
     "tslint": "^5.13.1",
     "tslint-config-prettier": "^1.17.0",
     "typescript": "^3.5.2",
-    "webpack": "^4.29.6",
+    "webpack": "^4.36.1",
     "zxcvbn": "^4.4.2"
   },
   "dependencies": {


### PR DESCRIPTION
The bug in webpack was resolved, so there is no
need to have acorn as a direct dependency anymore

Resolves #739
Change-type: patch
Signed-off-by: Stevche Radevski <stevche@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have rebuilt the README with `npm run build:docs`
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
