### PR TITLE
fix: Refactored deprecated react lifecycle hooks

### DIFF
--- a/src/components/Filters/index.tsx
+++ b/src/components/Filters/index.tsx
@@ -89,23 +89,23 @@ class Filters extends React.Component<FiltersProps, FiltersState> {
 		this.state.edit.push(this.getCleanEditModel());
 	}
 
-	componentWillReceiveProps(nextProps: FiltersProps) {
+	componentDidUpdate(prevProps: FiltersProps) {
 		const newState: any = {};
 
 		// If the schema prop updates, also update the internal 'flat' schema
-		if (!isEqual(nextProps.schema, this.props.schema)) {
-			newState.schema = SchemaSieve.flattenSchema(nextProps.schema);
+		if (!isEqual(prevProps.schema, this.props.schema)) {
+			newState.schema = SchemaSieve.flattenSchema(this.props.schema);
 		}
 
-		if (!isEqual(nextProps.filters, this.props.filters)) {
-			const filters = nextProps.filters || [];
+		if (!isEqual(prevProps.filters, this.props.filters)) {
+			const filters = this.props.filters || [];
 			newState.filters = filters.map(filter =>
 				SchemaSieve.flattenSchema(filter),
 			);
 		}
 
-		if (!isEqual(nextProps.views, this.props.views)) {
-			const views = nextProps.views || [];
+		if (!isEqual(prevProps.views, this.props.views)) {
+			const views = this.props.views || [];
 			newState.views = this.flattenViews(views);
 		}
 

--- a/src/components/Table/index.tsx
+++ b/src/components/Table/index.tsx
@@ -3,6 +3,7 @@ import filter from 'lodash/filter';
 import find from 'lodash/find';
 import includes from 'lodash/includes';
 import isArray from 'lodash/isArray';
+import isEqual from 'lodash/isEqual';
 import isFunction from 'lodash/isFunction';
 import isPlainObject from 'lodash/isPlainObject';
 import map from 'lodash/map';
@@ -161,9 +162,11 @@ class Table<T> extends React.Component<TableProps<T>, TableState<T>> {
 		};
 	}
 
-	componentWillReceiveProps(newProps: TableProps<T>) {
-		if (newProps.sort !== this.props.sort) {
-			this.setState({ sort: newProps.sort } as TableState<T>);
+	componentDidUpdate(prevProps: TableProps<T>) {
+		if (this.props.sort && !isEqual(prevProps.sort, this.props.sort)) {
+			this.setState({
+				sort: this.props.sort,
+			});
 		}
 	}
 
@@ -221,7 +224,7 @@ class Table<T> extends React.Component<TableProps<T>, TableState<T>> {
 
 	sortData(data: T[]): T[] {
 		const { sort } = this.state;
-		if (sort.field === null) {
+		if (!sort || sort.field === null) {
 			return data;
 		}
 

--- a/src/extra/Form/captcha.tsx
+++ b/src/extra/Form/captcha.tsx
@@ -29,9 +29,9 @@ export class CaptchaWidget extends React.Component<CaptchaWidgetProps> {
 		}
 	}
 
-	componentWillReceiveProps(newProps: CaptchaWidgetProps) {
+	componentDidUpdate(prevProps: CaptchaWidgetProps) {
 		// Reset the captcha component if the form was submitted, since a captcha value can only be used once (and it will error if used again). The caller is obliged to empty the captcha value on submit
-		if (newProps.value !== this.props.value && !Boolean(newProps.value)) {
+		if (prevProps.value !== this.props.value && !Boolean(this.props.value)) {
 			this.recaptchaRef.current.reset();
 		}
 	}

--- a/src/unstable/components/Form/index.tsx
+++ b/src/unstable/components/Form/index.tsx
@@ -93,16 +93,16 @@ export default class FormHOC extends React.Component<
 		widgets[name] = value;
 	}
 
-	componentWillReceiveProps(nextProps: FormProps) {
-		if (!isEqual(this.props.value, nextProps.value)) {
+	componentDidUpdate(prevProps: FormProps) {
+		if (!isEqual(this.props.value, prevProps.value)) {
 			this.setState({
-				value: nextProps.value,
+				value: this.props.value,
 			});
 		}
 
-		if (!isEqual(this.props.schema, nextProps.schema)) {
+		if (!isEqual(this.props.schema, prevProps.schema)) {
 			this.setState({
-				schema: this.parseSchema(nextProps.schema),
+				schema: this.parseSchema(this.props.schema),
 			});
 		}
 	}

--- a/src/unstable/components/Form/spec.js
+++ b/src/unstable/components/Form/spec.js
@@ -218,6 +218,7 @@ describe('Form component', () => {
       )
 
       component.setProps({ value })
+      component.update()
 
       const input = component.find('input')
       expect(input.props().value).toEqual('Squirtle')

--- a/src/unstable/components/JellyForm/index.tsx
+++ b/src/unstable/components/JellyForm/index.tsx
@@ -48,20 +48,20 @@ class JellyForm extends React.Component<JellyFormProps, JellyFormState> {
 		};
 	}
 
-	componentWillReceiveProps(nextProps: JellyFormProps) {
-		if (!isEqual(this.props.value, nextProps.value)) {
+	componentDidUpdate(prevProps: JellyFormProps) {
+		if (!isEqual(this.props.value, prevProps.value)) {
 			this.setState({
-				value: runFormulas(this.state.schema, nextProps.value),
+				value: runFormulas(this.state.schema, this.props.value),
 			});
 		}
 
 		if (
-			!isEqual(this.props.schema, nextProps.schema) ||
-			!isEqual(this.props.uiSchema, nextProps.uiSchema)
+			!isEqual(this.props.schema, prevProps.schema) ||
+			!isEqual(this.props.uiSchema, prevProps.uiSchema)
 		) {
 			const { schema, uiSchema } = computeFormSchemas(
-				nextProps.schema,
-				nextProps.uiSchema,
+				this.props.schema,
+				this.props.uiSchema,
 			);
 
 			this.setState({

--- a/src/unstable/components/JellyForm/spec.js
+++ b/src/unstable/components/JellyForm/spec.js
@@ -212,6 +212,7 @@ describe('JellyForm component', () => {
       )
 
       component.setProps({ value })
+      component.update()
 
       const input = component.find('input')
       expect(input.props().value).toEqual('Squirtle')


### PR DESCRIPTION
Connects-to: #944 
Change-type: patch

---
##### Contributor checklist
- [ ] I have rebuilt the README with `npm run build:docs`
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
