### PR TITLE
Change Form's submit method to do validation before calling onFormSubmit

### DIFF
--- a/src/unstable/components/Form/index.tsx
+++ b/src/unstable/components/Form/index.tsx
@@ -78,6 +78,8 @@ export default class FormHOC extends React.Component<
 	FormProps,
 	{ value: any; schema: JSONSchema6 }
 > {
+	private formRef = React.createRef<Form<any>>();
+
 	constructor(props: FormProps) {
 		super(props);
 
@@ -118,9 +120,9 @@ export default class FormHOC extends React.Component<
 		}
 	};
 
-	submit = (data: any) => {
-		if (this.props.onFormSubmit) {
-			this.props.onFormSubmit(data);
+	submit = () => {
+		if (this.formRef.current) {
+			this.formRef.current.submit();
 		}
 	};
 
@@ -148,14 +150,15 @@ export default class FormHOC extends React.Component<
 		return (
 			<FormWrapper {...props}>
 				<Form
+					ref={this.formRef}
 					liveValidate={liveValidate}
 					noValidate={noValidate}
 					validate={validate}
 					showErrorList={false}
 					schema={localSchema}
 					formData={this.state.value}
-					onSubmit={this.submit}
-					onChange={this.change}
+					onSubmit={this.props.onFormSubmit}
+					onChange={this.props.onFormChange}
 					uiSchema={uiSchema}
 					widgets={widgets}
 					fields={fields}


### PR DESCRIPTION
Change-type: minor
Signed-off-by: Stevche Radevski <stevche@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have rebuilt the README with `npm run build:docs`
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
