### PR TITLE
Override global height and width for Divider, fix Heading's typing

### DIFF
--- a/src/components/Divider/index.tsx
+++ b/src/components/Divider/index.tsx
@@ -10,7 +10,8 @@ const Base = styled.hr<InternalDividerProps>`
 	border: ${props =>
 		`${px(props.height || 0.5)} ${props.type || 'solid'} ${props.color ||
 			props.theme.colors.quartenary.main}}`};
-	height: ${props => px(props.height || 0.5)};
+	width: 100%;
+	height: 0;
 `;
 
 const FlexBase = styled(Base)`

--- a/src/components/Divider/spec.js.snap
+++ b/src/components/Divider/spec.js.snap
@@ -14,7 +14,8 @@ exports[`Divider renders correctly 1`] = `
 
 .c2 {
   border: 0.5px solid #DDE1f0;
-  height: 0.5px;
+  width: 100%;
+  height: 0;
 }
 
 .c0 {

--- a/src/components/Heading/index.tsx
+++ b/src/components/Heading/index.tsx
@@ -38,7 +38,7 @@ const Factory = (tag?: string) => {
 };
 
 interface InternalHeadingProps extends DefaultProps {
-	align?: boolean;
+	align?: string;
 	monospace?: boolean;
 	caps?: boolean;
 	bold?: boolean;


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Stevche Radevski <stevche@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have rebuilt the README with `npm run build:docs`
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
