### PR TITLE
Fix form not getting the Enter key event when nested in a modal

### DIFF
--- a/src/components/Form/index.tsx
+++ b/src/components/Form/index.tsx
@@ -173,6 +173,12 @@ class BaseForm extends React.Component<FormProps, FormState> {
 		}
 	}
 
+	public handleKeyUpDown(e: React.KeyboardEvent<HTMLDivElement>) {
+		if (e.key === 'Enter' && !this.props.hideSubmitButton) {
+			e.stopPropagation();
+		}
+	}
+
 	public change = (data: IChangeEvent) => {
 		this.setState({ value: data.formData });
 
@@ -211,7 +217,11 @@ class BaseForm extends React.Component<FormProps, FormState> {
 		);
 
 		return (
-			<FormWrapper {...props}>
+			<FormWrapper
+				{...props}
+				onKeyDown={this.handleKeyUpDown}
+				onKeyUp={this.handleKeyUpDown}
+			>
 				<RsjfForm
 					ref={this.formRef}
 					disabled={disabled}

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -51,7 +51,7 @@ class BaseModal extends React.Component<ThemedModalProps, any> {
 			document.body.classList.add(bodyNoOverflowClass);
 		}
 
-		window.document.addEventListener('keydown', this.handleKeyDown);
+		window.addEventListener('keydown', this.handleKeyDown);
 		BaseModal.mountedCount++;
 		this.ownIndex = BaseModal.mountedCount;
 	}
@@ -62,7 +62,7 @@ class BaseModal extends React.Component<ThemedModalProps, any> {
 			document.body.classList.remove(bodyNoOverflowClass);
 		}
 
-		window.document.removeEventListener('keydown', this.handleKeyDown);
+		window.removeEventListener('keydown', this.handleKeyDown);
 	}
 
 	public handleKeyDown = (e: KeyboardEvent) => {

--- a/src/components/Textarea/index.tsx
+++ b/src/components/Textarea/index.tsx
@@ -55,7 +55,23 @@ const BaseTextearea = ({
 		rowsProp = minRows;
 	}
 
-	return <StyledGrommetTextArea rows={rowsProp} {...props} />;
+	const handleKeyUpDown = React.useCallback(
+		(e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+			if (e.key === 'Enter') {
+				e.stopPropagation();
+			}
+		},
+		[],
+	);
+
+	return (
+		<StyledGrommetTextArea
+			rows={rowsProp}
+			onKeyDown={handleKeyUpDown}
+			onKeyUp={handleKeyUpDown}
+			{...props}
+		/>
+	);
 };
 
 export interface InternalTextareaProps


### PR DESCRIPTION
Fixes: #1223
Change-type: patch
Signed-off-by: Stevche Radevski <stevche@balena.io>

<!-- You can remove tags that do not apply. -->
Connects-to: # <!-- waffle convention to track a PR's status through its connected, open issue -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->
Change-type: major|minor|patch <!-- The change type of this PR -->

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have rebuilt the README with `npm run build:docs`
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
