### PR TITLE
Fix ordered number label squashing on 100% width

### DIFF
--- a/src/components/List/index.tsx
+++ b/src/components/List/index.tsx
@@ -41,6 +41,7 @@ const OrderedList = styled(ListBase).attrs({ as: 'ol' })`
 			background: ${props => props.theme.colors.primary.main};
 			height: ${ORDERED_LIST_SIZE}em;
 			width: ${ORDERED_LIST_SIZE}em;
+			min-width: ${ORDERED_LIST_SIZE}em;
 			line-height: ${ORDERED_LIST_SIZE}em;
 			color: white;
 			border-radius: 50%;

--- a/src/components/List/spec.js.snap
+++ b/src/components/List/spec.js.snap
@@ -64,6 +64,7 @@ exports[`Ordered list renders correctly 1`] = `
   background: #00AEEF;
   height: 1.5em;
   width: 1.5em;
+  min-width: 1.5em;
   line-height: 1.5em;
   color: white;
   border-radius: 50%;


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Stevche Radevski <stevche@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have rebuilt the README with `npm run build:docs`
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
