### PR TITLE
Fix: Confirm only depends on the files it needs

### DIFF
--- a/src/components/ButtonGroup/spec.js.snap
+++ b/src/components/ButtonGroup/spec.js.snap
@@ -61,6 +61,10 @@ exports[`ButtonGroup renders correctly 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
+.c2 {
+  box-sizing: border-box;
+}
+
 .c6 {
   font-weight: 600;
   font-size: 14px;
@@ -112,10 +116,6 @@ exports[`ButtonGroup renders correctly 1`] = `
 .c7:focus:enabled svg,
 .c7:active:enabled svg {
   color: white !important;
-}
-
-.c2 {
-  box-sizing: border-box;
 }
 
 .c3 {

--- a/src/components/DropDownButton/spec.js.snap
+++ b/src/components/DropDownButton/spec.js.snap
@@ -118,6 +118,10 @@ exports[`DropDownButton renders correctly 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
+.c2 {
+  box-sizing: border-box;
+}
+
 .c5 {
   font-weight: 600;
   font-size: 14px;
@@ -164,10 +168,6 @@ exports[`DropDownButton renders correctly 1`] = `
 .c6:focus:enabled svg,
 .c6:active:enabled svg {
   color: white !important;
-}
-
-.c2 {
-  box-sizing: border-box;
 }
 
 .c9 {
@@ -379,6 +379,14 @@ exports[`Opened DropDownButton renders correctly 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
+.c2 {
+  box-sizing: border-box;
+}
+
+.c11 {
+  min-width: 0px;
+}
+
 .c5 {
   font-weight: 600;
   font-size: 14px;
@@ -425,14 +433,6 @@ exports[`Opened DropDownButton renders correctly 1`] = `
 .c6:focus:enabled svg,
 .c6:active:enabled svg {
   color: white !important;
-}
-
-.c2 {
-  box-sizing: border-box;
-}
-
-.c11 {
-  min-width: 0px;
 }
 
 .c10 {

--- a/src/components/Filters/spec.js.snap
+++ b/src/components/Filters/spec.js.snap
@@ -145,6 +145,18 @@ exports[`Filters component should match the stored snapshot 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
+.c2 {
+  box-sizing: border-box;
+}
+
+.c3 {
+  margin-bottom: 16px;
+}
+
+.c20 {
+  margin-right: 8px;
+}
+
 .c7 {
   font-weight: 600;
   font-size: 14px;
@@ -220,18 +232,6 @@ exports[`Filters component should match the stored snapshot 1`] = `
 
 .c9 {
   margin-right: 30px;
-}
-
-.c2 {
-  box-sizing: border-box;
-}
-
-.c3 {
-  margin-bottom: 16px;
-}
-
-.c20 {
-  margin-right: 8px;
 }
 
 .c5 {

--- a/src/components/Form/spec.js.snap
+++ b/src/components/Form/spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Form component description keyword should support markdown 1`] = `"<div id=\\"root_foo__description\\" class=\\"sc-fFSRdu eIqcBa sc-bkbjAj jdNlJb sc-fuIRbl gFSOjd rendition-form-description\\"><div><p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">Lorem ipsum <em>dolor</em> sit amet</p></div></div>"`;
+exports[`Form component description keyword should support markdown 1`] = `"<div id=\\"root_foo__description\\" class=\\"sc-fKgIGh gAGA-DC sc-bCwgka jYLzkK sc-dFRpvv deHNzT rendition-form-description\\"><div><p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">Lorem ipsum <em>dolor</em> sit amet</p></div></div>"`;
 
 exports[`Form component should match the stored snapshot 1`] = `
 .c13 {
@@ -113,6 +113,25 @@ exports[`Form component should match the stored snapshot 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
+.c2 {
+  box-sizing: border-box;
+}
+
+.c6 {
+  box-sizing: border-box;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.c4 {
+  margin-bottom: 8px;
+}
+
+.c7 {
+  margin-right: 8px;
+}
+
 .c14 {
   font-weight: 600;
   font-size: 14px;
@@ -159,25 +178,6 @@ exports[`Form component should match the stored snapshot 1`] = `
 .c15:focus:enabled svg,
 .c15:active:enabled svg {
   color: white !important;
-}
-
-.c2 {
-  box-sizing: border-box;
-}
-
-.c6 {
-  box-sizing: border-box;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-}
-
-.c4 {
-  margin-bottom: 8px;
-}
-
-.c7 {
-  margin-right: 8px;
 }
 
 .c5 {
@@ -320,4 +320,4 @@ exports[`Form component should match the stored snapshot 1`] = `
 </div>
 `;
 
-exports[`Form component ui:help keyword should support markdown 1`] = `"<div class=\\"sc-fFSRdu eIqcBa sc-bkbjAj kApBnK sc-fuIRbl gFSOjd rendition-form-help\\"><div><p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp cPPbGH\\">Lorem ipsum <em>dolor</em> sit amet</p></div></div>"`;
+exports[`Form component ui:help keyword should support markdown 1`] = `"<div class=\\"sc-fKgIGh gAGA-DC sc-bCwgka fznsoX sc-dFRpvv deHNzT rendition-form-help\\"><div><p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT cbarZF\\">Lorem ipsum <em>dolor</em> sit amet</p></div></div>"`;

--- a/src/components/Modal/spec.js.snap
+++ b/src/components/Modal/spec.js.snap
@@ -128,6 +128,23 @@ exports[`Modal renders correctly 1`] = `
   position: absolute;
 }
 
+.c6 {
+  box-sizing: border-box;
+}
+
+.c7 {
+  width: 700px;
+  max-width: 100%;
+}
+
+.c9 {
+  padding: 16px;
+}
+
+.c10 {
+  margin-top: 48px;
+}
+
 .c13 {
   font-weight: 600;
   font-size: 14px;
@@ -174,23 +191,6 @@ exports[`Modal renders correctly 1`] = `
 .c14:focus:enabled svg,
 .c14:active:enabled svg {
   color: white !important;
-}
-
-.c6 {
-  box-sizing: border-box;
-}
-
-.c7 {
-  width: 700px;
-  max-width: 100%;
-}
-
-.c9 {
-  padding: 16px;
-}
-
-.c10 {
-  margin-top: 48px;
 }
 
 .c11 {

--- a/src/components/Pager/spec.js.snap
+++ b/src/components/Pager/spec.js.snap
@@ -112,6 +112,10 @@ exports[`Pager component should match the stored snapshot 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
+.c2 {
+  box-sizing: border-box;
+}
+
 .c8 {
   font-weight: 600;
   font-size: 14px;
@@ -163,10 +167,6 @@ exports[`Pager component should match the stored snapshot 1`] = `
 .c9:focus:enabled svg,
 .c9:active:enabled svg {
   color: #2A506F !important;
-}
-
-.c2 {
-  box-sizing: border-box;
 }
 
 .c3 {

--- a/src/components/Steps/spec.js.snap
+++ b/src/components/Steps/spec.js.snap
@@ -437,6 +437,40 @@ exports[`Steps component should match the stored snapshot 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
+.c2 {
+  box-sizing: border-box;
+}
+
+.c6 {
+  margin-left: 8px;
+  margin-right: 38px;
+  min-height: 24px;
+}
+
+.c10 {
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.c13 {
+  font-size: 14px;
+}
+
+.c15 {
+  margin-right: 8px;
+  color: #bbc8d6;
+}
+
+.c20 {
+  margin-left: 16px;
+  margin-right: 16px;
+}
+
+.c21 {
+  margin-right: 8px;
+  color: #1AC135;
+}
+
 .c23 {
   font-weight: 600;
   font-size: 14px;
@@ -486,40 +520,6 @@ exports[`Steps component should match the stored snapshot 1`] = `
 .c24:focus:enabled svg,
 .c24:active:enabled svg {
   color: hsl(196.29999999999995,100%,37.5%) !important;
-}
-
-.c2 {
-  box-sizing: border-box;
-}
-
-.c6 {
-  margin-left: 8px;
-  margin-right: 38px;
-  min-height: 24px;
-}
-
-.c10 {
-  margin-left: auto;
-  margin-right: auto;
-}
-
-.c13 {
-  font-size: 14px;
-}
-
-.c15 {
-  margin-right: 8px;
-  color: #bbc8d6;
-}
-
-.c20 {
-  margin-left: 16px;
-  margin-right: 16px;
-}
-
-.c21 {
-  margin-right: 8px;
-  color: #1AC135;
 }
 
 .c3 {

--- a/src/extra/JsonSchemaRenderer/spec.js.snap
+++ b/src/extra/JsonSchemaRenderer/spec.js.snap
@@ -699,6 +699,16 @@ exports[`JsonSchemaRenderer component A button group widget 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
+.c2 {
+  box-sizing: border-box;
+}
+
+.c3 {
+  margin-bottom: 4px;
+  min-width: 0;
+  min-height: 0;
+}
+
 .c8 {
   font-weight: 600;
   font-size: 14px;
@@ -750,16 +760,6 @@ exports[`JsonSchemaRenderer component A button group widget 1`] = `
 .c9:focus:enabled svg,
 .c9:active:enabled svg {
   color: white !important;
-}
-
-.c2 {
-  box-sizing: border-box;
-}
-
-.c3 {
-  margin-bottom: 4px;
-  min-width: 0;
-  min-height: 0;
 }
 
 .c4 {
@@ -919,6 +919,16 @@ exports[`JsonSchemaRenderer component A button widget 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
+.c2 {
+  box-sizing: border-box;
+}
+
+.c3 {
+  margin-bottom: 4px;
+  min-width: 0;
+  min-height: 0;
+}
+
 .c6 {
   font-weight: 600;
   font-size: 14px;
@@ -965,16 +975,6 @@ exports[`JsonSchemaRenderer component A button widget 1`] = `
 .c7:focus:enabled svg,
 .c7:active:enabled svg {
   color: white !important;
-}
-
-.c2 {
-  box-sizing: border-box;
-}
-
-.c3 {
-  margin-bottom: 4px;
-  min-width: 0;
-  min-height: 0;
 }
 
 .c4 {
@@ -1194,6 +1194,20 @@ exports[`JsonSchemaRenderer component A drop-down button widget 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
+.c2 {
+  box-sizing: border-box;
+}
+
+.c3 {
+  margin-bottom: 4px;
+  min-width: 0;
+  min-height: 0;
+}
+
+.c11 {
+  margin-right: 8px;
+}
+
 .c7 {
   font-weight: 600;
   font-size: 14px;
@@ -1245,20 +1259,6 @@ exports[`JsonSchemaRenderer component A drop-down button widget 1`] = `
 .c8:focus:enabled svg,
 .c8:active:enabled svg {
   color: white !important;
-}
-
-.c2 {
-  box-sizing: border-box;
-}
-
-.c3 {
-  margin-bottom: 4px;
-  min-width: 0;
-  min-height: 0;
-}
-
-.c11 {
-  margin-right: 8px;
 }
 
 .c4 {

--- a/src/extra/Markdown/spec.js.snap
+++ b/src/extra/Markdown/spec.js.snap
@@ -4,7 +4,7 @@ exports[`Markdown component Custom sanitizer options: allowedAttributes can be o
 
 exports[`Markdown component Custom sanitizer options: allowedTags can be overridden 1`] = `
 "Foobar
-<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">Some text</p>"
+<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">Some text</p>"
 `;
 
 exports[`Markdown component should decorate the text matching the condition 1`] = `
@@ -224,7 +224,7 @@ exports[`Markdown component should decorate the text matching the condition 1`] 
 
 exports[`Markdown component should drop the content of style elements tag 1`] = `".foo { color: blue; }"`;
 
-exports[`Markdown component should drop the content of textarea elements tag 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">foobar</p>"`;
+exports[`Markdown component should drop the content of textarea elements tag 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">foobar</p>"`;
 
 exports[`Markdown component should match the stored snapshot 1`] = `
 .c0 {
@@ -912,19 +912,19 @@ exports[`Markdown component should not sanitize html when disabled 1`] = `
 
 exports[`Markdown component should render html images 1`] = `"<img src=\\"https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png\\">"`;
 
-exports[`Markdown component should render html links 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"><a href=\\"https://github.com\\" color=\\"primary.main\\" class=\\"sc-jUfxsr cdkxvi sc-jQAyEw bABfJB\\">GitHub</a></p>"`;
+exports[`Markdown component should render html links 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"><a href=\\"https://github.com\\" color=\\"primary.main\\" class=\\"sc-eGJXgd kVAnIx sc-csTaMs eXDzCT\\">GitHub</a></p>"`;
 
-exports[`Markdown component should render link type strings as links 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"><a href=\\"https://github.com\\" color=\\"primary.main\\" class=\\"sc-jUfxsr cdkxvi sc-jQAyEw bABfJB\\">https://github.com</a></p>"`;
+exports[`Markdown component should render link type strings as links 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"><a href=\\"https://github.com\\" color=\\"primary.main\\" class=\\"sc-eGJXgd kVAnIx sc-csTaMs eXDzCT\\">https://github.com</a></p>"`;
 
 exports[`Markdown component should render markdown blockquotes 1`] = `
 "<blockquote>
-<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">Lorem ipsum dolor sit amet</p>
+<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">Lorem ipsum dolor sit amet</p>
 </blockquote>"
 `;
 
-exports[`Markdown component should render markdown bold using ** 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"><strong>Foobar</strong></p>"`;
+exports[`Markdown component should render markdown bold using ** 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"><strong>Foobar</strong></p>"`;
 
-exports[`Markdown component should render markdown bold using __ 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"><strong>Foobar</strong></p>"`;
+exports[`Markdown component should render markdown bold using __ 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"><strong>Foobar</strong></p>"`;
 
 exports[`Markdown component should render markdown code blocks 1`] = `
 "<pre><code>const foo = () =&gt; {
@@ -940,29 +940,29 @@ exports[`Markdown component should render markdown code blocks with language spe
 </code></pre>"
 `;
 
-exports[`Markdown component should render markdown h1 headers 1`] = `"<h1 class=\\"sc-kLokih jNhANF sc-jJMGHv jAhWWk\\">Foobar</h1>"`;
+exports[`Markdown component should render markdown h1 headers 1`] = `"<h1 class=\\"sc-jcwofb gsBeRa sc-iTVIwl cNyBNR\\">Foobar</h1>"`;
 
-exports[`Markdown component should render markdown h2 headers 1`] = `"<h2 class=\\"sc-kLokih jNhANF sc-hiKfjK goPRqP\\">Foobar</h2>"`;
+exports[`Markdown component should render markdown h2 headers 1`] = `"<h2 class=\\"sc-jcwofb gsBeRa sc-iBzFoy fBPwMD\\">Foobar</h2>"`;
 
-exports[`Markdown component should render markdown h3 headers 1`] = `"<h3 class=\\"sc-kLokih jNhANF sc-gXfWUo gONRWr\\">Foobar</h3>"`;
+exports[`Markdown component should render markdown h3 headers 1`] = `"<h3 class=\\"sc-jcwofb gsBeRa sc-efHXLn lolsrq\\">Foobar</h3>"`;
 
-exports[`Markdown component should render markdown h4 headers 1`] = `"<h4 class=\\"sc-kLokih bSIztw sc-cBoprd cqHIA\\">Foobar</h4>"`;
+exports[`Markdown component should render markdown h4 headers 1`] = `"<h4 class=\\"sc-jcwofb beXsQn sc-cTJmaU fijups\\">Foobar</h4>"`;
 
-exports[`Markdown component should render markdown h4 headers 2`] = `"<h4 class=\\"sc-kLokih bSIztw sc-cBoprd cqHIA\\">Foobar</h4>"`;
+exports[`Markdown component should render markdown h4 headers 2`] = `"<h4 class=\\"sc-jcwofb beXsQn sc-cTJmaU fijups\\">Foobar</h4>"`;
 
-exports[`Markdown component should render markdown h5 headers 1`] = `"<h5 class=\\"sc-kLokih bSIztw sc-ciSmjq kniKsZ\\">Foobar</h5>"`;
+exports[`Markdown component should render markdown h5 headers 1`] = `"<h5 class=\\"sc-jcwofb beXsQn sc-jNnnWF bbEDmH\\">Foobar</h5>"`;
 
-exports[`Markdown component should render markdown h5 headers 2`] = `"<h6 class=\\"sc-kLokih bSIztw sc-jcwofb izQUHV\\">Foobar</h6>"`;
+exports[`Markdown component should render markdown h5 headers 2`] = `"<h6 class=\\"sc-jcwofb beXsQn sc-dPaNSN gGnhSq\\">Foobar</h6>"`;
 
-exports[`Markdown component should render markdown images 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"><img src=\\"https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png\\" alt=\\"GitHub logo\\"></p>"`;
+exports[`Markdown component should render markdown images 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"><img src=\\"https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png\\" alt=\\"GitHub logo\\"></p>"`;
 
-exports[`Markdown component should render markdown inline code 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"><code>Lorem ipsum dolor sit amet</code></p>"`;
+exports[`Markdown component should render markdown inline code 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"><code>Lorem ipsum dolor sit amet</code></p>"`;
 
-exports[`Markdown component should render markdown italics using * 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"><em>Foobar</em></p>"`;
+exports[`Markdown component should render markdown italics using * 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"><em>Foobar</em></p>"`;
 
-exports[`Markdown component should render markdown italics using _ 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"><em>Foobar</em></p>"`;
+exports[`Markdown component should render markdown italics using _ 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"><em>Foobar</em></p>"`;
 
-exports[`Markdown component should render markdown links 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"><a href=\\"https://github.com\\" color=\\"primary.main\\" class=\\"sc-jUfxsr cdkxvi sc-jQAyEw bABfJB\\">GitHub</a></p>"`;
+exports[`Markdown component should render markdown links 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"><a href=\\"https://github.com\\" color=\\"primary.main\\" class=\\"sc-eGJXgd kVAnIx sc-csTaMs eXDzCT\\">GitHub</a></p>"`;
 
 exports[`Markdown component should render markdown ordered lists 1`] = `
 "<ol>
@@ -973,7 +973,7 @@ exports[`Markdown component should render markdown ordered lists 1`] = `
 </ol>"
 `;
 
-exports[`Markdown component should render markdown strikethroughs 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"><del>foobar</del></p>"`;
+exports[`Markdown component should render markdown strikethroughs 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"><del>foobar</del></p>"`;
 
 exports[`Markdown component should render markdown tables 1`] = `"<table><thead><tr><th>First</th><th>Second</th></tr></thead><tbody><tr><td>1</td><td>2</td></tr><tr><td>3</td><td>4</td></tr></tbody></table>"`;
 
@@ -999,17 +999,17 @@ exports[`Markdown component should render markdown unordered lists 1`] = `
 
 exports[`Markdown component xss: 1 1`] = `""`;
 
-exports[`Markdown component xss: 2 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&lt;script&gt;alert(&apos;123&apos;);&lt;/script&gt;</p>"`;
+exports[`Markdown component xss: 2 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&lt;script&gt;alert(&apos;123&apos;);&lt;/script&gt;</p>"`;
 
 exports[`Markdown component xss: 3 1`] = `"<img src=\\"x\\">"`;
 
-exports[`Markdown component xss: 4 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"></p>"`;
+exports[`Markdown component xss: 4 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"></p>"`;
 
-exports[`Markdown component xss: 5 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&quot;&gt;</p>"`;
+exports[`Markdown component xss: 5 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&quot;&gt;</p>"`;
 
-exports[`Markdown component xss: 6 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&quot;&gt;</p>"`;
+exports[`Markdown component xss: 6 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&quot;&gt;</p>"`;
 
-exports[`Markdown component xss: 7 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&apos;&gt;</p>"`;
+exports[`Markdown component xss: 7 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&apos;&gt;</p>"`;
 
 exports[`Markdown component xss: 8 1`] = `
 "<blockquote>
@@ -1017,402 +1017,402 @@ exports[`Markdown component xss: 8 1`] = `
 </blockquote>"
 `;
 
-exports[`Markdown component xss: 9 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"></p>"`;
+exports[`Markdown component xss: 9 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"></p>"`;
 
-exports[`Markdown component xss: 10 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&lt; / script &gt;&lt; script &gt;alert(123)&lt; / script &gt;</p>"`;
+exports[`Markdown component xss: 10 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&lt; / script &gt;&lt; script &gt;alert(123)&lt; / script &gt;</p>"`;
 
-exports[`Markdown component xss: 11 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"> onfocus=JaVaSCript:alert(123) autofocus</p>"`;
+exports[`Markdown component xss: 11 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"> onfocus=JaVaSCript:alert(123) autofocus</p>"`;
 
-exports[`Markdown component xss: 12 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&quot; onfocus=JaVaSCript:alert(123) autofocus</p>"`;
+exports[`Markdown component xss: 12 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&quot; onfocus=JaVaSCript:alert(123) autofocus</p>"`;
 
-exports[`Markdown component xss: 13 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&apos; onfocus=JaVaSCript:alert(123) autofocus</p>"`;
+exports[`Markdown component xss: 13 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&apos; onfocus=JaVaSCript:alert(123) autofocus</p>"`;
 
-exports[`Markdown component xss: 14 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&#xFF1C;script&#xFF1E;alert(123)&#xFF1C;/script&#xFF1E;</p>"`;
+exports[`Markdown component xss: 14 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&#xFF1C;script&#xFF1E;alert(123)&#xFF1C;/script&#xFF1E;</p>"`;
 
-exports[`Markdown component xss: 15 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&lt;script&gt;</p>"`;
+exports[`Markdown component xss: 15 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&lt;script&gt;</p>"`;
 
-exports[`Markdown component xss: 16 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">--&gt;</p>"`;
+exports[`Markdown component xss: 16 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">--&gt;</p>"`;
 
-exports[`Markdown component xss: 17 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&quot;;alert(123);t=&quot;</p>"`;
+exports[`Markdown component xss: 17 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&quot;;alert(123);t=&quot;</p>"`;
 
-exports[`Markdown component xss: 18 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&apos;;alert(123);t=&apos;</p>"`;
+exports[`Markdown component xss: 18 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&apos;;alert(123);t=&apos;</p>"`;
 
-exports[`Markdown component xss: 19 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">JavaSCript:alert(123)</p>"`;
+exports[`Markdown component xss: 19 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">JavaSCript:alert(123)</p>"`;
 
-exports[`Markdown component xss: 20 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">;alert(123);</p>"`;
+exports[`Markdown component xss: 20 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">;alert(123);</p>"`;
 
-exports[`Markdown component xss: 21 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">src=JaVaSCript:prompt(132)</p>"`;
+exports[`Markdown component xss: 21 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">src=JaVaSCript:prompt(132)</p>"`;
 
-exports[`Markdown component xss: 22 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&quot;&gt;</p>"`;
+exports[`Markdown component xss: 22 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&quot;&gt;</p>"`;
 
-exports[`Markdown component xss: 23 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&apos;&gt;</p>"`;
+exports[`Markdown component xss: 23 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&apos;&gt;</p>"`;
 
 exports[`Markdown component xss: 24 1`] = `
 "<blockquote>
 </blockquote>"
 `;
 
-exports[`Markdown component xss: 25 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&quot; autofocus onkeyup=&quot;javascript:alert(123)</p>"`;
+exports[`Markdown component xss: 25 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&quot; autofocus onkeyup=&quot;javascript:alert(123)</p>"`;
 
-exports[`Markdown component xss: 26 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&apos; autofocus onkeyup=&apos;javascript:alert(123)</p>"`;
+exports[`Markdown component xss: 26 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&apos; autofocus onkeyup=&apos;javascript:alert(123)</p>"`;
 
-exports[`Markdown component xss: 27 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&lt;script\\\\x20type=&quot;text/javascript&quot;&gt;javascript:alert(1);</p>"`;
+exports[`Markdown component xss: 27 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&lt;script\\\\x20type=&quot;text/javascript&quot;&gt;javascript:alert(1);</p>"`;
 
-exports[`Markdown component xss: 28 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&lt;script\\\\x3Etype=&quot;text/javascript&quot;&gt;javascript:alert(1);</p>"`;
+exports[`Markdown component xss: 28 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&lt;script\\\\x3Etype=&quot;text/javascript&quot;&gt;javascript:alert(1);</p>"`;
 
-exports[`Markdown component xss: 29 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&lt;script\\\\x0Dtype=&quot;text/javascript&quot;&gt;javascript:alert(1);</p>"`;
+exports[`Markdown component xss: 29 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&lt;script\\\\x0Dtype=&quot;text/javascript&quot;&gt;javascript:alert(1);</p>"`;
 
-exports[`Markdown component xss: 30 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&lt;script\\\\x09type=&quot;text/javascript&quot;&gt;javascript:alert(1);</p>"`;
+exports[`Markdown component xss: 30 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&lt;script\\\\x09type=&quot;text/javascript&quot;&gt;javascript:alert(1);</p>"`;
 
-exports[`Markdown component xss: 31 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&lt;script\\\\x0Ctype=&quot;text/javascript&quot;&gt;javascript:alert(1);</p>"`;
+exports[`Markdown component xss: 31 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&lt;script\\\\x0Ctype=&quot;text/javascript&quot;&gt;javascript:alert(1);</p>"`;
 
-exports[`Markdown component xss: 32 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&lt;script\\\\x2Ftype=&quot;text/javascript&quot;&gt;javascript:alert(1);</p>"`;
+exports[`Markdown component xss: 32 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&lt;script\\\\x2Ftype=&quot;text/javascript&quot;&gt;javascript:alert(1);</p>"`;
 
-exports[`Markdown component xss: 33 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&lt;script\\\\x0Atype=&quot;text/javascript&quot;&gt;javascript:alert(1);</p>"`;
+exports[`Markdown component xss: 33 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&lt;script\\\\x0Atype=&quot;text/javascript&quot;&gt;javascript:alert(1);</p>"`;
 
-exports[`Markdown component xss: 34 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&apos;\`&quot;&gt;&lt;\\\\x3Cscript&gt;javascript:alert(1)</p>"`;
+exports[`Markdown component xss: 34 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&apos;\`&quot;&gt;&lt;\\\\x3Cscript&gt;javascript:alert(1)</p>"`;
 
-exports[`Markdown component xss: 35 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&apos;\`&quot;&gt;&lt;\\\\x00script&gt;javascript:alert(1)</p>"`;
+exports[`Markdown component xss: 35 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&apos;\`&quot;&gt;&lt;\\\\x00script&gt;javascript:alert(1)</p>"`;
 
-exports[`Markdown component xss: 36 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">ABC</p><div>DEF<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"></p></div>"`;
+exports[`Markdown component xss: 36 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">ABC</p><div>DEF<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"></p></div>"`;
 
-exports[`Markdown component xss: 37 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">ABC</p><div>DEF<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"></p></div>"`;
+exports[`Markdown component xss: 37 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">ABC</p><div>DEF<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"></p></div>"`;
 
-exports[`Markdown component xss: 38 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">ABC</p><div>DEF<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"></p></div>"`;
+exports[`Markdown component xss: 38 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">ABC</p><div>DEF<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"></p></div>"`;
 
-exports[`Markdown component xss: 39 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">ABC</p><div>DEF<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"></p></div>"`;
+exports[`Markdown component xss: 39 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">ABC</p><div>DEF<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"></p></div>"`;
 
-exports[`Markdown component xss: 40 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">ABC</p><div>DEF<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"></p></div>"`;
+exports[`Markdown component xss: 40 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">ABC</p><div>DEF<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"></p></div>"`;
 
-exports[`Markdown component xss: 41 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">ABC</p><div>DEF<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"></p></div>"`;
+exports[`Markdown component xss: 41 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">ABC</p><div>DEF<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"></p></div>"`;
 
-exports[`Markdown component xss: 42 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">ABC</p><div>DEF<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"></p></div>"`;
+exports[`Markdown component xss: 42 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">ABC</p><div>DEF<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"></p></div>"`;
 
-exports[`Markdown component xss: 43 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">ABC</p><div>DEF<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"></p></div>"`;
+exports[`Markdown component xss: 43 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">ABC</p><div>DEF<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"></p></div>"`;
 
-exports[`Markdown component xss: 44 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">ABC</p><div>DEF<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"></p></div>"`;
+exports[`Markdown component xss: 44 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">ABC</p><div>DEF<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"></p></div>"`;
 
-exports[`Markdown component xss: 45 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">ABC</p><div>DEF<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"></p></div>"`;
+exports[`Markdown component xss: 45 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">ABC</p><div>DEF<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"></p></div>"`;
 
-exports[`Markdown component xss: 46 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">ABC</p><div>DEF<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"></p></div>"`;
+exports[`Markdown component xss: 46 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">ABC</p><div>DEF<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"></p></div>"`;
 
-exports[`Markdown component xss: 47 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">ABC</p><div>DEF<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"></p></div>"`;
+exports[`Markdown component xss: 47 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">ABC</p><div>DEF<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"></p></div>"`;
 
-exports[`Markdown component xss: 48 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">ABC</p><div>DEF<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"></p></div>"`;
+exports[`Markdown component xss: 48 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">ABC</p><div>DEF<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"></p></div>"`;
 
-exports[`Markdown component xss: 49 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">ABC</p><div>DEF<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"></p></div>"`;
+exports[`Markdown component xss: 49 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">ABC</p><div>DEF<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"></p></div>"`;
 
-exports[`Markdown component xss: 50 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">ABC</p><div>DEF<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"></p></div>"`;
+exports[`Markdown component xss: 50 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">ABC</p><div>DEF<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"></p></div>"`;
 
-exports[`Markdown component xss: 51 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">ABC</p><div>DEF<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"></p></div>"`;
+exports[`Markdown component xss: 51 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">ABC</p><div>DEF<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"></p></div>"`;
 
-exports[`Markdown component xss: 52 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">ABC</p><div>DEF<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"></p></div>"`;
+exports[`Markdown component xss: 52 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">ABC</p><div>DEF<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"></p></div>"`;
 
-exports[`Markdown component xss: 53 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">ABC</p><div>DEF<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"></p></div>"`;
+exports[`Markdown component xss: 53 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">ABC</p><div>DEF<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"></p></div>"`;
 
-exports[`Markdown component xss: 54 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">ABC</p><div>DEF<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"></p></div>"`;
+exports[`Markdown component xss: 54 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">ABC</p><div>DEF<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"></p></div>"`;
 
-exports[`Markdown component xss: 55 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">ABC</p><div>DEF<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"></p></div>"`;
+exports[`Markdown component xss: 55 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">ABC</p><div>DEF<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"></p></div>"`;
 
-exports[`Markdown component xss: 56 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">ABC</p><div>DEF<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"></p></div>"`;
+exports[`Markdown component xss: 56 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">ABC</p><div>DEF<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"></p></div>"`;
 
-exports[`Markdown component xss: 57 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">ABC</p><div>DEF<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"></p></div>"`;
+exports[`Markdown component xss: 57 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">ABC</p><div>DEF<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"></p></div>"`;
 
-exports[`Markdown component xss: 58 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">ABC</p><div>DEF<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"></p></div>"`;
+exports[`Markdown component xss: 58 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">ABC</p><div>DEF<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"></p></div>"`;
 
-exports[`Markdown component xss: 59 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">ABC</p><div>DEF<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"></p></div>"`;
+exports[`Markdown component xss: 59 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">ABC</p><div>DEF<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"></p></div>"`;
 
-exports[`Markdown component xss: 60 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">ABC</p><div>DEF<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"></p></div>"`;
+exports[`Markdown component xss: 60 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">ABC</p><div>DEF<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"></p></div>"`;
 
-exports[`Markdown component xss: 61 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">ABC</p><div>DEF<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"></p></div>"`;
+exports[`Markdown component xss: 61 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">ABC</p><div>DEF<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"></p></div>"`;
 
-exports[`Markdown component xss: 62 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">ABC</p><div>DEF<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"></p></div>"`;
+exports[`Markdown component xss: 62 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">ABC</p><div>DEF<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"></p></div>"`;
 
-exports[`Markdown component xss: 63 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-jUfxsr cdkxvi sc-jQAyEw bABfJB\\">test</a></p>"`;
+exports[`Markdown component xss: 63 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-eGJXgd kVAnIx sc-csTaMs eXDzCT\\">test</a></p>"`;
 
-exports[`Markdown component xss: 64 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-jUfxsr cdkxvi sc-jQAyEw bABfJB\\">test</a></p>"`;
+exports[`Markdown component xss: 64 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-eGJXgd kVAnIx sc-csTaMs eXDzCT\\">test</a></p>"`;
 
-exports[`Markdown component xss: 65 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-jUfxsr cdkxvi sc-jQAyEw bABfJB\\">test</a></p>"`;
+exports[`Markdown component xss: 65 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-eGJXgd kVAnIx sc-csTaMs eXDzCT\\">test</a></p>"`;
 
-exports[`Markdown component xss: 66 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-jUfxsr cdkxvi sc-jQAyEw bABfJB\\">test</a></p>"`;
+exports[`Markdown component xss: 66 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-eGJXgd kVAnIx sc-csTaMs eXDzCT\\">test</a></p>"`;
 
-exports[`Markdown component xss: 67 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-jUfxsr cdkxvi sc-jQAyEw bABfJB\\">test</a></p>"`;
+exports[`Markdown component xss: 67 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-eGJXgd kVAnIx sc-csTaMs eXDzCT\\">test</a></p>"`;
 
-exports[`Markdown component xss: 68 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-jUfxsr cdkxvi sc-jQAyEw bABfJB\\">test</a></p>"`;
+exports[`Markdown component xss: 68 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-eGJXgd kVAnIx sc-csTaMs eXDzCT\\">test</a></p>"`;
 
-exports[`Markdown component xss: 69 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-jUfxsr cdkxvi sc-jQAyEw bABfJB\\">test</a></p>"`;
+exports[`Markdown component xss: 69 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-eGJXgd kVAnIx sc-csTaMs eXDzCT\\">test</a></p>"`;
 
-exports[`Markdown component xss: 70 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-jUfxsr cdkxvi sc-jQAyEw bABfJB\\">test</a></p>"`;
+exports[`Markdown component xss: 70 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-eGJXgd kVAnIx sc-csTaMs eXDzCT\\">test</a></p>"`;
 
-exports[`Markdown component xss: 71 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-jUfxsr cdkxvi sc-jQAyEw bABfJB\\">test</a></p>"`;
+exports[`Markdown component xss: 71 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-eGJXgd kVAnIx sc-csTaMs eXDzCT\\">test</a></p>"`;
 
-exports[`Markdown component xss: 72 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-jUfxsr cdkxvi sc-jQAyEw bABfJB\\">test</a></p>"`;
+exports[`Markdown component xss: 72 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-eGJXgd kVAnIx sc-csTaMs eXDzCT\\">test</a></p>"`;
 
-exports[`Markdown component xss: 73 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-jUfxsr cdkxvi sc-jQAyEw bABfJB\\">test</a></p>"`;
+exports[`Markdown component xss: 73 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-eGJXgd kVAnIx sc-csTaMs eXDzCT\\">test</a></p>"`;
 
-exports[`Markdown component xss: 74 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-jUfxsr cdkxvi sc-jQAyEw bABfJB\\">test</a></p>"`;
+exports[`Markdown component xss: 74 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-eGJXgd kVAnIx sc-csTaMs eXDzCT\\">test</a></p>"`;
 
-exports[`Markdown component xss: 75 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-jUfxsr cdkxvi sc-jQAyEw bABfJB\\">test</a></p>"`;
+exports[`Markdown component xss: 75 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-eGJXgd kVAnIx sc-csTaMs eXDzCT\\">test</a></p>"`;
 
-exports[`Markdown component xss: 76 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-jUfxsr cdkxvi sc-jQAyEw bABfJB\\">test</a></p>"`;
+exports[`Markdown component xss: 76 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-eGJXgd kVAnIx sc-csTaMs eXDzCT\\">test</a></p>"`;
 
-exports[`Markdown component xss: 77 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-jUfxsr cdkxvi sc-jQAyEw bABfJB\\">test</a></p>"`;
+exports[`Markdown component xss: 77 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-eGJXgd kVAnIx sc-csTaMs eXDzCT\\">test</a></p>"`;
 
-exports[`Markdown component xss: 78 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-jUfxsr cdkxvi sc-jQAyEw bABfJB\\">test</a></p>"`;
+exports[`Markdown component xss: 78 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-eGJXgd kVAnIx sc-csTaMs eXDzCT\\">test</a></p>"`;
 
-exports[`Markdown component xss: 79 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-jUfxsr cdkxvi sc-jQAyEw bABfJB\\">test</a></p>"`;
+exports[`Markdown component xss: 79 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-eGJXgd kVAnIx sc-csTaMs eXDzCT\\">test</a></p>"`;
 
-exports[`Markdown component xss: 80 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-jUfxsr cdkxvi sc-jQAyEw bABfJB\\">test</a></p>"`;
+exports[`Markdown component xss: 80 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-eGJXgd kVAnIx sc-csTaMs eXDzCT\\">test</a></p>"`;
 
-exports[`Markdown component xss: 81 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-jUfxsr cdkxvi sc-jQAyEw bABfJB\\">test</a></p>"`;
+exports[`Markdown component xss: 81 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-eGJXgd kVAnIx sc-csTaMs eXDzCT\\">test</a></p>"`;
 
-exports[`Markdown component xss: 82 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-jUfxsr cdkxvi sc-jQAyEw bABfJB\\">test</a></p>"`;
+exports[`Markdown component xss: 82 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-eGJXgd kVAnIx sc-csTaMs eXDzCT\\">test</a></p>"`;
 
-exports[`Markdown component xss: 83 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-jUfxsr cdkxvi sc-jQAyEw bABfJB\\">test</a></p>"`;
+exports[`Markdown component xss: 83 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-eGJXgd kVAnIx sc-csTaMs eXDzCT\\">test</a></p>"`;
 
-exports[`Markdown component xss: 84 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-jUfxsr cdkxvi sc-jQAyEw bABfJB\\">test</a></p>"`;
+exports[`Markdown component xss: 84 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-eGJXgd kVAnIx sc-csTaMs eXDzCT\\">test</a></p>"`;
 
-exports[`Markdown component xss: 85 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-jUfxsr cdkxvi sc-jQAyEw bABfJB\\">test</a></p>"`;
+exports[`Markdown component xss: 85 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-eGJXgd kVAnIx sc-csTaMs eXDzCT\\">test</a></p>"`;
 
-exports[`Markdown component xss: 86 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-jUfxsr cdkxvi sc-jQAyEw bABfJB\\">test</a></p>"`;
+exports[`Markdown component xss: 86 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-eGJXgd kVAnIx sc-csTaMs eXDzCT\\">test</a></p>"`;
 
-exports[`Markdown component xss: 87 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-jUfxsr cdkxvi sc-jQAyEw bABfJB\\">test</a></p>"`;
+exports[`Markdown component xss: 87 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-eGJXgd kVAnIx sc-csTaMs eXDzCT\\">test</a></p>"`;
 
-exports[`Markdown component xss: 88 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-jUfxsr cdkxvi sc-jQAyEw bABfJB\\">test</a></p>"`;
+exports[`Markdown component xss: 88 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-eGJXgd kVAnIx sc-csTaMs eXDzCT\\">test</a></p>"`;
 
-exports[`Markdown component xss: 89 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-jUfxsr cdkxvi sc-jQAyEw bABfJB\\">test</a></p>"`;
+exports[`Markdown component xss: 89 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-eGJXgd kVAnIx sc-csTaMs eXDzCT\\">test</a></p>"`;
 
-exports[`Markdown component xss: 90 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-jUfxsr cdkxvi sc-jQAyEw bABfJB\\">test</a></p>"`;
+exports[`Markdown component xss: 90 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-eGJXgd kVAnIx sc-csTaMs eXDzCT\\">test</a></p>"`;
 
-exports[`Markdown component xss: 91 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-jUfxsr cdkxvi sc-jQAyEw bABfJB\\">test</a></p>"`;
+exports[`Markdown component xss: 91 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-eGJXgd kVAnIx sc-csTaMs eXDzCT\\">test</a></p>"`;
 
-exports[`Markdown component xss: 92 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-jUfxsr cdkxvi sc-jQAyEw bABfJB\\">test</a></p>"`;
+exports[`Markdown component xss: 92 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-eGJXgd kVAnIx sc-csTaMs eXDzCT\\">test</a></p>"`;
 
-exports[`Markdown component xss: 93 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-jUfxsr cdkxvi sc-jQAyEw bABfJB\\">test</a></p>"`;
+exports[`Markdown component xss: 93 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-eGJXgd kVAnIx sc-csTaMs eXDzCT\\">test</a></p>"`;
 
-exports[`Markdown component xss: 94 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-jUfxsr cdkxvi sc-jQAyEw bABfJB\\">test</a></p>"`;
+exports[`Markdown component xss: 94 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-eGJXgd kVAnIx sc-csTaMs eXDzCT\\">test</a></p>"`;
 
-exports[`Markdown component xss: 95 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-jUfxsr cdkxvi sc-jQAyEw bABfJB\\">test</a></p>"`;
+exports[`Markdown component xss: 95 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-eGJXgd kVAnIx sc-csTaMs eXDzCT\\">test</a></p>"`;
 
-exports[`Markdown component xss: 96 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-jUfxsr cdkxvi sc-jQAyEw bABfJB\\">test</a></p>"`;
+exports[`Markdown component xss: 96 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-eGJXgd kVAnIx sc-csTaMs eXDzCT\\">test</a></p>"`;
 
-exports[`Markdown component xss: 97 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-jUfxsr cdkxvi sc-jQAyEw bABfJB\\">test</a></p>"`;
+exports[`Markdown component xss: 97 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-eGJXgd kVAnIx sc-csTaMs eXDzCT\\">test</a></p>"`;
 
-exports[`Markdown component xss: 98 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-jUfxsr cdkxvi sc-jQAyEw bABfJB\\">test</a></p>"`;
+exports[`Markdown component xss: 98 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-eGJXgd kVAnIx sc-csTaMs eXDzCT\\">test</a></p>"`;
 
-exports[`Markdown component xss: 99 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-jUfxsr cdkxvi sc-jQAyEw bABfJB\\">test</a></p>"`;
+exports[`Markdown component xss: 99 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-eGJXgd kVAnIx sc-csTaMs eXDzCT\\">test</a></p>"`;
 
-exports[`Markdown component xss: 100 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-jUfxsr cdkxvi sc-jQAyEw bABfJB\\">test</a></p>"`;
+exports[`Markdown component xss: 100 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-eGJXgd kVAnIx sc-csTaMs eXDzCT\\">test</a></p>"`;
 
-exports[`Markdown component xss: 101 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-jUfxsr cdkxvi sc-jQAyEw bABfJB\\">test</a></p>"`;
+exports[`Markdown component xss: 101 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-eGJXgd kVAnIx sc-csTaMs eXDzCT\\">test</a></p>"`;
 
-exports[`Markdown component xss: 102 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-jUfxsr cdkxvi sc-jQAyEw bABfJB\\">test</a></p>"`;
+exports[`Markdown component xss: 102 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-eGJXgd kVAnIx sc-csTaMs eXDzCT\\">test</a></p>"`;
 
-exports[`Markdown component xss: 103 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-jUfxsr cdkxvi sc-jQAyEw bABfJB\\">test</a></p>"`;
+exports[`Markdown component xss: 103 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-eGJXgd kVAnIx sc-csTaMs eXDzCT\\">test</a></p>"`;
 
-exports[`Markdown component xss: 104 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-jUfxsr cdkxvi sc-jQAyEw bABfJB\\">test</a></p>"`;
+exports[`Markdown component xss: 104 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-eGJXgd kVAnIx sc-csTaMs eXDzCT\\">test</a></p>"`;
 
-exports[`Markdown component xss: 105 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-jUfxsr cdkxvi sc-jQAyEw bABfJB\\">test</a></p>"`;
+exports[`Markdown component xss: 105 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-eGJXgd kVAnIx sc-csTaMs eXDzCT\\">test</a></p>"`;
 
-exports[`Markdown component xss: 106 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-jUfxsr cdkxvi sc-jQAyEw bABfJB\\">test</a></p>"`;
+exports[`Markdown component xss: 106 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-eGJXgd kVAnIx sc-csTaMs eXDzCT\\">test</a></p>"`;
 
-exports[`Markdown component xss: 107 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-jUfxsr cdkxvi sc-jQAyEw bABfJB\\">test</a></p>"`;
+exports[`Markdown component xss: 107 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-eGJXgd kVAnIx sc-csTaMs eXDzCT\\">test</a></p>"`;
 
-exports[`Markdown component xss: 108 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-jUfxsr cdkxvi sc-jQAyEw bABfJB\\">test</a></p>"`;
+exports[`Markdown component xss: 108 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-eGJXgd kVAnIx sc-csTaMs eXDzCT\\">test</a></p>"`;
 
-exports[`Markdown component xss: 109 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-jUfxsr cdkxvi sc-jQAyEw bABfJB\\">test</a></p>"`;
+exports[`Markdown component xss: 109 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-eGJXgd kVAnIx sc-csTaMs eXDzCT\\">test</a></p>"`;
 
-exports[`Markdown component xss: 110 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-jUfxsr cdkxvi sc-jQAyEw bABfJB\\">test</a></p>"`;
+exports[`Markdown component xss: 110 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-eGJXgd kVAnIx sc-csTaMs eXDzCT\\">test</a></p>"`;
 
-exports[`Markdown component xss: 111 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-jUfxsr cdkxvi sc-jQAyEw bABfJB\\">test</a></p>"`;
+exports[`Markdown component xss: 111 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-eGJXgd kVAnIx sc-csTaMs eXDzCT\\">test</a></p>"`;
 
-exports[`Markdown component xss: 112 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-jUfxsr cdkxvi sc-jQAyEw bABfJB\\">test</a></p>"`;
+exports[`Markdown component xss: 112 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-eGJXgd kVAnIx sc-csTaMs eXDzCT\\">test</a></p>"`;
 
-exports[`Markdown component xss: 113 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-jUfxsr cdkxvi sc-jQAyEw bABfJB\\">test</a></p>"`;
+exports[`Markdown component xss: 113 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-eGJXgd kVAnIx sc-csTaMs eXDzCT\\">test</a></p>"`;
 
-exports[`Markdown component xss: 114 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-jUfxsr cdkxvi sc-jQAyEw bABfJB\\">test</a></p>"`;
+exports[`Markdown component xss: 114 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-eGJXgd kVAnIx sc-csTaMs eXDzCT\\">test</a></p>"`;
 
-exports[`Markdown component xss: 115 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-jUfxsr cdkxvi sc-jQAyEw bABfJB\\">test</a></p>"`;
+exports[`Markdown component xss: 115 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-eGJXgd kVAnIx sc-csTaMs eXDzCT\\">test</a></p>"`;
 
-exports[`Markdown component xss: 116 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-jUfxsr cdkxvi sc-jQAyEw bABfJB\\">test</a></p>"`;
+exports[`Markdown component xss: 116 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-eGJXgd kVAnIx sc-csTaMs eXDzCT\\">test</a></p>"`;
 
-exports[`Markdown component xss: 117 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-jUfxsr cdkxvi sc-jQAyEw bABfJB\\">test</a></p>"`;
+exports[`Markdown component xss: 117 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-eGJXgd kVAnIx sc-csTaMs eXDzCT\\">test</a></p>"`;
 
-exports[`Markdown component xss: 118 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-jUfxsr cdkxvi sc-jQAyEw bABfJB\\">test</a></p>"`;
+exports[`Markdown component xss: 118 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-eGJXgd kVAnIx sc-csTaMs eXDzCT\\">test</a></p>"`;
 
-exports[`Markdown component xss: 119 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-jUfxsr cdkxvi sc-jQAyEw bABfJB\\">test</a></p>"`;
+exports[`Markdown component xss: 119 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"><a id=\\"user-content-fuzzelement1\\" color=\\"primary.main\\" class=\\"sc-eGJXgd kVAnIx sc-csTaMs eXDzCT\\">test</a></p>"`;
 
-exports[`Markdown component xss: 120 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">\`&quot;&apos;&gt;&lt;img src=xxx:x \\\\x0Aonerror=javascript:alert(1)&gt;</p>"`;
+exports[`Markdown component xss: 120 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">\`&quot;&apos;&gt;&lt;img src=xxx:x \\\\x0Aonerror=javascript:alert(1)&gt;</p>"`;
 
-exports[`Markdown component xss: 121 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">\`&quot;&apos;&gt;&lt;img src=xxx:x \\\\x22onerror=javascript:alert(1)&gt;</p>"`;
+exports[`Markdown component xss: 121 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">\`&quot;&apos;&gt;&lt;img src=xxx:x \\\\x22onerror=javascript:alert(1)&gt;</p>"`;
 
-exports[`Markdown component xss: 122 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">\`&quot;&apos;&gt;&lt;img src=xxx:x \\\\x0Bonerror=javascript:alert(1)&gt;</p>"`;
+exports[`Markdown component xss: 122 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">\`&quot;&apos;&gt;&lt;img src=xxx:x \\\\x0Bonerror=javascript:alert(1)&gt;</p>"`;
 
-exports[`Markdown component xss: 123 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">\`&quot;&apos;&gt;&lt;img src=xxx:x \\\\x0Donerror=javascript:alert(1)&gt;</p>"`;
+exports[`Markdown component xss: 123 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">\`&quot;&apos;&gt;&lt;img src=xxx:x \\\\x0Donerror=javascript:alert(1)&gt;</p>"`;
 
-exports[`Markdown component xss: 124 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">\`&quot;&apos;&gt;&lt;img src=xxx:x \\\\x2Fonerror=javascript:alert(1)&gt;</p>"`;
+exports[`Markdown component xss: 124 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">\`&quot;&apos;&gt;&lt;img src=xxx:x \\\\x2Fonerror=javascript:alert(1)&gt;</p>"`;
 
-exports[`Markdown component xss: 125 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">\`&quot;&apos;&gt;&lt;img src=xxx:x \\\\x09onerror=javascript:alert(1)&gt;</p>"`;
+exports[`Markdown component xss: 125 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">\`&quot;&apos;&gt;&lt;img src=xxx:x \\\\x09onerror=javascript:alert(1)&gt;</p>"`;
 
-exports[`Markdown component xss: 126 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">\`&quot;&apos;&gt;&lt;img src=xxx:x \\\\x0Conerror=javascript:alert(1)&gt;</p>"`;
+exports[`Markdown component xss: 126 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">\`&quot;&apos;&gt;&lt;img src=xxx:x \\\\x0Conerror=javascript:alert(1)&gt;</p>"`;
 
-exports[`Markdown component xss: 127 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">\`&quot;&apos;&gt;&lt;img src=xxx:x \\\\x00onerror=javascript:alert(1)&gt;</p>"`;
+exports[`Markdown component xss: 127 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">\`&quot;&apos;&gt;&lt;img src=xxx:x \\\\x00onerror=javascript:alert(1)&gt;</p>"`;
 
-exports[`Markdown component xss: 128 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">\`&quot;&apos;&gt;&lt;img src=xxx:x \\\\x27onerror=javascript:alert(1)&gt;</p>"`;
+exports[`Markdown component xss: 128 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">\`&quot;&apos;&gt;&lt;img src=xxx:x \\\\x27onerror=javascript:alert(1)&gt;</p>"`;
 
-exports[`Markdown component xss: 129 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">\`&quot;&apos;&gt;&lt;img src=xxx:x \\\\x20onerror=javascript:alert(1)&gt;</p>"`;
+exports[`Markdown component xss: 129 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">\`&quot;&apos;&gt;&lt;img src=xxx:x \\\\x20onerror=javascript:alert(1)&gt;</p>"`;
 
-exports[`Markdown component xss: 130 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&quot;\`&apos;&gt;</p>"`;
+exports[`Markdown component xss: 130 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&quot;\`&apos;&gt;</p>"`;
 
-exports[`Markdown component xss: 131 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&quot;\`&apos;&gt;</p>"`;
+exports[`Markdown component xss: 131 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&quot;\`&apos;&gt;</p>"`;
 
-exports[`Markdown component xss: 132 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&quot;\`&apos;&gt;</p>"`;
+exports[`Markdown component xss: 132 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&quot;\`&apos;&gt;</p>"`;
 
-exports[`Markdown component xss: 133 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&quot;\`&apos;&gt;</p>"`;
+exports[`Markdown component xss: 133 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&quot;\`&apos;&gt;</p>"`;
 
-exports[`Markdown component xss: 134 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&quot;\`&apos;&gt;</p>"`;
+exports[`Markdown component xss: 134 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&quot;\`&apos;&gt;</p>"`;
 
-exports[`Markdown component xss: 135 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&quot;\`&apos;&gt;</p>"`;
+exports[`Markdown component xss: 135 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&quot;\`&apos;&gt;</p>"`;
 
-exports[`Markdown component xss: 136 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&quot;\`&apos;&gt;</p>"`;
+exports[`Markdown component xss: 136 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&quot;\`&apos;&gt;</p>"`;
 
-exports[`Markdown component xss: 137 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&quot;\`&apos;&gt;</p>"`;
+exports[`Markdown component xss: 137 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&quot;\`&apos;&gt;</p>"`;
 
-exports[`Markdown component xss: 138 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&quot;\`&apos;&gt;</p>"`;
+exports[`Markdown component xss: 138 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&quot;\`&apos;&gt;</p>"`;
 
-exports[`Markdown component xss: 139 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&quot;\`&apos;&gt;</p>"`;
+exports[`Markdown component xss: 139 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&quot;\`&apos;&gt;</p>"`;
 
-exports[`Markdown component xss: 140 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&quot;\`&apos;&gt;</p>"`;
+exports[`Markdown component xss: 140 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&quot;\`&apos;&gt;</p>"`;
 
-exports[`Markdown component xss: 141 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&quot;\`&apos;&gt;</p>"`;
+exports[`Markdown component xss: 141 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&quot;\`&apos;&gt;</p>"`;
 
-exports[`Markdown component xss: 142 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&quot;\`&apos;&gt;</p>"`;
+exports[`Markdown component xss: 142 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&quot;\`&apos;&gt;</p>"`;
 
-exports[`Markdown component xss: 143 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&quot;\`&apos;&gt;</p>"`;
+exports[`Markdown component xss: 143 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&quot;\`&apos;&gt;</p>"`;
 
-exports[`Markdown component xss: 144 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&quot;\`&apos;&gt;</p>"`;
+exports[`Markdown component xss: 144 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&quot;\`&apos;&gt;</p>"`;
 
-exports[`Markdown component xss: 145 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&quot;\`&apos;&gt;</p>"`;
+exports[`Markdown component xss: 145 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&quot;\`&apos;&gt;</p>"`;
 
-exports[`Markdown component xss: 146 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&quot;\`&apos;&gt;</p>"`;
+exports[`Markdown component xss: 146 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&quot;\`&apos;&gt;</p>"`;
 
-exports[`Markdown component xss: 147 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&quot;\`&apos;&gt;</p>"`;
+exports[`Markdown component xss: 147 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&quot;\`&apos;&gt;</p>"`;
 
-exports[`Markdown component xss: 148 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&quot;\`&apos;&gt;</p>"`;
+exports[`Markdown component xss: 148 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&quot;\`&apos;&gt;</p>"`;
 
-exports[`Markdown component xss: 149 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&quot;\`&apos;&gt;</p>"`;
+exports[`Markdown component xss: 149 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&quot;\`&apos;&gt;</p>"`;
 
-exports[`Markdown component xss: 150 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&quot;\`&apos;&gt;</p>"`;
+exports[`Markdown component xss: 150 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&quot;\`&apos;&gt;</p>"`;
 
-exports[`Markdown component xss: 151 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&quot;\`&apos;&gt;</p>"`;
+exports[`Markdown component xss: 151 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&quot;\`&apos;&gt;</p>"`;
 
-exports[`Markdown component xss: 152 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&quot;\`&apos;&gt;</p>"`;
+exports[`Markdown component xss: 152 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&quot;\`&apos;&gt;</p>"`;
 
-exports[`Markdown component xss: 153 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&quot;\`&apos;&gt;</p>"`;
+exports[`Markdown component xss: 153 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&quot;\`&apos;&gt;</p>"`;
 
-exports[`Markdown component xss: 154 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&quot;\`&apos;&gt;</p>"`;
+exports[`Markdown component xss: 154 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&quot;\`&apos;&gt;</p>"`;
 
-exports[`Markdown component xss: 155 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&quot;\`&apos;&gt;</p>"`;
+exports[`Markdown component xss: 155 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&quot;\`&apos;&gt;</p>"`;
 
-exports[`Markdown component xss: 156 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&quot;\`&apos;&gt;</p>"`;
+exports[`Markdown component xss: 156 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&quot;\`&apos;&gt;</p>"`;
 
-exports[`Markdown component xss: 157 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&quot;\`&apos;&gt;</p>"`;
+exports[`Markdown component xss: 157 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&quot;\`&apos;&gt;</p>"`;
 
-exports[`Markdown component xss: 158 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&quot;\`&apos;&gt;</p>"`;
+exports[`Markdown component xss: 158 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&quot;\`&apos;&gt;</p>"`;
 
-exports[`Markdown component xss: 159 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&quot;\`&apos;&gt;</p>"`;
+exports[`Markdown component xss: 159 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&quot;\`&apos;&gt;</p>"`;
 
-exports[`Markdown component xss: 160 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&quot;\`&apos;&gt;</p>"`;
+exports[`Markdown component xss: 160 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&quot;\`&apos;&gt;</p>"`;
 
-exports[`Markdown component xss: 161 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&quot;\`&apos;&gt;</p>"`;
+exports[`Markdown component xss: 161 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&quot;\`&apos;&gt;</p>"`;
 
-exports[`Markdown component xss: 162 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&quot;\`&apos;&gt;</p>"`;
+exports[`Markdown component xss: 162 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&quot;\`&apos;&gt;</p>"`;
 
-exports[`Markdown component xss: 163 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&quot;\`&apos;&gt;</p>"`;
+exports[`Markdown component xss: 163 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&quot;\`&apos;&gt;</p>"`;
 
-exports[`Markdown component xss: 164 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&quot;\`&apos;&gt;</p>"`;
+exports[`Markdown component xss: 164 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&quot;\`&apos;&gt;</p>"`;
 
-exports[`Markdown component xss: 165 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&quot;\`&apos;&gt;</p>"`;
+exports[`Markdown component xss: 165 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&quot;\`&apos;&gt;</p>"`;
 
-exports[`Markdown component xss: 166 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&quot;\`&apos;&gt;</p>"`;
+exports[`Markdown component xss: 166 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&quot;\`&apos;&gt;</p>"`;
 
-exports[`Markdown component xss: 167 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&lt;img \\\\x00src=x onerror=&quot;alert(1)&quot;&gt;</p>"`;
+exports[`Markdown component xss: 167 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&lt;img \\\\x00src=x onerror=&quot;alert(1)&quot;&gt;</p>"`;
 
-exports[`Markdown component xss: 168 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&lt;img \\\\x47src=x onerror=&quot;javascript:alert(1)&quot;&gt;</p>"`;
+exports[`Markdown component xss: 168 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&lt;img \\\\x47src=x onerror=&quot;javascript:alert(1)&quot;&gt;</p>"`;
 
-exports[`Markdown component xss: 169 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&lt;img \\\\x11src=x onerror=&quot;javascript:alert(1)&quot;&gt;</p>"`;
+exports[`Markdown component xss: 169 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&lt;img \\\\x11src=x onerror=&quot;javascript:alert(1)&quot;&gt;</p>"`;
 
-exports[`Markdown component xss: 170 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&lt;img \\\\x12src=x onerror=&quot;javascript:alert(1)&quot;&gt;</p>"`;
+exports[`Markdown component xss: 170 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&lt;img \\\\x12src=x onerror=&quot;javascript:alert(1)&quot;&gt;</p>"`;
 
-exports[`Markdown component xss: 171 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&lt;img\\\\x47src=x onerror=&quot;javascript:alert(1)&quot;&gt;</p>"`;
+exports[`Markdown component xss: 171 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&lt;img\\\\x47src=x onerror=&quot;javascript:alert(1)&quot;&gt;</p>"`;
 
-exports[`Markdown component xss: 172 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&lt;img\\\\x10src=x onerror=&quot;javascript:alert(1)&quot;&gt;</p>"`;
+exports[`Markdown component xss: 172 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&lt;img\\\\x10src=x onerror=&quot;javascript:alert(1)&quot;&gt;</p>"`;
 
-exports[`Markdown component xss: 173 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&lt;img\\\\x13src=x onerror=&quot;javascript:alert(1)&quot;&gt;</p>"`;
+exports[`Markdown component xss: 173 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&lt;img\\\\x13src=x onerror=&quot;javascript:alert(1)&quot;&gt;</p>"`;
 
-exports[`Markdown component xss: 174 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&lt;img\\\\x32src=x onerror=&quot;javascript:alert(1)&quot;&gt;</p>"`;
+exports[`Markdown component xss: 174 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&lt;img\\\\x32src=x onerror=&quot;javascript:alert(1)&quot;&gt;</p>"`;
 
-exports[`Markdown component xss: 175 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&lt;img\\\\x47src=x onerror=&quot;javascript:alert(1)&quot;&gt;</p>"`;
+exports[`Markdown component xss: 175 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&lt;img\\\\x47src=x onerror=&quot;javascript:alert(1)&quot;&gt;</p>"`;
 
-exports[`Markdown component xss: 176 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&lt;img\\\\x11src=x onerror=&quot;javascript:alert(1)&quot;&gt;</p>"`;
+exports[`Markdown component xss: 176 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&lt;img\\\\x11src=x onerror=&quot;javascript:alert(1)&quot;&gt;</p>"`;
 
-exports[`Markdown component xss: 177 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&lt;img \\\\x47src=x onerror=&quot;javascript:alert(1)&quot;&gt;</p>"`;
+exports[`Markdown component xss: 177 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&lt;img \\\\x47src=x onerror=&quot;javascript:alert(1)&quot;&gt;</p>"`;
 
-exports[`Markdown component xss: 178 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&lt;img \\\\x34src=x onerror=&quot;javascript:alert(1)&quot;&gt;</p>"`;
+exports[`Markdown component xss: 178 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&lt;img \\\\x34src=x onerror=&quot;javascript:alert(1)&quot;&gt;</p>"`;
 
-exports[`Markdown component xss: 179 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&lt;img \\\\x39src=x onerror=&quot;javascript:alert(1)&quot;&gt;</p>"`;
+exports[`Markdown component xss: 179 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&lt;img \\\\x39src=x onerror=&quot;javascript:alert(1)&quot;&gt;</p>"`;
 
-exports[`Markdown component xss: 180 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&lt;img \\\\x00src=x onerror=&quot;javascript:alert(1)&quot;&gt;</p>"`;
+exports[`Markdown component xss: 180 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&lt;img \\\\x00src=x onerror=&quot;javascript:alert(1)&quot;&gt;</p>"`;
 
-exports[`Markdown component xss: 181 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&lt;img src\\\\x09=x onerror=&quot;javascript:alert(1)&quot;&gt;</p>"`;
+exports[`Markdown component xss: 181 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&lt;img src\\\\x09=x onerror=&quot;javascript:alert(1)&quot;&gt;</p>"`;
 
-exports[`Markdown component xss: 182 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&lt;img src\\\\x10=x onerror=&quot;javascript:alert(1)&quot;&gt;</p>"`;
+exports[`Markdown component xss: 182 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&lt;img src\\\\x10=x onerror=&quot;javascript:alert(1)&quot;&gt;</p>"`;
 
-exports[`Markdown component xss: 183 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&lt;img src\\\\x13=x onerror=&quot;javascript:alert(1)&quot;&gt;</p>"`;
+exports[`Markdown component xss: 183 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&lt;img src\\\\x13=x onerror=&quot;javascript:alert(1)&quot;&gt;</p>"`;
 
-exports[`Markdown component xss: 184 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&lt;img src\\\\x32=x onerror=&quot;javascript:alert(1)&quot;&gt;</p>"`;
+exports[`Markdown component xss: 184 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&lt;img src\\\\x32=x onerror=&quot;javascript:alert(1)&quot;&gt;</p>"`;
 
-exports[`Markdown component xss: 185 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&lt;img src\\\\x12=x onerror=&quot;javascript:alert(1)&quot;&gt;</p>"`;
+exports[`Markdown component xss: 185 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&lt;img src\\\\x12=x onerror=&quot;javascript:alert(1)&quot;&gt;</p>"`;
 
-exports[`Markdown component xss: 186 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&lt;img src\\\\x11=x onerror=&quot;javascript:alert(1)&quot;&gt;</p>"`;
+exports[`Markdown component xss: 186 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&lt;img src\\\\x11=x onerror=&quot;javascript:alert(1)&quot;&gt;</p>"`;
 
-exports[`Markdown component xss: 187 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&lt;img src\\\\x00=x onerror=&quot;javascript:alert(1)&quot;&gt;</p>"`;
+exports[`Markdown component xss: 187 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&lt;img src\\\\x00=x onerror=&quot;javascript:alert(1)&quot;&gt;</p>"`;
 
-exports[`Markdown component xss: 188 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&lt;img src\\\\x47=x onerror=&quot;javascript:alert(1)&quot;&gt;</p>"`;
+exports[`Markdown component xss: 188 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&lt;img src\\\\x47=x onerror=&quot;javascript:alert(1)&quot;&gt;</p>"`;
 
-exports[`Markdown component xss: 189 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&lt;img src=x\\\\x09onerror=&quot;javascript:alert(1)&quot;&gt;</p>"`;
+exports[`Markdown component xss: 189 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&lt;img src=x\\\\x09onerror=&quot;javascript:alert(1)&quot;&gt;</p>"`;
 
-exports[`Markdown component xss: 190 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&lt;img src=x\\\\x10onerror=&quot;javascript:alert(1)&quot;&gt;</p>"`;
+exports[`Markdown component xss: 190 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&lt;img src=x\\\\x10onerror=&quot;javascript:alert(1)&quot;&gt;</p>"`;
 
-exports[`Markdown component xss: 191 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&lt;img src=x\\\\x11onerror=&quot;javascript:alert(1)&quot;&gt;</p>"`;
+exports[`Markdown component xss: 191 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&lt;img src=x\\\\x11onerror=&quot;javascript:alert(1)&quot;&gt;</p>"`;
 
-exports[`Markdown component xss: 192 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&lt;img src=x\\\\x12onerror=&quot;javascript:alert(1)&quot;&gt;</p>"`;
+exports[`Markdown component xss: 192 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&lt;img src=x\\\\x12onerror=&quot;javascript:alert(1)&quot;&gt;</p>"`;
 
-exports[`Markdown component xss: 193 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&lt;img src=x\\\\x13onerror=&quot;javascript:alert(1)&quot;&gt;</p>"`;
+exports[`Markdown component xss: 193 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&lt;img src=x\\\\x13onerror=&quot;javascript:alert(1)&quot;&gt;</p>"`;
 
-exports[`Markdown component xss: 194 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&lt;img[a][b][c]src[d]=x[e]onerror=[f]&quot;alert(1)&quot;&gt;</p>"`;
+exports[`Markdown component xss: 194 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&lt;img[a][b][c]src[d]=x[e]onerror=[f]&quot;alert(1)&quot;&gt;</p>"`;
 
-exports[`Markdown component xss: 195 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&lt;img src=x onerror=\\\\x09&quot;javascript:alert(1)&quot;&gt;</p>"`;
+exports[`Markdown component xss: 195 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&lt;img src=x onerror=\\\\x09&quot;javascript:alert(1)&quot;&gt;</p>"`;
 
-exports[`Markdown component xss: 196 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&lt;img src=x onerror=\\\\x10&quot;javascript:alert(1)&quot;&gt;</p>"`;
+exports[`Markdown component xss: 196 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&lt;img src=x onerror=\\\\x10&quot;javascript:alert(1)&quot;&gt;</p>"`;
 
-exports[`Markdown component xss: 197 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&lt;img src=x onerror=\\\\x11&quot;javascript:alert(1)&quot;&gt;</p>"`;
+exports[`Markdown component xss: 197 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&lt;img src=x onerror=\\\\x11&quot;javascript:alert(1)&quot;&gt;</p>"`;
 
-exports[`Markdown component xss: 198 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&lt;img src=x onerror=\\\\x12&quot;javascript:alert(1)&quot;&gt;</p>"`;
+exports[`Markdown component xss: 198 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&lt;img src=x onerror=\\\\x12&quot;javascript:alert(1)&quot;&gt;</p>"`;
 
-exports[`Markdown component xss: 199 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&lt;img src=x onerror=\\\\x32&quot;javascript:alert(1)&quot;&gt;</p>"`;
+exports[`Markdown component xss: 199 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&lt;img src=x onerror=\\\\x32&quot;javascript:alert(1)&quot;&gt;</p>"`;
 
-exports[`Markdown component xss: 200 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&lt;img src=x onerror=\\\\x00&quot;javascript:alert(1)&quot;&gt;</p>"`;
+exports[`Markdown component xss: 200 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&lt;img src=x onerror=\\\\x00&quot;javascript:alert(1)&quot;&gt;</p>"`;
 
-exports[`Markdown component xss: 201 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"><a color=\\"primary.main\\" class=\\"sc-jUfxsr cdkxvi sc-jQAyEw bABfJB\\">XXX</a></p>"`;
+exports[`Markdown component xss: 201 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"><a color=\\"primary.main\\" class=\\"sc-eGJXgd kVAnIx sc-csTaMs eXDzCT\\">XXX</a></p>"`;
 
-exports[`Markdown component xss: 202 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&lt;img src=&quot;x<code> </code>&quot;<code> </code>&gt;</p>"`;
+exports[`Markdown component xss: 202 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&lt;img src=&quot;x<code> </code>&quot;<code> </code>&gt;</p>"`;
 
-exports[`Markdown component xss: 203 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&lt;img src onerror /&quot; &apos;&quot;= alt=javascript:alert(1)//&quot;&gt;</p>"`;
+exports[`Markdown component xss: 203 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&lt;img src onerror /&quot; &apos;&quot;= alt=javascript:alert(1)//&quot;&gt;</p>"`;
 
 exports[`Markdown component xss: 204 1`] = `""`;
 
-exports[`Markdown component xss: 205 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&lt;a href=<a href=\\"http://foo.bar/#x=%60y%3E\\" color=\\"primary.main\\" class=\\"sc-jUfxsr cdkxvi sc-jQAyEw bABfJB\\">http://foo.bar/#x=\`y&gt;</a><img alt=\\"\`&gt;&lt;img src=x:x onerror=javascript:alert(1)&gt;&lt;/a&gt;\\"></p>"`;
+exports[`Markdown component xss: 205 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&lt;a href=<a href=\\"http://foo.bar/#x=%60y%3E\\" color=\\"primary.main\\" class=\\"sc-eGJXgd kVAnIx sc-csTaMs eXDzCT\\">http://foo.bar/#x=\`y&gt;</a><img alt=\\"\`&gt;&lt;img src=x:x onerror=javascript:alert(1)&gt;&lt;/a&gt;\\"></p>"`;
 
 exports[`Markdown component xss: 206 1`] = `""`;
 
@@ -1422,13 +1422,13 @@ exports[`Markdown component xss: 208 1`] = `""`;
 
 exports[`Markdown component xss: 209 1`] = `""`;
 
-exports[`Markdown component xss: 210 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&lt;IMG &quot;&quot;&quot;&gt;&quot;&gt;</p>"`;
+exports[`Markdown component xss: 210 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&lt;IMG &quot;&quot;&quot;&gt;&quot;&gt;</p>"`;
 
 exports[`Markdown component xss: 211 1`] = `"<img>"`;
 
 exports[`Markdown component xss: 212 1`] = `"<img src=\\"#\\">"`;
 
-exports[`Markdown component xss: 213 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&lt;IMG SRC= onmouseover=&quot;alert(&apos;xxs&apos;)&quot;&gt;</p>"`;
+exports[`Markdown component xss: 213 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&lt;IMG SRC= onmouseover=&quot;alert(&apos;xxs&apos;)&quot;&gt;</p>"`;
 
 exports[`Markdown component xss: 214 1`] = `"<img>"`;
 
@@ -1446,34 +1446,34 @@ exports[`Markdown component xss: 220 1`] = `"<img>"`;
 
 exports[`Markdown component xss: 221 1`] = `"<img>"`;
 
-exports[`Markdown component xss: 222 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">perl -e &apos;print &quot;&lt;IMG SRC=java\\\\0script:alert(\\\\&quot;XSS\\\\&quot;)&gt;&quot;;&apos; &gt; out</p>"`;
+exports[`Markdown component xss: 222 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">perl -e &apos;print &quot;&lt;IMG SRC=java\\\\0script:alert(\\\\&quot;XSS\\\\&quot;)&gt;&quot;;&apos; &gt; out</p>"`;
 
 exports[`Markdown component xss: 223 1`] = `"<img>"`;
 
-exports[`Markdown component xss: 224 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&lt;SCRIPT/XSS SRC=&quot;<a href=\\"http://ha.ckers.org/xss.js%22%3E\\" color=\\"primary.main\\" class=\\"sc-jUfxsr cdkxvi sc-jQAyEw bABfJB\\">http://ha.ckers.org/xss.js&quot;&gt;</a></p>"`;
+exports[`Markdown component xss: 224 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&lt;SCRIPT/XSS SRC=&quot;<a href=\\"http://ha.ckers.org/xss.js%22%3E\\" color=\\"primary.main\\" class=\\"sc-eGJXgd kVAnIx sc-csTaMs eXDzCT\\">http://ha.ckers.org/xss.js&quot;&gt;</a></p>"`;
 
 exports[`Markdown component xss: 225 1`] = `""`;
 
-exports[`Markdown component xss: 226 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"><a color=\\"primary.main\\" class=\\"sc-jUfxsr cdkxvi sc-jQAyEw bABfJB\\">SCRIPT/SRC=&quot;http://ha.ckers.org/xss.js&quot;</a></p>"`;
+exports[`Markdown component xss: 226 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"><a color=\\"primary.main\\" class=\\"sc-eGJXgd kVAnIx sc-csTaMs eXDzCT\\">SCRIPT/SRC=&quot;http://ha.ckers.org/xss.js&quot;</a></p>"`;
 
-exports[`Markdown component xss: 227 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&lt;</p>"`;
+exports[`Markdown component xss: 227 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&lt;</p>"`;
 
 exports[`Markdown component xss: 228 1`] = `""`;
 
 exports[`Markdown component xss: 229 1`] = `""`;
 
-exports[`Markdown component xss: 230 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">&lt;IMG SRC=&quot;javascript:alert(&apos;XSS&apos;)&quot;</p>"`;
+exports[`Markdown component xss: 230 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">&lt;IMG SRC=&quot;javascript:alert(&apos;XSS&apos;)&quot;</p>"`;
 
 exports[`Markdown component xss: 231 1`] = `""`;
 
-exports[`Markdown component xss: 232 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">\\\\&quot;;alert(&apos;XSS&apos;);//</p>"`;
+exports[`Markdown component xss: 232 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">\\\\&quot;;alert(&apos;XSS&apos;);//</p>"`;
 
-exports[`Markdown component xss: 233 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"> Copy me</p>"`;
+exports[`Markdown component xss: 233 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"> Copy me</p>"`;
 
-exports[`Markdown component xss: 234 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"><i> Scroll over me </i></p>"`;
+exports[`Markdown component xss: 234 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"><i> Scroll over me </i></p>"`;
 
 exports[`Markdown component xss: 235 1`] = `""`;
 
-exports[`Markdown component xss: 236 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\">http://a/%%30%30</p>"`;
+exports[`Markdown component xss: 236 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\">http://a/%%30%30</p>"`;
 
-exports[`Markdown component xss: 237 1`] = `"<p class=\\"sc-fFSRdu eIqcBa sc-dIvqjp gDTIuo\\"></p>"`;
+exports[`Markdown component xss: 237 1`] = `"<p class=\\"sc-fKgIGh gAGA-DC sc-cxNIbT hWnfAS\\"></p>"`;

--- a/src/internal/Confirm.tsx
+++ b/src/internal/Confirm.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
-import { Box, Button, Popover, PopoverProps, PopoverOptions } from '..';
+import { Box } from '../components/Box';
+import Button from '../components/Button';
+import Popover, { PopoverProps, PopoverOptions } from '../components/Popover';
 
 export interface ConfirmOptions extends PopoverOptions {
 	text: React.ClassicElement<any> | string;


### PR DESCRIPTION
Avoid calling import from '..'.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

---

This is an attempt to fix a weird error in Jellyfish that disappears when I fix the import statements as per this PR.

I suspect it's to do with how webpack resolves components when there is a circular dependency as with Confirm and Button. 

##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have rebuilt the README with `npm run build:docs`
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
