### PR TITLE
Make the theme object the source of the exported Theme interface

### DIFF
--- a/src/common-types.ts
+++ b/src/common-types.ts
@@ -10,27 +10,11 @@ import {
 	SpaceProps,
 	WidthProps,
 } from 'styled-system';
+import { Theme } from './theme';
 
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 
-export interface Theme {
-	breakpoints: number[];
-	space: number[];
-	fontSizes: number[];
-	weights: number[];
-	font: string;
-	monospace: string;
-	lineHeight: number;
-	colors: {
-		[key: string]: {
-			main: string;
-			light?: string;
-			dark?: string;
-			semilight?: string;
-		};
-	};
-	radius: number;
-}
+export { Theme } from './theme';
 
 export interface ThemedDefaultProps extends DefaultProps {
 	theme: Theme;

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,4 +1,5 @@
 import { px } from 'styled-system';
+import { Omit } from './common-types';
 
 const primary = '#00AEEF';
 const secondary = '#2A506F';
@@ -9,6 +10,13 @@ const danger = '#FF423D';
 const warning = '#FCA321';
 const success = '#1AC135';
 const info = '#1496E1';
+
+interface ColorVariants {
+	main: string;
+	light?: string;
+	dark?: string;
+	semilight?: string;
+}
 
 const colors = {
 	primary: {
@@ -117,7 +125,7 @@ export const titleFont = `CircularStd, Arial, sans-serif`;
 export const monospace = `'Ubuntu Mono', 'Courier New', monospace`;
 export const lineHeight = 1.5;
 
-export default {
+const theme = {
 	breakpoints,
 	space,
 	fontSizes,
@@ -307,3 +315,9 @@ export default {
 		},
 	},
 };
+
+export default theme;
+
+export interface Theme extends Omit<typeof theme, 'colors'> {
+	colors: Record<string, ColorVariants>;
+}


### PR DESCRIPTION
This properly exposes the props that were missing
from the currently exported interface, so that we can
override all the theme settings. Moreover we will no
longer need to maintain a separate Theme interface.

Change-type: minor
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

<!-- You can remove tags that do not apply. -->
Connects-to: # <!-- waffle convention to track a PR's status through its connected, open issue -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->
Change-type: major|minor|patch <!-- The change type of this PR -->

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have rebuilt the README with `npm run build:docs`
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
