### PR TITLE
fix: internal nullable prop

### DIFF
--- a/src/components/Steps/index.tsx
+++ b/src/components/Steps/index.tsx
@@ -105,7 +105,7 @@ const StepIcon = ({ ordered, status, active, index }: StepIconProps) => {
 	);
 };
 
-export const Step = ({
+const StepBase = ({
 	ordered,
 	active,
 	index,
@@ -135,6 +135,8 @@ export const Step = ({
 		</Flex>
 	);
 };
+
+export const Step = StepBase as React.FunctionComponent<StepProps>;
 
 const FramelessSteps = ({
 	ordered,


### PR DESCRIPTION
set index as a nullable internal prop on Step component

Change-type: patch
Signed-off-by: Andrea Rosci <andrear@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have rebuilt the README with `npm run build:docs`
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
