### PR TITLE
Provider: Type the theme property as deep partial

### DIFF
--- a/src/components/Provider/index.tsx
+++ b/src/components/Provider/index.tsx
@@ -1,4 +1,5 @@
 import { Grommet } from 'grommet';
+import { PartialDeep } from 'lodash/index';
 import merge from 'lodash/merge';
 import * as React from 'react';
 import styled from 'styled-components';
@@ -33,7 +34,7 @@ const Provider = ({ theme, ...props }: ThemedProvider) => {
 };
 
 export interface ThemedProvider extends DefaultProps {
-	theme?: Partial<Theme>;
+	theme?: PartialDeep<Theme>;
 }
 
 export default Provider;

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -192,13 +192,13 @@ const theme = {
 			`,
 		},
 		input: {
-			weight: 400,
+			weight: 400 as string | number,
 		},
 	},
 	button: {
 		height: '38px',
 		font: {
-			weight: 500,
+			weight: 500 as string | number,
 		},
 		border: {
 			width: '1px',


### PR DESCRIPTION
Also allows allow setting string values to the input & button weight theme properties (for strings like `normal`).

Change-type: patch
See: https://github.com/balena-io/balena-ui/pull/3636
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have rebuilt the README with `npm run build:docs`
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
