### PR TITLE
fix: Fall back to schema default for value in JsonSchemaRenderer

### DIFF
--- a/src/extra/JsonSchemaRenderer/examples.ts
+++ b/src/extra/JsonSchemaRenderer/examples.ts
@@ -70,6 +70,18 @@ const jsonDataExamples = {
 			'ui:widget': 'Txt',
 		},
 	},
+	'A default value': {
+		value: null,
+		schema: {
+			type: ['string', 'null'],
+			default: 'The default value',
+			title: 'Field title',
+			description: 'Field description',
+		},
+		uiSchema: {
+			'ui:widget': 'Txt',
+		},
+	},
 	'An array of strings field': {
 		value: ['first item', 'second item', 'third item'],
 		schema: {

--- a/src/extra/JsonSchemaRenderer/index.tsx
+++ b/src/extra/JsonSchemaRenderer/index.tsx
@@ -18,8 +18,16 @@ import widgets, {
 import { transformUiSchema } from './widgets/widget-util';
 import { Value, JSONSchema, UiSchema, Format } from './types';
 
-export const getValue = (value?: Value, uiSchema?: UiSchema) => {
-	return get(uiSchema, 'ui:value', value);
+export const getValue = (
+	value?: Value,
+	schema?: JSONSchema,
+	uiSchema?: UiSchema,
+) => {
+	const calculatedValue = get(uiSchema, 'ui:value', value);
+	// Fall back to schema's default value if value is undefined
+	return calculatedValue !== undefined
+		? calculatedValue
+		: get(schema, 'default');
 };
 
 const widgetWrapperUiOptionKeys = keys(WidgetWrapperUiOptions);
@@ -118,7 +126,7 @@ export const JsonSchemaRenderer = ({
 		uiSchema,
 		extraContext,
 	});
-	const processedValue = getValue(value, processedUiSchema);
+	const processedValue = getValue(value, schema, processedUiSchema);
 
 	if (processedValue === undefined || processedValue === null) {
 		return null;

--- a/src/extra/JsonSchemaRenderer/spec.js.snap
+++ b/src/extra/JsonSchemaRenderer/spec.js.snap
@@ -1020,6 +1020,29 @@ exports[`JsonSchemaRenderer component A button widget 1`] = `
 </div>
 `;
 
+exports[`JsonSchemaRenderer component A default value 1`] = `
+.c0 {
+  font-family: 'Source Sans Pro',Helvetica,sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  font-family: 'Source Sans Pro',Helvetica,sans-serif;
+  font-size: 14px;
+  color: #2A506F;
+}
+
+<div
+  className="c0 c1"
+/>
+`;
+
 exports[`JsonSchemaRenderer component A drop-down button widget 1`] = `
 .c6 {
   display: inline-block;


### PR DESCRIPTION
If the UI schema doesn't define a value and the data value isn't defined either we fall back to the 'default' value defined in the schema (if it is defined).

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

---

##### Contributor checklist
- [ ] I have rebuilt the README with `npm run build:docs`
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [x] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
