### PR TITLE
Fixes regression: className not being passed to Table

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "babel-eslint": "^10.0.1",
     "babel-loader": "^8.0.0-beta.6",
     "catch-uncommitted": "^1.3.0",
-    "circular-std": "^1.0.0",
+    "circular-std": "1.0.0",
     "css-loader": "^0.28.11",
     "enzyme": "^3.9.0",
     "enzyme-adapter-react-16": "^1.11.2",

--- a/src/components/Table/index.tsx
+++ b/src/components/Table/index.tsx
@@ -411,10 +411,11 @@ class Table<T> extends React.Component<TableProps<T>, TableState<T>> {
 			rowAnchorAttributes,
 			rowKey,
 			onCheck,
+			onRowClick,
+			getRowHref,
+			getRowClass,
 			...props
 		} = this.props;
-
-		const { getRowHref, getRowClass } = props;
 
 		const { page, sort } = this.state;
 		const items = data || [];
@@ -448,8 +449,9 @@ class Table<T> extends React.Component<TableProps<T>, TableState<T>> {
 
 				<BaseTableWrapper>
 					<BaseTable
-						hasRowClick={!!props.onRowClick}
-						hasGetRowRef={!!props.getRowHref}
+						{...props}
+						hasRowClick={!!onRowClick}
+						hasGetRowRef={!!getRowHref}
 						hasCheckbox={!!onCheck}
 					>
 						<div data-display="table-head">


### PR DESCRIPTION
Fixes a regression introduced by https://github.com/balena-io-modules/rendition/pull/1013/files
Change-type: patch
Signed-off-by: Stevche Radevski <stevche@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have rebuilt the README with `npm run build:docs`
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
