### PR TITLE
feat: Add ColorWidget for JsonSchemaRenderer

### DIFF
--- a/src/extra/JsonSchemaRenderer/JsonSchemaRendererPlayground/index.tsx
+++ b/src/extra/JsonSchemaRenderer/JsonSchemaRendererPlayground/index.tsx
@@ -22,33 +22,10 @@ import Button from '../../../components/Button';
 import Heading from '../../../components/Heading';
 import Checkbox from '../../../components/Checkbox';
 import JsonSchemaRenderer, { JsonSchemaRendererProps } from '../index';
-import { Format, Value, JSONSchema, UiSchema } from '../types';
-import { CONTEXT_FUNCTIONS } from '../examples';
+import { Value, JSONSchema, UiSchema } from '../types';
+import { CONTEXT_FUNCTIONS, EXTRA_FORMATS } from '../examples';
 import JsonEditor from './JsonEditor';
 import { generateUiSchemaMetaSchema } from './util';
-
-const EXTRA_FORMATS: Format[] = [
-	{
-		name: 'markdown',
-		format: '.*',
-	},
-	{
-		name: 'mermaid',
-		format: '.*',
-	},
-	{
-		name: 'uri',
-		format: '.*',
-	},
-	{
-		name: 'email',
-		format: '.*',
-	},
-	{
-		name: 'data-url',
-		format: '.*',
-	},
-];
 
 const SlimCard = styled(Card)`
 	& > div {

--- a/src/extra/JsonSchemaRenderer/examples.ts
+++ b/src/extra/JsonSchemaRenderer/examples.ts
@@ -1,3 +1,5 @@
+import { Format } from './types';
+
 /* eslint-disable no-template-curly-in-string */
 
 export const CONTEXT_FUNCTIONS = {
@@ -5,6 +7,33 @@ export const CONTEXT_FUNCTIONS = {
 		prependHello: (input: string) => `Hello ${input}`,
 	},
 };
+
+export const EXTRA_FORMATS: Format[] = [
+	{
+		name: 'markdown',
+		format: '.*',
+	},
+	{
+		name: 'mermaid',
+		format: '.*',
+	},
+	{
+		name: 'color',
+		format: '.*',
+	},
+	{
+		name: 'uri',
+		format: '.*',
+	},
+	{
+		name: 'email',
+		format: '.*',
+	},
+	{
+		name: 'data-url',
+		format: '.*',
+	},
+];
 
 const jsonDataExamples = {
 	'A string': {
@@ -364,6 +393,21 @@ const jsonDataExamples = {
 				outline: false,
 				plain: false,
 				underline: false,
+			},
+		},
+	},
+	'A color widget': {
+		value: '#ff0000',
+		schema: {
+			type: 'string',
+			format: 'color',
+		},
+		uiSchema: {
+			'ui:options': {
+				label: 'Danger',
+				hideValueDisplay: false,
+				width: 100,
+				height: 60,
 			},
 		},
 	},

--- a/src/extra/JsonSchemaRenderer/spec.js
+++ b/src/extra/JsonSchemaRenderer/spec.js
@@ -9,14 +9,7 @@ import omit from 'lodash/omit'
 import forEach from 'lodash/forEach'
 import { Provider } from '../../../dist'
 import JsonSchemaRenderer from '../../../dist/extra/JsonSchemaRenderer'
-import allExamples, { CONTEXT_FUNCTIONS } from './examples'
-
-const EXTRA_FORMATS = [
-  {
-    name: 'markdown',
-    format: '.*'
-  }
-]
+import allExamples, { CONTEXT_FUNCTIONS, EXTRA_FORMATS } from './examples'
 
 describe.only('JsonSchemaRenderer component', () => {
   const examples = omit(allExamples, 'A mermaid field', 'A date time field')

--- a/src/extra/JsonSchemaRenderer/spec.js.snap
+++ b/src/extra/JsonSchemaRenderer/spec.js.snap
@@ -1020,6 +1020,97 @@ exports[`JsonSchemaRenderer component A button widget 1`] = `
 </div>
 `;
 
+exports[`JsonSchemaRenderer component A color widget 1`] = `
+.c0 {
+  font-family: 'Source Sans Pro',Helvetica,sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c2 {
+  box-sizing: border-box;
+}
+
+.c3 {
+  margin-bottom: 4px;
+  min-width: 0;
+  min-height: 0;
+}
+
+.c5 {
+  width: 100px;
+  height: 60px;
+  color: #FFF;
+  background-color: #ff0000;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c1 {
+  font-family: 'Source Sans Pro',Helvetica,sans-serif;
+  font-size: 14px;
+  color: #2A506F;
+}
+
+<div
+  className="c0 c1"
+>
+  <div
+    className="c2 c3 c4 "
+  >
+    <div
+      className="c2 c5 c6"
+    >
+      <div
+        className=""
+      >
+        Danger
+      </div>
+      <div
+        className=""
+      >
+        #ff0000
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`JsonSchemaRenderer component A default value 1`] = `
 .c0 {
   font-family: 'Source Sans Pro',Helvetica,sans-serif;

--- a/src/extra/JsonSchemaRenderer/widgets/ColorWidget.tsx
+++ b/src/extra/JsonSchemaRenderer/widgets/ColorWidget.tsx
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import React from 'react';
+import { Flex } from '../../../components/Flex';
+import Txt from '../../../components/Txt';
+import { JsonTypes } from '../types';
+import { UiOption } from './ui-options';
+import { Widget, WidgetProps } from './widget-util';
+import { isLight } from '../../../utils/colorUtils';
+
+const DEFAULT_WIDTH = '100px';
+const DEFAULT_HEIGHT = '100px';
+
+interface ColorWidgetProps extends WidgetProps {
+	label?: string;
+	hideValueDisplay?: boolean;
+	width?: string | number;
+	height?: string | number;
+}
+
+const ColorWidget: Widget = ({
+	value,
+	schema,
+	uiSchema,
+	label,
+	hideValueDisplay,
+	width = DEFAULT_WIDTH,
+	height = DEFAULT_HEIGHT,
+	...props
+}: ColorWidgetProps) => {
+	const bg = value.toString() || 'transparent';
+	const color = isLight(bg) ? '#000' : '#FFF';
+	return (
+		<Flex
+			{...props}
+			width={width}
+			height={height}
+			bg={bg}
+			color={color}
+			alignItems="center"
+			flexDirection="column"
+			justifyContent="center"
+		>
+			{label && <Txt>{label}</Txt>}
+			{!hideValueDisplay && <Txt>{value}</Txt>}
+		</Flex>
+	);
+};
+
+ColorWidget.displayName = 'Color';
+
+ColorWidget.uiOptions = {
+	label: UiOption.string,
+	hideValueDisplay: UiOption.bool,
+	width: UiOption.space,
+	height: UiOption.space,
+};
+
+ColorWidget.supportedTypes = [JsonTypes.string];
+
+export default ColorWidget;

--- a/src/extra/JsonSchemaRenderer/widgets/index.ts
+++ b/src/extra/JsonSchemaRenderer/widgets/index.ts
@@ -4,6 +4,7 @@ import BadgeWidget from './BadgeWidget';
 import ButtonGroupWidget from './ButtonGroupWidget';
 import ButtonWidget from './ButtonWidget';
 import CheckboxWidget from './CheckboxWidget';
+import ColorWidget from './ColorWidget';
 import DropDownButtonWidget from './DropDownButtonWidget';
 import HeadingWidget from './HeadingWidget';
 import HighlightedNameWidget from './HighlightedNameWidget';
@@ -44,6 +45,7 @@ const allWidgets: WidgetLookup = {};
 	ButtonGroupWidget,
 	ButtonWidget,
 	CheckboxWidget,
+	ColorWidget,
 	DropDownButtonWidget,
 	HeadingWidget,
 	HighlightedNameWidget,
@@ -86,6 +88,7 @@ export const formatWidgetMap: {
 	mermaid: allWidgets[MermaidWidget.displayName],
 	email: allWidgets[LinkWidget.displayName],
 	uri: allWidgets[LinkWidget.displayName],
+	color: allWidgets[ColorWidget.displayName],
 };
 
 export default widgets;


### PR DESCRIPTION
Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

---

This widget will be used by Jellyfish for displaying color fields!

##### Contributor checklist
- [ ] I have rebuilt the README with `npm run build:docs`
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [x] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
