### PR TITLE
Add optional createFullTextSearchFilter prop to Filters component

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,8 @@ A view has the following properties:
 | `renderMode` | <code>string &#124; string[]</code> | - | - | Controls which parts of the `Filters` interface are displayed. One of `all`, `add`, `search`, `views`, `summary`, or an array containing any of these values |
 | `dark`    | `boolean` | -         | -          | If true, Set the `Filters` component against a dark background |
 | `compact`    | `boolean[]` | -         | -          | Accept a boolean for each rendition breakpoint. If true remove `Filters` labels  |
+| `createFullTextSearchFilter` | `(filterTitle: string, schema: JSONSchema6, term?: string) => JSONSchema6` | - | - | Optional callback method to create a full text search filter for the given schema and search term |
+
 ### Fixed
 
 Displays an element with a [`fixed`](https://developer.mozilla.org/en-US/docs/Web/CSS/position#fixed) position.

--- a/src/components/Filters/README.md
+++ b/src/components/Filters/README.md
@@ -93,3 +93,4 @@ A view has the following properties:
 | `renderMode` | <code>string &#124; string[]</code> | - | - | Controls which parts of the `Filters` interface are displayed. One of `all`, `add`, `search`, `views`, `summary`, or an array containing any of these values |
 | `dark`    | `boolean` | -         | -          | If true, Set the `Filters` component against a dark background |
 | `compact`    | `boolean[]` | -         | -          | Accept a boolean for each rendition breakpoint. If true remove `Filters` labels  |
+| `createFullTextSearchFilter` | `(filterTitle: string, schema: JSONSchema6, term?: string) => JSONSchema6` | - | - | Optional callback method to create a full text search filter for the given schema and search term |

--- a/src/components/Filters/SchemaSieve.spec.js
+++ b/src/components/Filters/SchemaSieve.spec.js
@@ -1054,56 +1054,49 @@ describe('SchemaSieve', () => {
     })
   })
 
