### PR TITLE
fix: modal enter key check

### DIFF
--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -75,6 +75,10 @@ class Modal extends React.Component<ThemedModalProps, any> {
 			e.preventDefault();
 			e.stopPropagation();
 
+			if (this.props.primaryButtonProps?.disabled) {
+				return;
+			}
+
 			// Enter key
 			if (e.which === 13) {
 				this.props.done();

--- a/src/components/Modal/spec.js
+++ b/src/components/Modal/spec.js
@@ -116,4 +116,30 @@ describe('Keyboard submitting nested modals', () => {
     expect(firstModalSpy.notCalled).toBeTruthy()
     expect(secondModalSpy.calledOnce).toBeTruthy()
   })
+
+  it('should not call any callback of either modal on Enter key press when the primary button is disabled', () => {
+    const firstModalSpy = sinon.spy()
+    const secondModalSpy = sinon.spy()
+
+    mount(
+      <Provider>
+        <Modal done={firstModalSpy}>
+          <Modal primaryButtonProps={{ disabled: true }} done={secondModalSpy}>
+            Test
+          </Modal>
+        </Modal>
+      </Provider>
+    )
+
+    // Enter key
+    eventListenersMap.keydown.forEach(fn =>
+      fn({
+        preventDefault: () => null,
+        stopPropagation: () => null,
+        which: ENTER_KEY
+      })
+    )
+    expect(firstModalSpy.notCalled).toBeTruthy()
+    expect(secondModalSpy.notCalled).toBeTruthy()
+  })
 })


### PR DESCRIPTION
add check on enter key when primary button is disabled

Change-type: minor
Signed-off-by: Andrea Rosci <andrear@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] I have rebuilt the README with `npm run build:docs`
- [x] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
