### PR TITLE
Allow passing responsive values to datagrid width props

### DIFF
--- a/src/components/DataGrid/DataGrid.stories.tsx
+++ b/src/components/DataGrid/DataGrid.stories.tsx
@@ -13,8 +13,8 @@ const Template = createTemplate<DataGridProps<number>>(DataGrid);
 
 export const Default = createStory<DataGridProps<number>>(Template, {
 	items: [1, 2, 3, 4, 5, 6],
-	itemMinWidth: '320px',
-	itemMaxWidth: '640px',
+	itemMinWidth: ['180px', '260px', '320px'],
+	itemMaxWidth: ['360px', '520px', '640px'],
 	getItemKey: (i: number) => i,
 	renderItem: (i: number) => (
 		<Card>

--- a/src/components/DataGrid/index.tsx
+++ b/src/components/DataGrid/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { px } from '../../utils';
+import { useBreakpoint } from '../../hooks/useBreakpoint';
 
 const Base = styled.div<MinMaxProps>`
 	display: grid;
@@ -12,7 +13,7 @@ const Base = styled.div<MinMaxProps>`
 
 const BaseItem = styled.div<MinMaxProps>`
 	min-width: ${(props) => props.itemMinWidth};
-	max-width: ${(props) => props.itemMaxWidth ?? '100%'};
+	max-width: ${(props) => props.itemMaxWidth};
 `;
 
 const BaseDataGrid = <T extends any>({
@@ -22,13 +23,16 @@ const BaseDataGrid = <T extends any>({
 	renderItem,
 	getItemKey,
 }: DataGridProps<T>) => {
+	const currentMinWidth = useBreakpoint(itemMinWidth);
+	const currentMaxWidth = useBreakpoint(itemMaxWidth ?? '100%');
+
 	return (
-		<Base itemMinWidth={itemMinWidth} itemMaxWidth={itemMaxWidth}>
+		<Base itemMinWidth={currentMinWidth} itemMaxWidth={currentMaxWidth}>
 			{items.map((item) => (
 				<BaseItem
 					key={getItemKey(item)}
-					itemMinWidth={itemMinWidth}
-					itemMaxWidth={itemMaxWidth}
+					itemMinWidth={currentMinWidth}
+					itemMaxWidth={currentMaxWidth}
 				>
 					{renderItem(item)}
 				</BaseItem>
@@ -45,9 +49,9 @@ export interface DataGridProps<T> {
 	/** A function that returns an item key for each item */
 	getItemKey: (item: T) => string | number;
 	/** The minimum width of each grid item */
-	itemMinWidth: number | string;
+	itemMinWidth: number | string | number[] | string[];
 	/** The maximum width of each grid item */
-	itemMaxWidth?: number | string;
+	itemMaxWidth?: number | string | number[] | string[];
 }
 
 type MinMaxProps = Pick<DataGridProps<any>, 'itemMinWidth' | 'itemMaxWidth'>;

--- a/src/hooks/useBreakpoint.ts
+++ b/src/hooks/useBreakpoint.ts
@@ -8,17 +8,19 @@ import { breakpoints } from '../theme';
 // Min values: 1; Max values: Theme breakpoints length
 // Passing less than the max values the array will automatically be filled with the last value passed.
 // E.g. tablet breakpoint: useBreakpoint(['mobile', 'tablet', 'landscape', 'desktop']) will return 'tablet'
-export const useBreakpoint = <T extends any>(values: T[]): T => {
-	if (values.length > breakpoints.length) {
+export const useBreakpoint = <T extends any>(value: T | T[]): T => {
+	const normalizedValue = Array.isArray(value) ? value : [value];
+
+	if (normalizedValue.length > breakpoints.length) {
 		throw new Error(
 			`There should be no more than ${breakpoints.length} value entries`,
 		);
 	}
 	const { currentBreakpoint } = React.useContext(BreakpointContext);
-	const missingValues = Array(breakpoints.length - values.length).fill(
-		values[values.length - 1],
+	const missingValues = Array(breakpoints.length - normalizedValue.length).fill(
+		normalizedValue[normalizedValue.length - 1],
 	);
-	const newValues = [...values, ...missingValues];
+	const newValues = [...normalizedValue, ...missingValues];
 
 	return newValues[currentBreakpoint];
 };


### PR DESCRIPTION
Change-type: minor
Signed-off-by: Stevche Radevski <stevche@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have rebuilt the README with `npm run build:docs`
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
