### PR TITLE
Add: number match on text search

### DIFF
--- a/src/components/Filters/SchemaSieve.spec.js
+++ b/src/components/Filters/SchemaSieve.spec.js
@@ -1023,16 +1023,28 @@ describe('SchemaSieve', () => {
       const schema = {
         type: 'object',
         properties: {
-          text: { type: 'string' }
+          text: { type: 'string' },
+          number: { type: 'number' }
         }
       }
 
       const filter = sieve.createFullTextSearchFilter(schema, 'test')
-
       expect(ajv.compile(filter)).not.toThrow()
     })
 
-    it('should work when "type" is an array', () => {
+    it('should create a valid JSON schema with number type', () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          number: { type: 'number' }
+        }
+      }
+
+      const filter = sieve.createFullTextSearchFilter(schema, '5')
+      expect(ajv.compile(filter)).not.toThrow()
+    })
+
+    it('should work when "type" is string or an array of strings', () => {
       const schema = {
         type: 'object',
         properties: {
@@ -1047,8 +1059,36 @@ describe('SchemaSieve', () => {
       }
 
       const filter = sieve.createFullTextSearchFilter(schema, 'test')
-
       expect(ajv.validate(filter, value)).toBe(true)
+    })
+
+    it('should work when "type" is number or an array of numbers', () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          foo: { type: ['number', 'null'] },
+          bar: { type: 'number' },
+          foobar: { type: 'string' }
+        }
+      }
+
+      const value = [{ baz: 55 }, { bar: 8 }, { foobar: 'test-8' }]
+
+      const filter = sieve.createFullTextSearchFilter(schema, '8')
+      expect(sieve.filter(filter, value)).toHaveLength(2)
+    })
+
+    it('should work when "type" is number or an array of numbers', () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          foo: { type: ['number', 'null'] },
+          bar: { type: 'number' }
+        }
+      }
+
+      const filter = sieve.createFullTextSearchFilter(schema, '9')
+      expect(ajv.validate(filter, [55, 9])).toBe(true)
     })
   })
 

--- a/src/components/Filters/story.js
+++ b/src/components/Filters/story.js
@@ -78,7 +78,7 @@ const schema = {
       type: 'object',
       properties: {
         Height: {
-          type: 'number'
+          type: ['number', null]
         },
         Weight: {
           type: 'number'


### PR DESCRIPTION
add the possibility to filter also fields with type number from the search bar

Change-type: patch
Signed-off-by: Andrea Rosci <andrear@balena.io>

this is a PR that has been made to add the possibility to filter also the numeric fields from the search bar as shown in the image below:

<img width="990" alt="Screenshot 2020-07-14 at 18 18 11" src="https://user-images.githubusercontent.com/7238159/87450559-eefacb80-c5fe-11ea-9456-497a541cc240.png">

<img width="868" alt="Screenshot 2020-08-11 at 14 47 31" src="https://user-images.githubusercontent.com/7238159/89899659-e89e4600-dbe2-11ea-890f-0add8256131b.png">

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have rebuilt the README with `npm run build:docs`
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
