### PR TITLE
fix: build and bump typescript version

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "ts-jest": "^24.3.0",
     "ts-loader": "^5.3.0",
     "ts-node": "^8.0.2",
-    "typescript": "^3.5.2",
+    "typescript": "^3.8.2",
     "webpack": "^4.41.5",
     "zxcvbn": "^4.4.2"
   },

--- a/src/extra/Markdown/specsuite.json
+++ b/src/extra/Markdown/specsuite.json
@@ -307,137 +307,137 @@
   {
     "name": "xss: 36",
     "source": "ABC<div style=\"x\\x3Aexpression(javascript:alert(1)\">DEF",
-    "expected": "<p>ABC</p><div>DEF</div><p></p>"
+    "expected": "<p>ABC</p><div>DEF<p></p>\n</div>"
   },
   {
     "name": "xss: 37",
     "source": "ABC<div style=\"x:expression\\x5C(javascript:alert(1)\">DEF",
-    "expected": "<p>ABC</p><div>DEF</div><p></p>"
+    "expected": "<p>ABC</p><div>DEF<p></p>\n</div>"
   },
   {
     "name": "xss: 38",
     "source": "ABC<div style=\"x:expression\\x00(javascript:alert(1)\">DEF",
-    "expected": "<p>ABC</p><div>DEF</div><p></p>"
+    "expected": "<p>ABC</p><div>DEF<p></p>\n</div>"
   },
   {
     "name": "xss: 39",
     "source": "ABC<div style=\"x:exp\\x00ression(javascript:alert(1)\">DEF",
-    "expected": "<p>ABC</p><div>DEF</div><p></p>"
+    "expected": "<p>ABC</p><div>DEF<p></p>\n</div>"
   },
   {
     "name": "xss: 40",
     "source": "ABC<div style=\"x:exp\\x5Cression(javascript:alert(1)\">DEF",
-    "expected": "<p>ABC</p><div>DEF</div><p></p>"
+    "expected": "<p>ABC</p><div>DEF<p></p>\n</div>"
   },
   {
     "name": "xss: 41",
     "source": "ABC<div style=\"x:\\x0Aexpression(javascript:alert(1)\">DEF",
-    "expected": "<p>ABC</p><div>DEF</div><p></p>"
+    "expected": "<p>ABC</p><div>DEF<p></p>\n</div>"
   },
   {
     "name": "xss: 42",
     "source": "ABC<div style=\"x:\\x09expression(javascript:alert(1)\">DEF",
-    "expected": "<p>ABC</p><div>DEF</div><p></p>"
+    "expected": "<p>ABC</p><div>DEF<p></p>\n</div>"
   },
   {
     "name": "xss: 43",
     "source": "ABC<div style=\"x:\\xE3\\x80\\x80expression(javascript:alert(1)\">DEF",
-    "expected": "<p>ABC</p><div>DEF</div><p></p>"
+    "expected": "<p>ABC</p><div>DEF<p></p>\n</div>"
   },
   {
     "name": "xss: 44",
     "source": "ABC<div style=\"x:\\xE2\\x80\\x84expression(javascript:alert(1)\">DEF",
-    "expected": "<p>ABC</p><div>DEF</div><p></p>"
+    "expected": "<p>ABC</p><div>DEF<p></p>\n</div>"
   },
   {
     "name": "xss: 45",
     "source": "ABC<div style=\"x:\\xC2\\xA0expression(javascript:alert(1)\">DEF",
-    "expected": "<p>ABC</p><div>DEF</div><p></p>"
+    "expected": "<p>ABC</p><div>DEF<p></p>\n</div>"
   },
   {
     "name": "xss: 46",
     "source": "ABC<div style=\"x:\\xE2\\x80\\x80expression(javascript:alert(1)\">DEF",
-    "expected": "<p>ABC</p><div>DEF</div><p></p>"
+    "expected": "<p>ABC</p><div>DEF<p></p>\n</div>"
   },
   {
     "name": "xss: 47",
     "source": "ABC<div style=\"x:\\xE2\\x80\\x8Aexpression(javascript:alert(1)\">DEF",
-    "expected": "<p>ABC</p><div>DEF</div><p></p>"
+    "expected": "<p>ABC</p><div>DEF<p></p>\n</div>"
   },
   {
     "name": "xss: 48",
     "source": "ABC<div style=\"x:\\x0Dexpression(javascript:alert(1)\">DEF",
-    "expected": "<p>ABC</p><div>DEF</div><p></p>"
+    "expected": "<p>ABC</p><div>DEF<p></p>\n</div>"
   },
   {
     "name": "xss: 49",
     "source": "ABC<div style=\"x:\\x0Cexpression(javascript:alert(1)\">DEF",
-    "expected": "<p>ABC</p><div>DEF</div><p></p>"
+    "expected": "<p>ABC</p><div>DEF<p></p>\n</div>"
   },
   {
     "name": "xss: 50",
     "source": "ABC<div style=\"x:\\xE2\\x80\\x87expression(javascript:alert(1)\">DEF",
-    "expected": "<p>ABC</p><div>DEF</div><p></p>"
+    "expected": "<p>ABC</p><div>DEF<p></p>\n</div>"
   },
   {
     "name": "xss: 51",
     "source": "ABC<div style=\"x:\\xEF\\xBB\\xBFexpression(javascript:alert(1)\">DEF",
-    "expected": "<p>ABC</p><div>DEF</div><p></p>"
+    "expected": "<p>ABC</p><div>DEF<p></p>\n</div>"
   },
   {
     "name": "xss: 52",
     "source": "ABC<div style=\"x:\\x20expression(javascript:alert(1)\">DEF",
-    "expected": "<p>ABC</p><div>DEF</div><p></p>"
+    "expected": "<p>ABC</p><div>DEF<p></p>\n</div>"
   },
   {
     "name": "xss: 53",
     "source": "ABC<div style=\"x:\\xE2\\x80\\x88expression(javascript:alert(1)\">DEF",
-    "expected": "<p>ABC</p><div>DEF</div><p></p>"
+    "expected": "<p>ABC</p><div>DEF<p></p>\n</div>"
   },
   {
     "name": "xss: 54",
     "source": "ABC<div style=\"x:\\x00expression(javascript:alert(1)\">DEF",
-    "expected": "<p>ABC</p><div>DEF</div><p></p>"
+    "expected": "<p>ABC</p><div>DEF<p></p>\n</div>"
   },
   {
     "name": "xss: 55",
     "source": "ABC<div style=\"x:\\xE2\\x80\\x8Bexpression(javascript:alert(1)\">DEF",
-    "expected": "<p>ABC</p><div>DEF</div><p></p>"
+    "expected": "<p>ABC</p><div>DEF<p></p>\n</div>"
   },
   {
     "name": "xss: 56",
     "source": "ABC<div style=\"x:\\xE2\\x80\\x86expression(javascript:alert(1)\">DEF",
-    "expected": "<p>ABC</p><div>DEF</div><p></p>"
+    "expected": "<p>ABC</p><div>DEF<p></p>\n</div>"
   },
   {
     "name": "xss: 57",
     "source": "ABC<div style=\"x:\\xE2\\x80\\x85expression(javascript:alert(1)\">DEF",
-    "expected": "<p>ABC</p><div>DEF</div><p></p>"
+    "expected": "<p>ABC</p><div>DEF<p></p>\n</div>"
   },
   {
     "name": "xss: 58",
     "source": "ABC<div style=\"x:\\xE2\\x80\\x82expression(javascript:alert(1)\">DEF",
-    "expected": "<p>ABC</p><div>DEF</div><p></p>"
+    "expected": "<p>ABC</p><div>DEF<p></p>\n</div>"
   },
   {
     "name": "xss: 59",
     "source": "ABC<div style=\"x:\\x0Bexpression(javascript:alert(1)\">DEF",
-    "expected": "<p>ABC</p><div>DEF</div><p></p>"
+    "expected": "<p>ABC</p><div>DEF<p></p>\n</div>"
   },
   {
     "name": "xss: 60",
     "source": "ABC<div style=\"x:\\xE2\\x80\\x81expression(javascript:alert(1)\">DEF",
-    "expected": "<p>ABC</p><div>DEF</div><p></p>"
+    "expected": "<p>ABC</p><div>DEF<p></p>\n</div>"
   },
   {
     "name": "xss: 61",
     "source": "ABC<div style=\"x:\\xE2\\x80\\x83expression(javascript:alert(1)\">DEF",
-    "expected": "<p>ABC</p><div>DEF</div><p></p>"
+    "expected": "<p>ABC</p><div>DEF<p></p>\n</div>"
   },
   {
     "name": "xss: 62",
     "source": "ABC<div style=\"x:\\xE2\\x80\\x89expression(javascript:alert(1)\">DEF",
-    "expected": "<p>ABC</p><div>DEF</div><p></p>"
+    "expected": "<p>ABC</p><div>DEF<p></p>\n</div>"
   },
   {
     "name": "xss: 63",

--- a/src/unstable/components/Form/widgets/PasswordWidget.tsx
+++ b/src/unstable/components/Form/widgets/PasswordWidget.tsx
@@ -39,7 +39,9 @@ export interface PasswordStrengthProps {
 }
 
 const PasswordStrength = ({ password }: PasswordStrengthProps) => {
-	const [strengthScore, setStrengthScore] = React.useState();
+	const [strengthScore, setStrengthScore] = React.useState<
+		number | undefined
+	>();
 
 	React.useEffect(() => {
 		// @ts-ignore If you wish to show a stength meter, you need to load and set `zxcvbn` to a window variable by yourself.


### PR DESCRIPTION
fix build null index error and bump typescript version

Change-type: patch
See: https://www.typescriptlang.org/docs/handbook/interfaces.html#indexable-types
Signed-off-by: Andrea Rosci <andrear@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have rebuilt the README with `npm run build:docs`
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
