### PR TITLE
Specify tabs width and height to fix layout problems

### DIFF
--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -27,12 +27,15 @@ const ScrollWrapper = styled(GrommetTabs)<{
 	${(props) => {
 		if (props.compact) {
 			return `
-			& > div {
+				width: 100%;
+
+				& > div {
 					scroll-snap-type: x mandatory;
 					overflow-x: scroll;
 					display: flex;
 					flex-wrap: nowrap;
 				}
+
 				div[role=tabpanel] {
 					overflow-x: auto;
 				}

--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -8,7 +8,6 @@ import {
 export { TabProps, TabsProps } from 'grommet';
 import React from 'react';
 import asRendition from '../../asRendition';
-import { Flex } from '../Flex';
 
 interface InnerTabProps extends TabProps {
 	compact?: boolean;
@@ -24,6 +23,15 @@ const ScrollWrapper = styled(GrommetTabs)<{
 	compact?: boolean;
 }>`
 	position: relative;
+	display: flex;
+	align-items: stretch;
+	height: 100%;
+
+	div[role='tabpanel'] {
+		display: flex;
+		flex: 1;
+	}
+
 	${(props) => {
 		if (props.compact) {
 			return `
@@ -67,18 +75,16 @@ export const Tab = ({ compact, title, ...props }: InnerTabProps) => {
 
 const TabsBase = ({ children, compact = false, ...props }: InnerTabsProps) => {
 	return (
-		<Flex>
-			<ScrollWrapper justify="start" compact={compact} {...props}>
-				{React.Children.map(
-					children,
-					(tab: React.ReactElement<InnerTabProps>) => {
-						return React.cloneElement(tab, {
-							compact,
-						});
-					},
-				)}
-			</ScrollWrapper>
-		</Flex>
+		<ScrollWrapper justify="start" compact={compact} {...props}>
+			{React.Children.map(
+				children,
+				(tab: React.ReactElement<InnerTabProps>) => {
+					return React.cloneElement(tab, {
+						compact,
+					});
+				},
+			)}
+		</ScrollWrapper>
 	);
 };
 


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Stef Kors <stef@balena.io>

Change-type: patch

We need to specify a tab width, otherwise the tabs component won't spread out to full width.

(screenshots are illustrative, see committed screenshot for accurate colors)
## Before
<img width="539" alt="Screenshot 2020-09-23 at 15 04 52" src="https://user-images.githubusercontent.com/11800807/94025540-e66e0080-fdb8-11ea-928a-d7730d850c56.png">
## After
<img width="445" alt="Screenshot 2020-09-23 at 15 05 08" src="https://user-images.githubusercontent.com/11800807/94025569-ef5ed200-fdb8-11ea-989a-2606272f2be6.png">



---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have rebuilt the README with `npm run build:docs`
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
