### PR TITLE
filters: Fix default datepicker date

### DIFF
--- a/src/components/DataTypes/date-time-helpers.tsx
+++ b/src/components/DataTypes/date-time-helpers.tsx
@@ -2,8 +2,7 @@ import memoize from 'lodash/memoize';
 
 export const getDefaultDate = (): string => {
 	const date = new Date();
-	date.setUTCHours(0, 0, 0, 0);
-	return date.toISOString().split('.')[0] + 'Z';
+	return date.toISOString().split('.')[0];
 };
 
 // Normalize a timestamp to a RFC3339 timestamp, which is required for JSON schema.


### PR DESCRIPTION
The default Date that the datepicker input would receive wasn't in the right format. As a result it would fail to set the current datetime on first render. Any consequent props that the component would receive would retrigger this conditional resulting in an never ending loop.

If the user would try to select a date while a polling is in place, the field would reset. This fix ensures that the initial value is correct.

Fixes: #887
Change-type: patch
Signed-off-by: Dimitrios Lytras <dimitrios@balena.io>

<!-- You can remove tags that do not apply. -->
Connects-to: # <!-- waffle convention to track a PR's status through its connected, open issue -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->
Change-type: major|minor|patch <!-- The change type of this PR -->

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have rebuilt the README with `npm run build:docs`
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
