### PR TITLE
fix: Use widget's display name to reference the widget

### DIFF
--- a/src/extra/JsonSchemaRenderer/widgets/ArrayWidget.tsx
+++ b/src/extra/JsonSchemaRenderer/widgets/ArrayWidget.tsx
@@ -33,6 +33,8 @@ const ArrayWidget: Widget = ({
 	);
 };
 
+ArrayWidget.displayName = 'Array';
+
 ArrayWidget.uiOptions = {
 	orientation: {
 		...UiOption.string,

--- a/src/extra/JsonSchemaRenderer/widgets/BadgeWidget.tsx
+++ b/src/extra/JsonSchemaRenderer/widgets/BadgeWidget.tsx
@@ -20,6 +20,8 @@ const BadgeWidget: Widget = ({
 	);
 };
 
+BadgeWidget.displayName = 'Badge';
+
 BadgeWidget.uiOptions = {
 	shade: UiOption.number,
 };

--- a/src/extra/JsonSchemaRenderer/widgets/ButtonGroupWidget.tsx
+++ b/src/extra/JsonSchemaRenderer/widgets/ButtonGroupWidget.tsx
@@ -40,6 +40,8 @@ const ButtonGroupWidget: Widget = ({
 	);
 };
 
+ButtonGroupWidget.displayName = 'ButtonGroup';
+
 ButtonGroupWidget.uiOptions = ButtonWidget.uiOptions;
 
 ButtonGroupWidget.supportedTypes = [JsonTypes.array];

--- a/src/extra/JsonSchemaRenderer/widgets/ButtonWidget.tsx
+++ b/src/extra/JsonSchemaRenderer/widgets/ButtonWidget.tsx
@@ -13,6 +13,8 @@ const ButtonWidget: Widget = ({
 	return <Button {...props}>{value.toString()}</Button>;
 };
 
+ButtonWidget.displayName = 'Button';
+
 ButtonWidget.uiOptions = {
 	href: UiOption.string,
 	target: {

--- a/src/extra/JsonSchemaRenderer/widgets/CheckboxWidget.tsx
+++ b/src/extra/JsonSchemaRenderer/widgets/CheckboxWidget.tsx
@@ -14,6 +14,8 @@ const CheckboxWidget: Widget = ({
 	return <Checkbox {...props} checked={Boolean(value)} onChange={noop} />;
 };
 
+CheckboxWidget.displayName = 'Checkbox';
+
 CheckboxWidget.uiOptions = {
 	label: UiOption.string,
 	reverse: UiOption.boolean,

--- a/src/extra/JsonSchemaRenderer/widgets/DropDownButtonWidget.tsx
+++ b/src/extra/JsonSchemaRenderer/widgets/DropDownButtonWidget.tsx
@@ -38,6 +38,8 @@ const DropDownButtonWidget: Widget = ({
 	);
 };
 
+DropDownButtonWidget.displayName = 'DropDownButton';
+
 DropDownButtonWidget.uiOptions = {
 	...ButtonWidget.uiOptions,
 	label: UiOption.string,

--- a/src/extra/JsonSchemaRenderer/widgets/HeadingWidget.tsx
+++ b/src/extra/JsonSchemaRenderer/widgets/HeadingWidget.tsx
@@ -20,6 +20,8 @@ const HeadingWidget: Widget = ({
 	return <HeadingComponent {...props}>{value.toString()}</HeadingComponent>;
 };
 
+HeadingWidget.displayName = 'Heading';
+
 HeadingWidget.uiOptions = {
 	size: {
 		...UiOption.number,

--- a/src/extra/JsonSchemaRenderer/widgets/HighlightedNameWidget.tsx
+++ b/src/extra/JsonSchemaRenderer/widgets/HighlightedNameWidget.tsx
@@ -21,6 +21,8 @@ const HighlightedNameWidget: Widget = ({
 	);
 };
 
+HighlightedNameWidget.displayName = 'HighlightedName';
+
 HighlightedNameWidget.uiOptions = {
 	bg: UiOption.string,
 	color: UiOption.string,

--- a/src/extra/JsonSchemaRenderer/widgets/ImgWidget.tsx
+++ b/src/extra/JsonSchemaRenderer/widgets/ImgWidget.tsx
@@ -33,6 +33,8 @@ ImgWidget.uiOptions = {
 	srcset: UiOption.string,
 };
 
+ImgWidget.displayName = 'Img';
+
 ImgWidget.supportedTypes = [JsonTypes.string];
 
 export default ImgWidget;

--- a/src/extra/JsonSchemaRenderer/widgets/LinkWidget.tsx
+++ b/src/extra/JsonSchemaRenderer/widgets/LinkWidget.tsx
@@ -22,6 +22,8 @@ const LinkWidget: Widget = ({
 	);
 };
 
+LinkWidget.displayName = 'Link';
+
 LinkWidget.uiOptions = {
 	blank: UiOption.boolean,
 	download: UiOption.string,

--- a/src/extra/JsonSchemaRenderer/widgets/ListWidget.tsx
+++ b/src/extra/JsonSchemaRenderer/widgets/ListWidget.tsx
@@ -36,6 +36,8 @@ const ListWidget: Widget = ({
 	);
 };
 
+ListWidget.displayName = 'List';
+
 ListWidget.uiOptions = {
 	truncate: UiOption.integer,
 	ordered: UiOption.boolean,

--- a/src/extra/JsonSchemaRenderer/widgets/MarkdownWidget.tsx
+++ b/src/extra/JsonSchemaRenderer/widgets/MarkdownWidget.tsx
@@ -12,6 +12,8 @@ const MarkdownWidget: Widget = ({
 	return <Markdown {...props}>{value.toString()}</Markdown>;
 };
 
+MarkdownWidget.displayName = 'Markdown';
+
 MarkdownWidget.supportedTypes = [JsonTypes.string];
 
 export default MarkdownWidget;

--- a/src/extra/JsonSchemaRenderer/widgets/MermaidWidget.tsx
+++ b/src/extra/JsonSchemaRenderer/widgets/MermaidWidget.tsx
@@ -12,6 +12,8 @@ const MermaidWidget: Widget = ({
 	return <Mermaid width="100%" {...props} value={value.toString()} />;
 };
 
+MermaidWidget.displayName = 'Mermaid';
+
 MermaidWidget.uiOptions = {};
 
 MermaidWidget.supportedTypes = [JsonTypes.string];

--- a/src/extra/JsonSchemaRenderer/widgets/ObjectWidget.tsx
+++ b/src/extra/JsonSchemaRenderer/widgets/ObjectWidget.tsx
@@ -34,6 +34,8 @@ const ObjectWidget: Widget = ({
 	);
 };
 
+ObjectWidget.displayName = 'Object';
+
 ObjectWidget.supportedTypes = [JsonTypes.object];
 
 export default ObjectWidget;

--- a/src/extra/JsonSchemaRenderer/widgets/TagWidget.tsx
+++ b/src/extra/JsonSchemaRenderer/widgets/TagWidget.tsx
@@ -13,6 +13,8 @@ const TagWidget: Widget = ({
 	return <Tag {...props} value={value.toString()} />;
 };
 
+TagWidget.displayName = 'Tag';
+
 TagWidget.uiOptions = {
 	operator: UiOption.boolean,
 	name: UiOption.string,

--- a/src/extra/JsonSchemaRenderer/widgets/TxtWidget.tsx
+++ b/src/extra/JsonSchemaRenderer/widgets/TxtWidget.tsx
@@ -46,6 +46,8 @@ const TxtWidget: Widget = ({
 	return <Component {...props}>{displayValue || ''}</Component>;
 };
 
+TxtWidget.displayName = 'Txt';
+
 TxtWidget.uiOptions = {
 	dtFormat: UiOption.string,
 	bold: UiOption.boolean,

--- a/src/extra/JsonSchemaRenderer/widgets/index.ts
+++ b/src/extra/JsonSchemaRenderer/widgets/index.ts
@@ -56,37 +56,36 @@ const allWidgets: WidgetLookup = {};
 	TagWidget,
 	TxtWidget,
 ].reduce((acc, widget) => {
-	const widgetName = widget.name.replace(/Widget$/, '');
 	const wrappedWidget = widget.uiOptions
 		? withOptionProps(widget.uiOptions)(widget)
 		: widget;
-	acc[widgetName] = wrappedWidget;
+	acc[widget.displayName] = wrappedWidget;
 	if (widget.supportedTypes) {
 		widget.supportedTypes.forEach((jsonType) => {
-			widgets[jsonType][widgetName] = wrappedWidget;
+			widgets[jsonType][widget.displayName] = wrappedWidget;
 		});
 	}
 	return acc;
 }, allWidgets);
 
-widgets.object.default = allWidgets.Object;
-widgets.string.default = allWidgets.Txt;
-widgets.null.default = allWidgets.Txt;
-widgets.integer.default = allWidgets.Txt;
-widgets.number.default = allWidgets.Txt;
-widgets.boolean.default = allWidgets.Txt;
-widgets.array.default = allWidgets.Array;
+widgets.object.default = allWidgets[ObjectWidget.displayName];
+widgets.string.default = allWidgets[TxtWidget.displayName];
+widgets.null.default = allWidgets[TxtWidget.displayName];
+widgets.integer.default = allWidgets[TxtWidget.displayName];
+widgets.number.default = allWidgets[TxtWidget.displayName];
+widgets.boolean.default = allWidgets[TxtWidget.displayName];
+widgets.array.default = allWidgets[ArrayWidget.displayName];
 widgets.default = {
-	default: allWidgets.Txt,
+	default: allWidgets[TxtWidget.displayName],
 };
 
 export const formatWidgetMap: {
 	[key: string]: Widget;
 } = {
-	markdown: allWidgets.Markdown,
-	mermaid: allWidgets.Mermaid,
-	email: allWidgets.Link,
-	uri: allWidgets.Link,
+	markdown: allWidgets[MarkdownWidget.displayName],
+	mermaid: allWidgets[MermaidWidget.displayName],
+	email: allWidgets[LinkWidget.displayName],
+	uri: allWidgets[LinkWidget.displayName],
 };
 
 export default widgets;

--- a/src/extra/JsonSchemaRenderer/widgets/widget-util.tsx
+++ b/src/extra/JsonSchemaRenderer/widgets/widget-util.tsx
@@ -24,6 +24,7 @@ export interface Widget {
 	(props: WidgetProps): JSX.Element | null;
 	uiOptions?: UiOptions;
 	supportedTypes?: string[];
+	displayName: string;
 }
 
 export function formatTimestamp(timestamp: string, uiSchema: UiSchema = {}) {
@@ -44,6 +45,7 @@ export function withOptionProps(uiOptions: UiOptions) {
 			return <Component {...props} {...extraProps} />;
 		};
 
+		wrapped.displayName = Component.displayName;
 		wrapped.uiOptions = Component.uiOptions;
 		wrapped.supportedTypes = Component.supportedTypes;
 		return wrapped;


### PR DESCRIPTION
Otherwise obfuscation causes problems in production code!

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

---

##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have rebuilt the README with `npm run build:docs`
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
