### PR TITLE
fix: UI schema for JsonSchemaRenderer DropDownButton and ButtonGroup widgets

### DIFF
--- a/src/extra/JsonSchemaRenderer/examples.ts
+++ b/src/extra/JsonSchemaRenderer/examples.ts
@@ -379,20 +379,10 @@ const jsonDataExamples = {
 		},
 		uiSchema: {
 			'ui:widget': 'ButtonGroup',
-			'ui:options': {
-				disabled: false,
-				primary: true,
-				secondary: false,
-				tertiary: false,
-				quarternary: false,
-				danger: false,
-				warning: false,
-				success: false,
-				info: false,
-				light: false,
-				outline: false,
-				plain: false,
-				underline: false,
+			items: {
+				'ui:options': {
+					href: 'https://jel.ly.fish/${source}',
+				},
 			},
 		},
 	},
@@ -412,7 +402,7 @@ const jsonDataExamples = {
 		},
 	},
 	'A drop-down button widget': {
-		value: ['Action 1', 'Action 2', 'Action 3'],
+		value: ['link1', 'link2', 'link3'],
 		schema: {
 			type: 'array',
 			items: {
@@ -422,9 +412,9 @@ const jsonDataExamples = {
 		uiSchema: {
 			'ui:widget': 'DropDownButton',
 			'ui:options': {
-				label: 'Actions',
+				label: 'Links',
 				disabled: false,
-				primary: true,
+				primary: false,
 				secondary: false,
 				tertiary: false,
 				quarternary: false,
@@ -432,10 +422,18 @@ const jsonDataExamples = {
 				warning: false,
 				success: false,
 				info: false,
-				light: false,
-				outline: false,
-				plain: false,
-				underline: false,
+				emphasized: false,
+				square: false,
+				border: false,
+				joined: true,
+				alignRight: true,
+				listMaxHeight: '300px',
+			},
+			items: {
+				'ui:widget': 'Link',
+				'ui:options': {
+					href: 'https://jel.ly.fish/${source}',
+				},
 			},
 		},
 	},

--- a/src/extra/JsonSchemaRenderer/spec.js.snap
+++ b/src/extra/JsonSchemaRenderer/spec.js.snap
@@ -650,15 +650,12 @@ exports[`JsonSchemaRenderer component A button group widget 1`] = `
   background: transparent;
   overflow: visible;
   text-transform: none;
-  border: 1px solid #00AEEF;
+  border: 1px solid #2A506F;
   border-radius: 20px;
   color: #444444;
   padding: 4px 30px;
   font-size: 14px;
   line-height: 1.5;
-  background-color: #00AEEF;
-  color: #444444;
-  border-radius: 20px;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
   transition-property: color,background-color,border-color,box-shadow;
   -webkit-transition-duration: 0.1s;
@@ -668,7 +665,7 @@ exports[`JsonSchemaRenderer component A button group widget 1`] = `
 }
 
 .c7:hover {
-  box-shadow: 0px 0px 0px 2px #00AEEF;
+  box-shadow: 0px 0px 0px 2px #2A506F;
 }
 
 .c7:focus {
@@ -731,15 +728,20 @@ exports[`JsonSchemaRenderer component A button group widget 1`] = `
 }
 
 .c9 {
-  color: white;
+  color: #2A506F;
+  border-color: #2A506F;
+}
+
+.c9 svg {
+  color: #527699 !important;
 }
 
 .c9:hover:enabled,
 .c9:focus:enabled,
 .c9:active:enabled {
   box-shadow: none;
-  background: hsl(196.29999999999995,100%,37.5%);
-  border-color: hsl(196.29999999999995,100%,37.5%);
+  background: #2A506F;
+  border-color: #2A506F;
   color: white;
   opacity: initial;
 }
@@ -818,39 +820,36 @@ exports[`JsonSchemaRenderer component A button group widget 1`] = `
     <div
       className="c2 c5 c6"
     >
-      <button
+      <a
         className="c7 c8 c9 "
-        disabled={false}
+        href="https://jel.ly.fish/item 1"
         onBlur={[Function]}
         onFocus={[Function]}
         onMouseOut={[Function]}
         onMouseOver={[Function]}
-        type="button"
       >
         item 1
-      </button>
-      <button
+      </a>
+      <a
         className="c7 c8 c9 "
-        disabled={false}
+        href="https://jel.ly.fish/item 2"
         onBlur={[Function]}
         onFocus={[Function]}
         onMouseOut={[Function]}
         onMouseOver={[Function]}
-        type="button"
       >
         item 2
-      </button>
-      <button
+      </a>
+      <a
         className="c7 c8 c9 "
-        disabled={false}
+        href="https://jel.ly.fish/item 3"
         onBlur={[Function]}
         onFocus={[Function]}
         onMouseOut={[Function]}
         onMouseOver={[Function]}
-        type="button"
       >
         item 3
-      </button>
+      </a>
     </div>
   </div>
 </div>
@@ -1146,15 +1145,12 @@ exports[`JsonSchemaRenderer component A drop-down button widget 1`] = `
   background: transparent;
   overflow: visible;
   text-transform: none;
-  border: 1px solid #00AEEF;
+  border: 1px solid #2A506F;
   border-radius: 20px;
   color: #444444;
   padding: 4px 30px;
   font-size: 14px;
   line-height: 1.5;
-  background-color: #00AEEF;
-  color: #444444;
-  border-radius: 20px;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
   transition-property: color,background-color,border-color,box-shadow;
   -webkit-transition-duration: 0.1s;
@@ -1164,7 +1160,7 @@ exports[`JsonSchemaRenderer component A drop-down button widget 1`] = `
 }
 
 .c6:hover {
-  box-shadow: 0px 0px 0px 2px #00AEEF;
+  box-shadow: 0px 0px 0px 2px #2A506F;
 }
 
 .c6:focus {
@@ -1184,60 +1180,6 @@ exports[`JsonSchemaRenderer component A drop-down button widget 1`] = `
 }
 
 .c6:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c10 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: 1px solid #00AEEF;
-  border-radius: 20px;
-  color: #444444;
-  padding: 4px 30px;
-  font-size: 14px;
-  line-height: 1.5;
-  background-color: #00AEEF;
-  color: #444444;
-  border-radius: 20px;
-  -webkit-transition-property: color,background-color,border-color,box-shadow;
-  transition-property: color,background-color,border-color,box-shadow;
-  -webkit-transition-duration: 0.1s;
-  transition-duration: 0.1s;
-  -webkit-transition-timing-function: ease-in-out;
-  transition-timing-function: ease-in-out;
-  line-height: 0;
-  padding: 12px;
-}
-
-.c10:hover {
-  box-shadow: 0px 0px 0px 2px #00AEEF;
-}
-
-.c10:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #00AEEF;
-}
-
-.c10:focus > circle,
-.c10:focus > ellipse,
-.c10:focus > line,
-.c10:focus > path,
-.c10:focus > polygon,
-.c10:focus > polyline,
-.c10:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #00AEEF;
-}
-
-.c10:focus::-moz-focus-inner {
   border: 0;
 }
 
@@ -1281,15 +1223,20 @@ exports[`JsonSchemaRenderer component A drop-down button widget 1`] = `
 }
 
 .c8 {
-  color: white;
+  color: #2A506F;
+  border-color: #2A506F;
+}
+
+.c8 svg {
+  color: #527699 !important;
 }
 
 .c8:hover:enabled,
 .c8:focus:enabled,
 .c8:active:enabled {
   box-shadow: none;
-  background: hsl(196.29999999999995,100%,37.5%);
-  border-color: hsl(196.29999999999995,100%,37.5%);
+  background: #2A506F;
+  border-color: #2A506F;
   color: white;
   opacity: initial;
 }
@@ -1310,6 +1257,10 @@ exports[`JsonSchemaRenderer component A drop-down button widget 1`] = `
   min-height: 0;
 }
 
+.c11 {
+  margin-right: 8px;
+}
+
 .c4 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -1324,23 +1275,19 @@ exports[`JsonSchemaRenderer component A drop-down button widget 1`] = `
   align-items: flex-start;
 }
 
-.c11 {
-  min-width: 0;
-  border-top-left-radius: 0;
-  border-bottom-left-radius: 0;
-  border-left: 0;
-  margin: 0;
-  vertical-align: top;
-  padding: 0 16px;
-  width: 44px;
-}
-
-.c9 {
-  border-top-right-radius: 0;
-  border-bottom-right-radius: 0;
-  border-right: 0;
-  margin: 0;
-  width: calc(100% - 44px);
+.c10 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
 }
 
 .c5 {
@@ -1355,6 +1302,11 @@ exports[`JsonSchemaRenderer component A drop-down button widget 1`] = `
   -webkit-transform: translateY(1px);
   -ms-transform: translateY(1px);
   transform: translateY(1px);
+}
+
+.c9 {
+  margin: 0;
+  width: 100%;
 }
 
 .c1 {
@@ -1373,32 +1325,27 @@ exports[`JsonSchemaRenderer component A drop-down button widget 1`] = `
       className="c2 c5 "
       disabled={false}
     >
-      <span>
-        <button
-          className="c6 c7 c8 c9"
-          disabled={false}
-          onBlur={[Function]}
-          onFocus={[Function]}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
-          type="button"
+      <button
+        className="c6 c7 c8 c9"
+        disabled={false}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onMouseOut={[Function]}
+        onMouseOver={[Function]}
+        type="button"
+      >
+        <div
+          className="c2 c10"
         >
-          Actions
-        </button>
-        <button
-          className="c10 c7 c8 c11"
-          disabled={false}
-          onBlur={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
-          type="button"
-        >
+          <div
+            className="c2 c11"
+          >
+            Links
+          </div>
           <svg
             aria-hidden="true"
             className="svg-inline--fa fa-chevron-down fa-w-14 "
-            color="#444444"
             data-icon="chevron-down"
             data-prefix="fas"
             focusable="false"
@@ -1413,8 +1360,8 @@ exports[`JsonSchemaRenderer component A drop-down button widget 1`] = `
               style={Object {}}
             />
           </svg>
-        </button>
-      </span>
+        </div>
+      </button>
     </div>
   </div>
 </div>

--- a/src/extra/JsonSchemaRenderer/widgets/ButtonGroupWidget.tsx
+++ b/src/extra/JsonSchemaRenderer/widgets/ButtonGroupWidget.tsx
@@ -2,20 +2,28 @@ import * as React from 'react';
 import isArray from 'lodash/isArray';
 import get from 'lodash/get';
 import map from 'lodash/map';
-import Button from '../../../components/Button';
 import ButtonGroup from '../../../components/ButtonGroup';
-import { Widget, WidgetProps } from './widget-util';
+import {
+	Widget,
+	WidgetProps,
+	getArrayItems,
+	withOptionProps,
+} from './widget-util';
 import { JsonTypes } from '../types';
 import ButtonWidget from './ButtonWidget';
 
 const validItemTypes = ['string', 'integer', 'number'];
 
-// TODO: how to define UI Schema for items of an array?
-// (e.g. so the href prop for each item in the array can be uniquely set)
+const WrappedButtonWidget = ButtonWidget.uiOptions
+	? withOptionProps(ButtonWidget.uiOptions)(ButtonWidget)
+	: ButtonWidget;
+
 const ButtonGroupWidget: Widget = ({
 	value,
 	schema,
 	uiSchema,
+	extraContext,
+	extraFormats,
 	...props
 }: WidgetProps) => {
 	if (!isArray(value)) {
@@ -29,12 +37,15 @@ const ButtonGroupWidget: Widget = ({
 			`ButtonGroupWidget cannot be used to render an array of items of type ${itemType}`,
 		);
 	}
+	const items = getArrayItems({ value, schema, uiSchema, extraContext });
 	return (
-		<ButtonGroup>
-			{map(value, (item) => (
-				<Button key={item} {...props}>
-					{item.toString()}
-				</Button>
+		<ButtonGroup {...props}>
+			{map(items, (item: WidgetProps, index: number) => (
+				<WrappedButtonWidget
+					key={index}
+					{...item}
+					extraFormats={extraFormats}
+				/>
 			))}
 		</ButtonGroup>
 	);
@@ -42,7 +53,7 @@ const ButtonGroupWidget: Widget = ({
 
 ButtonGroupWidget.displayName = 'ButtonGroup';
 
-ButtonGroupWidget.uiOptions = ButtonWidget.uiOptions;
+ButtonGroupWidget.uiOptions = {};
 
 ButtonGroupWidget.supportedTypes = [JsonTypes.array];
 

--- a/src/extra/JsonSchemaRenderer/widgets/DropDownButtonWidget.tsx
+++ b/src/extra/JsonSchemaRenderer/widgets/DropDownButtonWidget.tsx
@@ -3,19 +3,19 @@ import isArray from 'lodash/isArray';
 import get from 'lodash/get';
 import map from 'lodash/map';
 import DropDownButton from '../../../components/DropDownButton';
-import { Widget, WidgetProps } from './widget-util';
-import ButtonWidget from './ButtonWidget';
+import { Widget, WidgetProps, getArrayItems } from './widget-util';
 import { JsonTypes } from '../types';
 import { UiOption } from './ui-options';
+import { RenditionJsonSchemaRenderer } from '../index';
 
 const validItemTypes = ['string', 'integer', 'number'];
 
-// TODO: how to define UI Schema for items of an array?
-// (e.g. so the href prop for each item in the array can be uniquely set)
 const DropDownButtonWidget: Widget = ({
 	value,
 	schema,
 	uiSchema,
+	extraContext,
+	extraFormats,
 	...props
 }: WidgetProps) => {
 	if (!isArray(value)) {
@@ -29,10 +29,15 @@ const DropDownButtonWidget: Widget = ({
 			`DropDownButtonWidget cannot be used to render an array of items of type ${itemType}`,
 		);
 	}
+	const items = getArrayItems({ value, schema, uiSchema, extraContext });
 	return (
 		<DropDownButton {...props}>
-			{map(value, (item) => (
-				<div key={item}>{item.toString()}</div>
+			{map(items, (item: WidgetProps, index: number) => (
+				<RenditionJsonSchemaRenderer
+					key={index}
+					{...item}
+					extraFormats={extraFormats}
+				/>
 			))}
 		</DropDownButton>
 	);
@@ -41,8 +46,22 @@ const DropDownButtonWidget: Widget = ({
 DropDownButtonWidget.displayName = 'DropDownButton';
 
 DropDownButtonWidget.uiOptions = {
-	...ButtonWidget.uiOptions,
 	label: UiOption.string,
+	disabled: UiOption.boolean,
+	primary: UiOption.boolean,
+	secondary: UiOption.boolean,
+	tertiary: UiOption.boolean,
+	quarternary: UiOption.boolean,
+	danger: UiOption.boolean,
+	warning: UiOption.boolean,
+	success: UiOption.boolean,
+	info: UiOption.boolean,
+	emphasized: UiOption.boolean,
+	square: UiOption.boolean,
+	border: UiOption.boolean,
+	joined: UiOption.boolean,
+	alignRight: UiOption.boolean,
+	listMaxHeight: UiOption.space,
 };
 
 DropDownButtonWidget.supportedTypes = [JsonTypes.array];

--- a/src/extra/JsonSchemaRenderer/widgets/ImgWidget.tsx
+++ b/src/extra/JsonSchemaRenderer/widgets/ImgWidget.tsx
@@ -15,8 +15,8 @@ const ImgWidget: Widget = ({
 
 ImgWidget.uiOptions = {
 	alt: UiOption.string,
-	height: UiOption.integer,
-	width: UiOption.integer,
+	height: UiOption.space,
+	width: UiOption.space,
 	crossorigin: {
 		...UiOption.string,
 		enum: ['anonymous', 'use-credentials'],

--- a/src/extra/JsonSchemaRenderer/widgets/ui-options.ts
+++ b/src/extra/JsonSchemaRenderer/widgets/ui-options.ts
@@ -6,7 +6,7 @@ export type UiOptions = {
 
 // styled-system props can be passed as arrays, with each item
 // representing the value at a particular breakpoint.
-const responsive = (schema: JSONSchema): JSONSchema => {
+export const responsive = (schema: JSONSchema): JSONSchema => {
 	return {
 		anyOf: [
 			{


### PR DESCRIPTION
UI Schema for items can now be set on these widgets.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

---

The `ButtonGroup` and `DropDownButton` widgets now support setting the `ui:options` for `items` within the array they represent. This means we can derive the value (or, for example, href) individually for each child button or item.

##### Contributor checklist
- [ ] I have rebuilt the README with `npm run build:docs`
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [x] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
