### PR TITLE
Make value and onChange optional for Search to allow uncontrolled

### DIFF
--- a/src/components/Input/spec.js.snap
+++ b/src/components/Input/spec.js.snap
@@ -7,10 +7,10 @@ exports[`Input renders correctly 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  padding: 11px;
   outline: none;
   background: transparent;
   color: inherit;
+  padding: 11px;
   font-weight: 400;
   margin: 0;
   border: 1px solid #DDE1f0;

--- a/src/components/Search/index.tsx
+++ b/src/components/Search/index.tsx
@@ -65,8 +65,8 @@ export interface InternalSearchProps extends DefaultProps {
 	dark?: boolean;
 	disabled?: boolean;
 	placeholder?: string;
-	value: string;
-	onChange: (value: any) => void;
+	value?: string;
+	onChange?: (value: any) => void;
 }
 
 export type SearchProps = InternalSearchProps & RenditionSystemProps;

--- a/src/components/Select/spec.js.snap
+++ b/src/components/Select/spec.js.snap
@@ -122,10 +122,10 @@ exports[`Select component should match the stored snapshot 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  padding: 11px;
   outline: none;
   background: transparent;
   color: inherit;
+  padding: 11px;
   font-weight: 400;
   margin: 0;
   border: 1px solid #DDE1f0;

--- a/src/components/Textarea/spec.js.snap
+++ b/src/components/Textarea/spec.js.snap
@@ -18,10 +18,10 @@ exports[`Textarea component should match the stored snapshot 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  padding: 11px;
   outline: none;
   background: transparent;
   color: inherit;
+  padding: 11px;
   font-weight: 400;
   margin: 0;
   border: 1px solid #DDE1f0;

--- a/src/unstable/components/Form/spec.js.snap
+++ b/src/unstable/components/Form/spec.js.snap
@@ -59,10 +59,10 @@ exports[`Form component should match the stored snapshot 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  padding: 11px;
   outline: none;
   background: transparent;
   color: inherit;
+  padding: 11px;
   font-weight: 400;
   margin: 0;
   border: 1px solid #DDE1f0;

--- a/src/unstable/components/JellyForm/spec.js.snap
+++ b/src/unstable/components/JellyForm/spec.js.snap
@@ -40,10 +40,10 @@ exports[`JellyForm component should match the stored snapshot 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  padding: 11px;
   outline: none;
   background: transparent;
   color: inherit;
+  padding: 11px;
   font-weight: 400;
   margin: 0;
   border: 1px solid #DDE1f0;


### PR DESCRIPTION
If integrating with Algolia for example, the input is controlled by
the Algolia script and the input should remain uncontrolled

Change-type: patch
Signed-off-by: Stevche Radevski <stevche@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have rebuilt the README with `npm run build:docs`
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
