### PR TITLE
Don't load SSP and Ubuntu mono if custom font is provided

### DIFF
--- a/src/components/Provider/index.tsx
+++ b/src/components/Provider/index.tsx
@@ -16,15 +16,18 @@ const Base = styled(Grommet)`
 `;
 
 const Provider = ({ theme, ...props }: ThemedProvider) => {
+	const isDefaultFont = !theme?.font;
 	const providerTheme = merge(defaultTheme, theme);
 	return (
 		<BreakpointProvider breakpoints={providerTheme.breakpoints}>
-			<Helmet>
-				<link
-					href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:ital,wght@0,400;0,600;1,400&family=Ubuntu+Mono:wght@400;700&display=fallback"
-					rel="stylesheet"
-				/>
-			</Helmet>
+			{!isDefaultFont && (
+				<Helmet>
+					<link
+						href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:ital,wght@0,400;0,600;1,400&family=Ubuntu+Mono:wght@400;700&display=fallback"
+						rel="stylesheet"
+					/>
+				</Helmet>
+			)}
 			<Base theme={providerTheme} {...props} />
 		</BreakpointProvider>
 	);


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Stevche Radevski <stevche@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have rebuilt the README with `npm run build:docs`
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
