### PR TITLE
Card: make body to be full height

### DIFF
--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -44,7 +44,11 @@ const BaseCard = ({
 			</Box>
 		));
 
-	const Body = children && <Box fontSize={2}>{children}</Box>;
+	const Body = children && (
+		<Box fontSize={2} height="100%">
+			{children}
+		</Box>
+	);
 
 	return (
 		<Wrapper {...props}>


### PR DESCRIPTION
make the body of the card to be full height

Change-type: patch
Signed-off-by: Andrea Rosci <andrear@balena.io>


Opening this PR to be able to bottom align buttons on cards

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have rebuilt the README with `npm run build:docs`
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