-  describe('.upsertFullTextSearch()', () => {
-    const collection = [
-      {
-        test: 'abcde',
-        description: 'maecenas convallis aliquet arcu sed faucibus'
-      },
-      {
-        test: 'fghij',
-        description: 'lorem ipsum dolor sit amet'
-      }
-    ]
-
-    it('should create and append a new filter if a search filter does not already exist', () => {
-      const schema = {
-        type: 'object',
-        properties: {
-          test: { type: 'string' },
-          description: { type: 'string' }
+  describe('.upsertFilter()', () => {
+    it('should append a new filter if a matching filter does not already exist', () => {
+      const existingFilters = [
+        {
+          $id: 'test1',
+          title: 'Filter A'
         }
+      ]
+      const filter = {
+        $id: 'test2',
+        title: 'Filter B'
       }
 
-      const term = 'lorem'
+      const filters = sieve.upsertFilter(
+        filter,
+        { title: filter.title },
+        existingFilters
+      )
 
-      const filters = sieve.upsertFullTextSearch(schema, [], term)
-
-      expect(filters).toHaveLength(1)
-      expect(sieve.filter(filters, collection)).toHaveLength(1)
-      expect(sieve.filter(filters, collection)).toEqual([collection[1]])
-
-      expect(filters).toHaveLength(1)
+      expect(filters).toHaveLength(2)
+      expect(filters[1].title).toBe(filter.title)
     })
 
-    it('should modify an existing search filter', () => {
-      const schema = {
-        type: 'object',
-        properties: {
-          test: { type: 'string' },
-          description: { type: 'string' }
+    it('should modify an existing filter if found', () => {
+      const existingFilters = [
+        {
+          $id: 'test1',
+          title: 'Filter A'
         }
+      ]
+      const filter = {
+        ...existingFilters[0],
+        anyOf: []
       }
 
-      const existingFilters = [sieve.createFullTextSearchFilter(schema, 'test')]
-
-      const term = 'lorem'
-
-      const filters = sieve.upsertFullTextSearch(schema, existingFilters, term)
+      const filters = sieve.upsertFilter(
+        filter,
+        { title: filter.title },
+        existingFilters
+      )
 
       expect(filters).toHaveLength(1)
-      expect(sieve.filter(filters, collection)).toHaveLength(1)
-      expect(sieve.filter(filters, collection)).toEqual([collection[1]])
+      expect(filters[0]).toEqual(filter)
     })
   })
 

--- a/src/components/Filters/SchemaSieve.ts
+++ b/src/components/Filters/SchemaSieve.ts
@@ -2,6 +2,7 @@ import Ajv from 'ajv';
 import ajvKeywords from 'ajv-keywords';
 import metaSchema6 from 'ajv/lib/refs/json-schema-draft-06.json';
 import { JSONSchema6 } from 'json-schema';
+import { ListIterateeCustom } from 'lodash';
 import cloneDeep from 'lodash/cloneDeep';
 import defaults from 'lodash/defaults';
 import every from 'lodash/every';
@@ -88,21 +89,20 @@ export const createFullTextSearchFilter = (
 	return filter as JSONSchema6;
 };
 
-// Update or insert a full text search filter into an array of filters
-export const upsertFullTextSearch = (
-	schema: JSONSchema6,
+// Update or insert a filter into an array of filters
+export const upsertFilter = (
+	filter: JSONSchema6,
+	predicate: ListIterateeCustom<JSONSchema6, boolean>,
 	filters: JSONSchema6[] = [],
-	term: string,
 ) => {
-	const searchFilter = createFullTextSearchFilter(schema, term);
-	const existingSearchIndex = findIndex(filters, { title: FULL_TEXT_SLUG });
+	const existingFilterIndex = findIndex(filters, predicate);
 
-	if (existingSearchIndex > -1) {
-		return filters.map((filter, i) =>
-			existingSearchIndex === i ? searchFilter : filter,
+	if (existingFilterIndex > -1) {
+		return filters.map((existingFilter, i) =>
+			existingFilterIndex === i ? filter : existingFilter,
 		);
 	}
-	return [...filters, searchFilter as JSONSchema6];
+	return [...filters, filter as JSONSchema6];
 };
 
 // Removes a full text search filter from an array of filters

--- a/src/components/Filters/index.tsx
+++ b/src/components/Filters/index.tsx
@@ -243,17 +243,29 @@ class Filters extends React.Component<FiltersProps, FiltersState> {
 	public setSimpleSearch(term: string) {
 		this.setState(
 			(prevState) => {
-				const newFilters = term
-					? SchemaSieve.upsertFullTextSearch(
-							this.state.schema,
-							prevState.filters,
-							term,
-					  )
-					: SchemaSieve.removeFullTextSearch(prevState.filters);
+				const { createFullTextSearchFilter } = this.props;
 
+				if (term) {
+					const searchFilter = createFullTextSearchFilter
+						? createFullTextSearchFilter(
+								SchemaSieve.FULL_TEXT_SLUG,
+								this.state.schema,
+								term,
+						  )
+						: SchemaSieve.createFullTextSearchFilter(this.state.schema, term);
+					const filters = SchemaSieve.upsertFilter(
+						searchFilter,
+						{ title: SchemaSieve.FULL_TEXT_SLUG },
+						prevState.filters,
+					);
+					return {
+						searchString: term,
+						filters,
+					};
+				}
 				return {
 					searchString: term,
-					filters: newFilters,
+					filters: SchemaSieve.removeFullTextSearch(prevState.filters),
 				};
 			},
 			() => this.emitFilterUpdate(),
@@ -435,6 +447,11 @@ export interface FiltersProps extends DefaultProps {
 	renderMode?: FilterRenderMode | FilterRenderMode[];
 	dark?: boolean;
 	compact?: boolean[];
+	createFullTextSearchFilter?: (
+		filterTitle: string,
+		schema: JSONSchema6,
+		term?: string,
+	) => JSONSchema6;
 }
 
 export default Filters;


### PR DESCRIPTION
This prop allows the creation of a full text search filter to be delegated to the parent component.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

---

See: [Jellyfish: Add support for full text search in views](https://github.com/product-os/jellyfish/pull/4013)

Jellyfish now has a different way of generating a full text search query (see [this method](https://github.com/product-os/jellyfish/blob/3af1067b4a1993dc822e69409351f0808f79bdcf/lib/ui-components/services/helpers.js#L359-L404)). To accommodate this but still allow Jellyfish to make use of the search box in Rendition's `Filters` component, I'd like to add a new option prop, `createFullTextSearchFilter`, that can be used to override the default filter-creation.

##### Contributor checklist
- [x] I have rebuilt the README with `npm run build:docs`
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
