### PR TITLE
Switch xterm.js to dynamic char atlas for performance

### DIFF
--- a/src/components/Terminal/index.tsx
+++ b/src/components/Terminal/index.tsx
@@ -59,6 +59,7 @@ class Terminal extends React.Component<ThemedTerminalProps, {}> {
 				background: '#343434',
 				cursor: props.nonInteractive ? '#343434' : undefined,
 			},
+			experimentalCharAtlas: 'dynamic',
 		});
 
 		// Allow an existing tty instance to be rebound to this react element


### PR DESCRIPTION
This is also the default/only option in xterm.js 4.x: https://github.com/xtermjs/xterm.js/releases/tag/4.0.0

>```
>// before 4.0.0
>const term = new Terminal({ experimentalCharAtlas: 'static' });
>
>// after 4.0.0
>// No-op, the previous 'dynamic' is the only option available now due to
>// superior performance in every way.
>```