### PR TITLE
Markdown: Allow markdown parser to be imported on its own

### DIFF
--- a/src/extra/Markdown.tsx
+++ b/src/extra/Markdown.tsx
@@ -1,57 +1,10 @@
-import marked from 'marked';
 import * as React from 'react';
-import sanitizeHtml from 'sanitize-html';
 import styled from 'styled-components';
 import Txt, { TxtProps } from '../components/Txt';
+import { parseMarkdown } from './utils';
 
 type MarkdownProps = TxtProps & {
 	children: string;
-};
-
-const renderer = new marked.Renderer();
-renderer.link = function(_href, _title, _text) {
-	const link = marked.Renderer.prototype.link.apply(this, arguments);
-	return link.replace('<a', '<a target="_blank" rel="noopener noreferrer"');
-};
-
-const markedOptions = {
-	// Enable github flavored markdown
-	gfm: true,
-	breaks: true,
-	headerIds: false,
-	// Input text is sanitized using `sanitize-html` prior to being transformed by
-	// `marked`
-	sanitize: false,
-	renderer,
-};
-
-const sanitizerOptions = {
-	allowedTags: sanitizeHtml.defaults.allowedTags.concat([
-		'del',
-		'h1',
-		'h2',
-		'img',
-		'input',
-	]),
-	allowedAttributes: {
-		a: ['href', 'name', 'target', 'rel'],
-		img: ['src'],
-		input: [
-			{
-				name: 'type',
-				multiple: false,
-				values: ['checkbox'],
-			},
-			'disabled',
-			'checked',
-		],
-	},
-};
-
-const render = (text: string = '') => {
-	const html = marked(text, markedOptions);
-	const clean = sanitizeHtml(html, sanitizerOptions as any);
-	return clean;
 };
 
 /*
@@ -762,7 +715,7 @@ export const Markdown = ({ children, ...props }: MarkdownProps) => {
 	return (
 		<GitHubMarkdown
 			{...props}
-			dangerouslySetInnerHTML={{ __html: render(children) }}
+			dangerouslySetInnerHTML={{ __html: parseMarkdown(children) }}
 		/>
 	);
 };

--- a/src/extra/utils.ts
+++ b/src/extra/utils.ts
@@ -1,0 +1,49 @@
+import marked from 'marked';
+import sanitizeHtml from 'sanitize-html';
+
+const renderer = new marked.Renderer();
+
+renderer.link = function(_href, _title, _text) {
+	const link = marked.Renderer.prototype.link.apply(this, arguments);
+	return link.replace('<a', '<a target="_blank" rel="noopener noreferrer"');
+};
+
+const markedOptions = {
+	// Enable github flavored markdown
+	gfm: true,
+	breaks: true,
+	headerIds: false,
+	// Input text is sanitized using `sanitize-html` prior to being transformed by
+	// `marked`
+	sanitize: false,
+	renderer,
+};
+
+const sanitizerOptions = {
+	allowedTags: sanitizeHtml.defaults.allowedTags.concat([
+		'del',
+		'h1',
+		'h2',
+		'img',
+		'input',
+	]),
+	allowedAttributes: {
+		a: ['href', 'name', 'target', 'rel'],
+		img: ['src'],
+		input: [
+			{
+				name: 'type',
+				multiple: false,
+				values: ['checkbox'],
+			},
+			'disabled',
+			'checked',
+		],
+	},
+};
+
+export const parseMarkdown = (text: string = '') => {
+	const html = marked(text, markedOptions);
+	const clean = sanitizeHtml(html, sanitizerOptions as any);
+	return clean;
+};


### PR DESCRIPTION
Fixes #935

This is particularly useful to homogenize server side markdown parsing
with client presentation.

Change-type: minor
Signed-off-by: Lucian <lucian.buzzo@gmail.com>

<!-- You can remove tags that do not apply. -->
Connects-to: # <!-- waffle convention to track a PR's status through its connected, open issue -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->
Change-type: major|minor|patch <!-- The change type of this PR -->

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have rebuilt the README with `npm run build:docs`
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
