### PR TITLE
Fix table not displaying data when data length reduces

### DIFF
--- a/src/components/Table/index.tsx
+++ b/src/components/Table/index.tsx
@@ -168,6 +168,12 @@ class Table<T> extends React.Component<TableProps<T>, TableState<T>> {
 				sort: this.props.sort,
 			});
 		}
+
+		const totalItems = this.props.data?.length ?? 0;
+		const itemsPerPage = this.props.itemsPerPage ?? 50;
+		if (this.state.page !== 0 && totalItems <= this.state.page * itemsPerPage) {
+			this.resetPager();
+		}
 	}
 
 	isChecked(item: T) {

--- a/src/components/Table/spec.js
+++ b/src/components/Table/spec.js
@@ -908,6 +908,32 @@ describe('Table component', () => {
 
       expect(component.find(Pager)).toHaveLength(0)
     })
+
+    it('should reset the page if the data length becomes less than the current pager value', () => {
+      const component = mount(
+        React.createElement(
+          props => (
+            <Provider>
+              <Table {...props} />
+            </Provider>
+          ),
+          {
+            columns: [{ field: 'Name' }],
+            data: PokeDex,
+            itemsPerPage: 2,
+            usePager: true
+          }
+        )
+      )
+
+      const table = component.find(Table).instance()
+      expect(table.state.page).toEqual(0)
+      table.incrementPage()
+      table.incrementPage()
+      expect(table.state.page).toEqual(2)
+      component.setProps({ data: PokeDex.slice(0, 2) })
+      expect(table.state.page).toEqual(0)
+    })
   })
 })
 


### PR DESCRIPTION
If the data length becomes less than the initial one
(like when you apply a filter), the data would not show
up, and the pager will get stuck at whatever page the user
was at.

Change-type: patch
Signed-off-by: Stevche Radevski <stevche@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have rebuilt the README with `npm run build:docs`
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
