### PR TITLE
table: Display pager only when needed

### DIFF
--- a/__tests__/components/Table.spec.js
+++ b/__tests__/components/Table.spec.js
@@ -787,22 +787,6 @@ describe('Table component', () => {
     })
   })
 
-  describe('usePager property', () => {
-    it('should display a pager', () => {
-      const component = mount(
-        <Provider>
-          <Table
-            columns={[ { field: 'Name' } ]}
-            data={PokeDex}
-            usePager
-          />
-        </Provider>
-      )
-
-      expect(component.find(Pager)).toHaveLength(1)
-    })
-  })
-
   describe('itemsPerPage property', () => {
     it('should limit the number of items shown at one time', () => {
       const component = mount(
@@ -822,6 +806,36 @@ describe('Table component', () => {
       const result = PokeDex.slice(0, 3).map(p => p.Name)
 
       expect(match.map(e => e.text())).toEqual(result)
+    })
+  })
+
+  describe('usePager property', () => {
+    it('should display a pager', () => {
+      const component = mount(
+        <Provider>
+          <Table
+            columns={[ { field: 'Name' } ]}
+            data={PokeDex}
+            usePager
+          />
+        </Provider>
+      )
+
+      expect(component.find(Pager)).toHaveLength(1)
+    })
+
+    it('shouldn\'t display a pager if there are no items', () => {
+      const component = mount(
+        <Provider>
+          <Table
+            columns={[ { field: 'Name' } ]}
+            data={[]}
+            usePager
+          />
+        </Provider>
+      )
+
+      expect(component.find(Pager)).toHaveLength(0)
     })
   })
 })

--- a/src/components/Table/index.tsx
+++ b/src/components/Table/index.tsx
@@ -404,9 +404,11 @@ class Table<T> extends React.Component<TableProps<T>, TableState<T>> {
 
 		const sortedData = this.sortData(items).slice(lowerBound, upperBound);
 
+		const shouldShowPaper = !!usePager && totalItems > 0;
+
 		return (
 			<>
-				{!!usePager &&
+				{shouldShowPaper &&
 					(_pagerPosition === 'top' || _pagerPosition === 'both') && (
 						<Pager
 							totalItems={totalItems}
@@ -503,7 +505,7 @@ class Table<T> extends React.Component<TableProps<T>, TableState<T>> {
 					</BaseTable>
 				</BaseTableWrapper>
 
-				{!!usePager &&
+				{shouldShowPaper &&
 					(_pagerPosition === 'bottom' || _pagerPosition === 'both') && (
 						<Pager
 							totalItems={totalItems}


### PR DESCRIPTION
1. Doesn't display pager when there are no elements
2. Doesn't display pager when the elements fit into a single page

Fixes: #895
Change-type: minor
Signed-off-by: Dimitrios Lytras <dimitrios@balena.io>

<!-- You can remove tags that do not apply. -->
Connects-to: # <!-- waffle convention to track a PR's status through its connected, open issue -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->
Change-type: major|minor|patch <!-- The change type of this PR -->

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have rebuilt the README with `npm run build:docs`
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
