### PR TITLE
Markdown: extend allowed set of tags and attributes

### DIFF
--- a/src/extra/Markdown/specsuite.json
+++ b/src/extra/Markdown/specsuite.json
@@ -67,7 +67,7 @@
   {
     "name": "should render markdown images",
     "source": "![GitHub logo](https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png)",
-    "expected": "<p><img src=\"https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png\"></p>"
+    "expected": "<p><img src=\"https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png\" alt=\"GitHub logo\"></p>"
   },
   {
     "name": "should render markdown links",
@@ -1152,7 +1152,7 @@
   {
     "name": "xss: 205",
     "source": "<a href=http://foo.bar/#x=`y></a><img alt=\"`><img src=x:x onerror=javascript:alert(1)></a>\">",
-    "expected": "<p>&lt;a href=<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"http://foo.bar/#x=%60y&gt;\">http://foo.bar/#x=`y&gt;</a><img></p>"
+    "expected": "<p>&lt;a href=<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"http://foo.bar/#x=%60y&gt;\">http://foo.bar/#x=`y&gt;</a><img alt=\"`&gt;&lt;img src=x:x onerror=javascript:alert(1)&gt;&lt;/a&gt;\"></p>"
   },
   {
     "name": "xss: 206",

--- a/src/extra/utils.ts
+++ b/src/extra/utils.ts
@@ -21,16 +21,20 @@ const markedOptions = {
 
 const sanitizerOptions = {
 	allowedTags: sanitizeHtml.defaults.allowedTags.concat([
+		'article',
+		'aside',
 		'del',
+		'div',
 		'h1',
 		'h2',
+		'header',
 		'img',
 		'input',
 		'span',
 	]),
 	allowedAttributes: {
 		a: ['href', 'name', 'target', 'rel'],
-		img: ['src'],
+		img: ['src', 'class', 'title', 'alt'],
 		input: [
 			{
 				name: 'type',
@@ -41,6 +45,10 @@ const sanitizerOptions = {
 			'checked',
 		],
 		span: ['class'],
+		div: ['class'],
+		aside: ['class'],
+		article: ['class'],
+		header: ['class'],
 	},
 };
 


### PR DESCRIPTION
To better support structured contend, extend the set of allowed tags to
include:
- article
- aside
- div
- header

The img tag has also been extended to allow the alt, title and class
attributes.

Change-type: minor
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

<!-- You can remove tags that do not apply. -->
Connects-to: # <!-- waffle convention to track a PR's status through its connected, open issue -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->
Change-type: major|minor|patch <!-- The change type of this PR -->

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have rebuilt the README with `npm run build:docs`
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
