### PR TITLE
Add onPageChange callback to table component 

### DIFF
--- a/README.md
+++ b/README.md
@@ -757,6 +757,7 @@ cause a re-render of the component and will not be reflected on the table.
 | `onCheck`    | `(checkedItems: T[]) => string` | - | - | If provided, each row will begin with a checkbox. This function is called with every checked row every time a checkbox is toggled on or off. This property requires that you have provided a `rowKey` property |
 | `onRowClick`    | `(row: T, event: Event) => void` | - | - | A function that is called when a row is clicked. This property requires that you have provided a `rowKey` property |
 | `onSort`    | `(sort: TableSortOptions<T>) => void` | - | - | A function that is called when a column is sorted |
+| `onPageChange`    | `(page: number) => void` | - | - | A function that is called when the page is incremented, decremented and reset |
 | `sort`    | `TableSortOptions<T>` | - | - | sort options to be used both as a default sort, and on subsequent renders if the passed sort changes |
 | `rowAnchorAttributes`    | `object` | - | - | Attributes to pass to the anchor element used in a row |
 | `rowCheckboxAttributes`    | `object` | - | - | Attributes to pass to the checkbox element used in a row |

--- a/src/components/Table/README.md
+++ b/src/components/Table/README.md
@@ -56,6 +56,7 @@ cause a re-render of the component and will not be reflected on the table.
 | `onCheck`    | `(checkedItems: T[]) => string` | - | - | If provided, each row will begin with a checkbox. This function is called with every checked row every time a checkbox is toggled on or off. This property requires that you have provided a `rowKey` property |
 | `onRowClick`    | `(row: T, event: Event) => void` | - | - | A function that is called when a row is clicked. This property requires that you have provided a `rowKey` property |
 | `onSort`    | `(sort: TableSortOptions<T>) => void` | - | - | A function that is called when a column is sorted |
+| `onPageChange`    | `(page: number) => void` | - | - | A function that is called when the page is incremented, decremented and reset |
 | `sort`    | `TableSortOptions<T>` | - | - | sort options to be used both as a default sort, and on subsequent renders if the passed sort changes |
 | `rowAnchorAttributes`    | `object` | - | - | Attributes to pass to the anchor element used in a row |
 | `rowCheckboxAttributes`    | `object` | - | - | Attributes to pass to the checkbox element used in a row |

--- a/src/components/Table/index.tsx
+++ b/src/components/Table/index.tsx
@@ -396,16 +396,24 @@ class Table<T> extends React.Component<TableProps<T>, TableState<T>> {
 		}
 	};
 
+	public setPage = (change: any) => {
+		if (this.props.onPageChange) {
+			this.props.onPageChange(change);
+		}
+
+		this.setState({ page: change });
+	};
+
 	public resetPager = () => {
-		this.setState({ page: 0 });
+		this.setPage(0);
 	};
 
 	public incrementPage = () => {
-		this.setState({ page: this.state.page + 1 });
+		this.setPage(this.state.page + 1);
 	};
 
 	public decrementPage = () => {
-		this.setState({ page: this.state.page - 1 });
+		this.setPage(this.state.page - 1);
 	};
 
 	public render() {
@@ -571,6 +579,7 @@ export interface TableProps<T> {
 	onCheck?: (checkedItems: T[]) => void;
 	onRowClick?: (row: T, event: React.MouseEvent<HTMLAnchorElement>) => void;
 	onSort?: (sort: TableSortOptions<T>) => void;
+	onPageChange?: (page: number) => void;
 	sort?: TableSortOptions<T>;
 	rowAnchorAttributes?: React.AnchorHTMLAttributes<HTMLAnchorElement>;
 	rowCheckboxAttributes?: CheckboxProps;

--- a/src/components/Table/story.js
+++ b/src/components/Table/story.js
@@ -89,6 +89,20 @@ class HOC extends React.Component {
 
 storiesOf('Core/Table', module)
   .addDecorator(withReadme(Readme))
+  .add('Pager callback', () => {
+    return (
+      <Box m={3}>
+        <Table
+          columns={columns}
+          data={PokeDex}
+          usePager
+          pagerPosition='both'
+          itemsPerPage={3}
+          onPageChange={e => console.log('update!', e)}
+        />
+      </Box>
+    )
+  })
   .add('Standard', () => {
     return (
       <Box m={3}>


### PR DESCRIPTION
This Pr adds callbacks on the table component when using the pager. For example, this way the user can update the table data with API requests.

Change-type: patch 

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] I have rebuilt the README with `npm run build:docs`
- [x] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [x] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
