### PR TITLE
Add onclick handler to Copy, fix children typings

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ Wrapper that adds a "copy to clipboard" button to any component and copies the p
 | ------ | ------ | --------- | ---------- | ------------- |
 | `content`      | `string` | -         | ✓          | The value that should be copied to the clipboard
 | `show`      | <code>'hover' &#124; 'always'</code> | - | - | Optionally show the copy button on hover or always show the button
+| `onClick`      | `(content: string) => void` | - | - | onClick handler, useful if you wish to do other actions after content was copied
 | `children`      | `React.ReactNode` | -         | - | The content next to which the clipboard button should be shown
 
 ### Divider

--- a/src/components/Copy/README.md
+++ b/src/components/Copy/README.md
@@ -10,4 +10,5 @@ Wrapper that adds a "copy to clipboard" button to any component and copies the p
 | ------ | ------ | --------- | ---------- | ------------- |
 | `content`      | `string` | -         | ✓          | The value that should be copied to the clipboard
 | `show`      | <code>'hover' &#124; 'always'</code> | - | - | Optionally show the copy button on hover or always show the button
+| `onClick`      | `(content: string) => void` | - | - | onClick handler, useful if you wish to do other actions after content was copied
 | `children`      | `React.ReactNode` | -         | - | The content next to which the clipboard button should be shown

--- a/src/components/Copy/index.tsx
+++ b/src/components/Copy/index.tsx
@@ -33,6 +33,7 @@ export default ({
 	content,
 	show,
 	children,
+	onClick,
 	...otherProps
 }: InternalCopyProps) => {
 	const normalizedText = (content || '').toString().trim();
@@ -51,6 +52,9 @@ export default ({
 				onClick={e => {
 					stopEvent(e);
 					copyToClipboard(normalizedText);
+					if (onClick) {
+						onClick(normalizedText);
+					}
 				}}
 			>
 				<FontAwesomeIcon icon={faCopy} />
@@ -59,10 +63,11 @@ export default ({
 	);
 };
 
-export interface InternalCopyProps extends FlexProps {
+export interface InternalCopyProps extends Omit<FlexProps, 'onClick'> {
 	content: string;
 	show?: 'hover' | 'always';
-	children: React.ReactNode;
+	onClick?: (content: string) => void;
+	children?: React.ReactNode;
 }
 
 export type CopyProps = InternalCopyProps & RenditionSystemProps;


### PR DESCRIPTION
Change-type: minor
Signed-off-by: Stevche Radevski <stevche@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have rebuilt the README with `npm run build:docs`
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
