### PR TITLE
fix: object filters

### DIFF
--- a/src/common-types.ts
+++ b/src/common-types.ts
@@ -38,7 +38,7 @@ export type ResponsiveStyle = string | number | Array<string | number>;
 export interface DefaultProps extends React.DOMAttributes<HTMLElement> {
 	// React-specific Attributes
 	defaultChecked?: boolean;
-	defaultValue?: string | number | string[];
+	defaultValue?: string | number | ReadonlyArray<string>;
 	suppressContentEditableWarning?: boolean;
 
 	// Standard HTML Attributes

--- a/src/components/Filters/index.tsx
+++ b/src/components/Filters/index.tsx
@@ -154,7 +154,7 @@ class Filters extends React.Component<FiltersProps, FiltersState> {
 	}
 
 	public addFilter(edit: EditModel[]) {
-		const newFilter = SchemaSieve.createFilter(this.props.schema, edit);
+		const newFilter = SchemaSieve.createFilter(this.state.schema, edit);
 		const currentFilters: JSONSchema6[] = !!this.state.editingFilter
 			? this.state.filters.map((filter) =>
 					filter.$id === this.state.editingFilter ? newFilter : filter,


### PR DESCRIPTION
replace schema with flat schema to match object filters properties

Depends-on: #1120 
Change-type: patch
Signed-off-by: Andrea Rosci <andrear@balena.io>


Description: 

On the  constructor of the component we run the `flatSchama` function on the schema prop to flat it. Then we use it to match the correct property on the `createFilter`function. At the moment all the filters object that does not have a `description: 'key'` `description: 'value'` will not be correctly represented on the `Summary` component.

Current: 
<img width="678" alt="Screenshot 2020-06-02 at 18 35 02" src="https://user-images.githubusercontent.com/7238159/83545677-d37cab00-a4ff-11ea-86a5-adb395cc3928.png">

Updated:
<img width="684" alt="Screenshot 2020-06-02 at 18 34 40" src="https://user-images.githubusercontent.com/7238159/83545703-daa3b900-a4ff-11ea-8d27-85d3d9ae8d1e.png">



---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have rebuilt the README with `npm run build:docs`
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
