### PR TITLE
minifix: onRowClick warning in Table component

### DIFF
--- a/src/components/Table/index.tsx
+++ b/src/components/Table/index.tsx
@@ -32,7 +32,13 @@ const BaseTableWrapper = styled.div`
 	max-width: 100%;
 `;
 
-const BaseTable = styled.div<{ hasCheckbox: boolean }>`
+interface BaseTableProps {
+	hasCheckbox: boolean;
+	hasRowClick: boolean;
+	hasGetRowRef: boolean;
+}
+
+const BaseTable = styled.div<BaseTableProps>`
 	display: table;
 	width: 100%;
 	border-spacing: 0;
@@ -93,8 +99,8 @@ const BaseTable = styled.div<{ hasCheckbox: boolean }>`
 			}
 
 			> a[data-display='table-cell'] {
-				cursor: ${(props: any) =>
-					!!props.onRowClick || !!props.getRowHref ? 'pointer' : 'auto'};
+				cursor: ${props =>
+					props.hasRowClick || props.hasGetRowRef ? 'pointer' : 'auto'};
 			}
 
 			&:nth-of-type(even) {
@@ -103,8 +109,8 @@ const BaseTable = styled.div<{ hasCheckbox: boolean }>`
 
 			&:hover {
 				text-decoration: none;
-				${(props: any) =>
-					!!props.onRowClick || !!props.getRowHref || !!props.onCheck
+				${props =>
+					props.hasRowClick || props.hasGetRowRef || props.hasCheckbox
 						? highlightStyle
 						: ''};
 			}
@@ -438,7 +444,11 @@ class Table<T> extends React.Component<TableProps<T>, TableState<T>> {
 					)}
 
 				<BaseTableWrapper>
-					<BaseTable {...props} hasCheckbox={Boolean(onCheck)}>
+					<BaseTable
+						hasRowClick={!!props.onRowClick}
+						hasGetRowRef={!!props.getRowHref}
+						hasCheckbox={!!onCheck}
+					>
 						<div data-display="table-head">
 							<div data-display="table-row">
 								{onCheck && (


### PR DESCRIPTION
Fixes the `Warning: Unknown event handler property `onRowClick`. It will be ignored.` warning when setting the OnRowClick handler on the Table component.

<img width="530" alt="Screen Shot 2019-11-08 at 13 11 09" src="https://user-images.githubusercontent.com/3798908/68475501-f6c4cd80-0230-11ea-956a-2f08fb438e7c.png">

This warning is logged by styled components as its looks for any props passed to it that are prefixed with `on`. 

More information on this issue [here](https://github.com/styled-components/styled-components/issues/2218)

There was also an invalid property 'onCheck' that was being referenced in the styled component. This was removed.

All tests still passing

<img width="250" alt="Screen Shot 2019-11-08 at 14 07 59" src="https://user-images.githubusercontent.com/3798908/68475596-312e6a80-0231-11ea-93d3-1c4b3b54b494.png">

See: https://github.com/styled-components/styled-components/issues/2218
Change-type: patch

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have rebuilt the README with `npm run build:docs`
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
