### PR TITLE
Add: container obesrver to resize the terminal

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,6 +143,7 @@
     "react-simplemde-editor": "^4.1.1",
     "recompose": "0.26.0",
     "regex-parser": "^2.2.7",
+    "resize-observer": "^1.0.0",
     "sanitize-html": "^1.20.1",
     "styled-components": "^5.0.1",
     "styled-system": "^4.1.0",

--- a/src/extra/MarkdownEditor/defaultStyle.ts
+++ b/src/extra/MarkdownEditor/defaultStyle.ts
@@ -207,16 +207,16 @@ export default css`
 	}
 	.CodeMirror-scroll {
 		overflow: scroll !important;
-		margin-bottom: -30px;
-		margin-right: -30px;
-		padding-bottom: 30px;
+		margin-bottom: -50px;
+		margin-right: -50px;
+		padding-bottom: 50px;
 		height: 100%;
 		outline: 0;
 		position: relative;
 	}
 	.CodeMirror-sizer {
 		position: relative;
-		border-right: 30px solid transparent;
+		border-right: 50px solid transparent;
 	}
 	.CodeMirror-gutter-filler,
 	.CodeMirror-hscrollbar,
@@ -258,7 +258,7 @@ export default css`
 		height: 100%;
 		display: inline-block;
 		vertical-align: top;
-		margin-bottom: -30px;
+		margin-bottom: -50px;
 	}
 	.CodeMirror-gutter-wrapper {
 		position: absolute;
@@ -403,6 +403,14 @@ export default css`
 	span.CodeMirror-selectedtext {
 		background: 0 0;
 	}
+	.EasyMDEContainer {
+		display: block;
+	}
+	.EasyMDEContainer.sided--no-fullscreen {
+		display: flex;
+		flex-direction: row;
+		flex-wrap: wrap;
+	}
 	.CodeMirror {
 		box-sizing: border-box;
 		height: auto;
@@ -431,6 +439,12 @@ export default css`
 	}
 	.CodeMirror-sided {
 		width: 50% !important;
+	}
+	.CodeMirror-sided.sided--no-fullscreen {
+		border-right: none !important;
+		border-bottom-right-radius: 0;
+		position: relative;
+		flex: 1 1 auto;
 	}
 	.CodeMirror-placeholder {
 		opacity: 0.5;
@@ -528,6 +542,9 @@ export default css`
 		margin: 0;
 		padding: 0;
 	}
+	.editor-toolbar.sided--no-fullscreen {
+		width: 100%;
+	}
 	.editor-toolbar .easymde-dropdown,
 	.editor-toolbar button {
 		background: 0 0;
@@ -595,6 +612,9 @@ export default css`
 		color: #959694;
 		text-align: right;
 	}
+	.editor-statusbar.sided--no-fullscreen {
+		width: 100%;
+	}
 	.editor-statusbar span {
 		display: inline-block;
 		min-width: 4em;
@@ -635,6 +655,11 @@ export default css`
 	}
 	.editor-preview-active-side {
 		display: block;
+	}
+	.editor-preview-active-side.sided--no-fullscreen {
+		flex: 1 1 auto;
+		height: auto;
+		position: static;
 	}
 	.editor-preview-active {
 		display: block;


### PR DESCRIPTION
add observer to resize terminal on container resize event

Change-type: patch
Signed-off-by: Andrea Rosci <andrear@balena.io>

Unfortunately with the previous PR I didn't realize that I had brought regressions to the terminal. Handling instances of the tty object does not work as expected as the new `Addons API` still has some bugs. I open this PR to add:
1) Terminal sizing based on the parent component resize event and not the window resize event.    
2) Save the `fitAddon` instance within the `ttyInstance` in order to be able to recover it when necessary.

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have rebuilt the README with `npm run build:docs`
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
