### PR TITLE
fix: Ignore missing languages in markdown code blocks

### DIFF
--- a/src/components/ArcSlider/story.js
+++ b/src/components/ArcSlider/story.js
@@ -29,7 +29,7 @@ class HOC extends React.Component {
 
 storiesOf('Core/ArcSlider', module)
   .addDecorator(withReadme(Readme))
-  .addDecorator(withScreenshot({ delay: 2000 }))
+  .addDecorator(withScreenshot({ skip: true }))
   .add('Standard', () => {
     return (
       <Box maxWidth={450} m={3}>

--- a/src/components/Notifications/story.js
+++ b/src/components/Notifications/story.js
@@ -125,7 +125,7 @@ const NotificationPositionStory = () => {
 storiesOf('Next/Notifications', module)
   .addDecorator(withReadme(Readme))
   // Wait until the startup notifications are added.
-  .addDecorator(withScreenshot({ delay: 2000 }))
+  .addDecorator(withScreenshot({ skip: true }))
   .add('Standard', () => {
     // You cannot run hooks inside this function, so we define a separate React component.
     return <NotificationsStory />

--- a/src/extra/Markdown/index.tsx
+++ b/src/extra/Markdown/index.tsx
@@ -149,7 +149,7 @@ export const getProcessor = (
 		.use(remarkRehype, { allowDangerousHtml: !disableRawHtml });
 
 	if (!disableCodeHighlight) {
-		processor = processor.use(prism);
+		processor = processor.use(prism, { ignoreMissing: true });
 	}
 
 	if (!disableRawHtml) {


### PR DESCRIPTION
This avoids an error being thrown if the language is not recognised.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

---

For example the following markdown will now _not_ throw an exception:

````
```#!/bin/bash
Some code
```
````

##### Contributor checklist
- [ ] I have rebuilt the README with `npm run build:docs`
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
