### PR TITLE
Removed out-of-date documentation and template text

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,6 @@ Change-type: major|minor|patch <!-- The change type of this PR -->
 ---
 ##### Contributor checklist
 <!-- For completed items, change [ ] to [x].  -->
-- [ ] I have rebuilt the README with `npm run build:docs`
 - [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
 - [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -64,21 +64,6 @@ other text editing default. We encourage you to install the relevant plugin in
 your text editor of choice to avoid having to fix any issues during the review
 process.
 
-
-Updating documentation
-----------------------
-
-All components have a corresponding markdown file that documents their API. The
-markdown files are found in `src/stories/README/`. The markdown files are
-displayed in the interactive storybook and also aggregated into the main README
-file. After making any changes to a component, make sure the corresponding
-markdown file is up to date and then update the README using the following
-command:
-
-```sh
-npm run build:docs
-```
-
 Commit Guidelines
 -----------------
 

--- a/src/components/Accordion/__snapshots__/Accordion.stories.storyshot
+++ b/src/components/Accordion/__snapshots__/Accordion.stories.storyshot
@@ -59,13 +59,7 @@ exports[`Storyshots Core/Accordion Default 1`] = `
           <div
             aria-hidden="true"
             class="StyledBox-sc-13pk1d4-0 dYebPD Collapsible__AnimatedBox-sc-15kniua-0 euNsBL"
-          >
-            <div
-              class="sc-gKsewC cgpPfo sc-iBPRYJ dcxFGD"
-            >
-              First Panel
-            </div>
-          </div>
+          />
         </div>
       </div>
       <div
@@ -118,13 +112,7 @@ exports[`Storyshots Core/Accordion Default 1`] = `
           <div
             aria-hidden="true"
             class="StyledBox-sc-13pk1d4-0 dYebPD Collapsible__AnimatedBox-sc-15kniua-0 euNsBL"
-          >
-            <div
-              class="sc-gKsewC cgpPfo sc-iBPRYJ dcxFGD"
-            >
-              Second Panel
-            </div>
-          </div>
+          />
         </div>
       </div>
     </div>

--- a/src/components/Form/__snapshots__/Form.stories.storyshot
+++ b/src/components/Form/__snapshots__/Form.stories.storyshot
@@ -48,7 +48,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                         
                         <input
                           autocomplete="off"
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
                           id="root_Name"
                           label="Name"
                           list="dummy-datalist"
@@ -79,7 +79,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
                           id="root_Height"
                           label="Height"
                           placeholder=""
@@ -106,7 +106,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
                           id="root_Weight"
                           label="Weight"
                           placeholder=""
@@ -133,7 +133,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
                           id="root_Description"
                           label="Description"
                           placeholder=""
@@ -160,7 +160,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
                           id="root_Category"
                           label="Category"
                           placeholder=""
@@ -187,7 +187,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
                           id="root_Abilities"
                           label="Abilities"
                           placeholder=""
@@ -214,7 +214,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
                           id="root_pokedex_number"
                           label="National Pokèdex Number"
                           placeholder=""
@@ -274,7 +274,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
                           id="root_first_seen"
                           label="First seen"
                           placeholder=""
@@ -313,7 +313,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
                           id="root_poke_password"
                           label="Poke Password"
                           placeholder=""
@@ -355,7 +355,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                               >
                                 <input
                                   autocomplete="off"
-                                  class="StyledTextInput-sc-1x30a0s-0 eRNDsB Select__SelectTextInput-sc-17idtfo-0 bIurki sc-higXBA gDWSrd"
+                                  class="StyledTextInput-sc-1x30a0s-0 ccRbRh Select__SelectTextInput-sc-17idtfo-0 bIurki sc-higXBA gDWSrd"
                                   id="root_environment__input"
                                   readonly=""
                                   tabindex="-1"
@@ -518,7 +518,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                         
                         <input
                           autocomplete="off"
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
                           id="root_Name"
                           label="Name"
                           list="dummy-datalist"
@@ -549,7 +549,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
                           id="root_Height"
                           label="Height"
                           placeholder=""
@@ -576,7 +576,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
                           id="root_Weight"
                           label="Weight"
                           placeholder=""
@@ -603,7 +603,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
                           id="root_Description"
                           label="Description"
                           placeholder=""
@@ -630,7 +630,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
                           id="root_Category"
                           label="Category"
                           placeholder=""
@@ -657,7 +657,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
                           id="root_Abilities"
                           label="Abilities"
                           placeholder=""
@@ -684,7 +684,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
                           id="root_pokedex_number"
                           label="National Pokèdex Number"
                           placeholder=""
@@ -744,7 +744,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
                           id="root_first_seen"
                           label="First seen"
                           placeholder=""
@@ -783,7 +783,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
                           id="root_poke_password"
                           label="Poke Password"
                           placeholder=""
@@ -825,7 +825,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                               >
                                 <input
                                   autocomplete="off"
-                                  class="StyledTextInput-sc-1x30a0s-0 eRNDsB Select__SelectTextInput-sc-17idtfo-0 bIurki sc-higXBA gDWSrd"
+                                  class="StyledTextInput-sc-1x30a0s-0 ccRbRh Select__SelectTextInput-sc-17idtfo-0 bIurki sc-higXBA gDWSrd"
                                   id="root_environment__input"
                                   readonly=""
                                   tabindex="-1"
@@ -988,7 +988,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                         
                         <input
                           autocomplete="off"
-                          class="StyledTextInput-sc-1x30a0s-0 jUIQqT sc-iNqMTl bYipSQ sc-jeGSBP gPfRGf"
+                          class="StyledTextInput-sc-1x30a0s-0 gCxMXz sc-iNqMTl bYipSQ sc-jeGSBP gPfRGf"
                           disabled=""
                           id="root_Name"
                           label="Name"
@@ -1020,7 +1020,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 jUIQqT sc-iNqMTl bYipSQ sc-jeGSBP gPfRGf"
+                          class="StyledTextInput-sc-1x30a0s-0 gCxMXz sc-iNqMTl bYipSQ sc-jeGSBP gPfRGf"
                           disabled=""
                           id="root_Height"
                           label="Height"
@@ -1048,7 +1048,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 jUIQqT sc-iNqMTl bYipSQ sc-jeGSBP gPfRGf"
+                          class="StyledTextInput-sc-1x30a0s-0 gCxMXz sc-iNqMTl bYipSQ sc-jeGSBP gPfRGf"
                           disabled=""
                           id="root_Weight"
                           label="Weight"
@@ -1076,7 +1076,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 jUIQqT sc-iNqMTl bYipSQ sc-jeGSBP gPfRGf"
+                          class="StyledTextInput-sc-1x30a0s-0 gCxMXz sc-iNqMTl bYipSQ sc-jeGSBP gPfRGf"
                           disabled=""
                           id="root_Description"
                           label="Description"
@@ -1104,7 +1104,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 jUIQqT sc-iNqMTl bYipSQ sc-jeGSBP gPfRGf"
+                          class="StyledTextInput-sc-1x30a0s-0 gCxMXz sc-iNqMTl bYipSQ sc-jeGSBP gPfRGf"
                           disabled=""
                           id="root_Category"
                           label="Category"
@@ -1132,7 +1132,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 jUIQqT sc-iNqMTl bYipSQ sc-jeGSBP gPfRGf"
+                          class="StyledTextInput-sc-1x30a0s-0 gCxMXz sc-iNqMTl bYipSQ sc-jeGSBP gPfRGf"
                           disabled=""
                           id="root_Abilities"
                           label="Abilities"
@@ -1160,7 +1160,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 jUIQqT sc-iNqMTl bYipSQ sc-jeGSBP gPfRGf"
+                          class="StyledTextInput-sc-1x30a0s-0 gCxMXz sc-iNqMTl bYipSQ sc-jeGSBP gPfRGf"
                           disabled=""
                           id="root_pokedex_number"
                           label="National Pokèdex Number"
@@ -1222,7 +1222,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 jUIQqT sc-iNqMTl bYipSQ sc-jeGSBP gPfRGf"
+                          class="StyledTextInput-sc-1x30a0s-0 gCxMXz sc-iNqMTl bYipSQ sc-jeGSBP gPfRGf"
                           disabled=""
                           id="root_first_seen"
                           label="First seen"
@@ -1262,7 +1262,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 jUIQqT sc-iNqMTl bYipSQ sc-jeGSBP gPfRGf"
+                          class="StyledTextInput-sc-1x30a0s-0 gCxMXz sc-iNqMTl bYipSQ sc-jeGSBP gPfRGf"
                           disabled=""
                           id="root_poke_password"
                           label="Poke Password"
@@ -1306,7 +1306,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                               >
                                 <input
                                   autocomplete="off"
-                                  class="StyledTextInput-sc-1x30a0s-0 eRNDsB Select__SelectTextInput-sc-17idtfo-0 cANsmG sc-higXBA gDWSrd"
+                                  class="StyledTextInput-sc-1x30a0s-0 ccRbRh Select__SelectTextInput-sc-17idtfo-0 cANsmG sc-higXBA gDWSrd"
                                   id="root_environment__input"
                                   readonly=""
                                   tabindex="-1"
@@ -1469,7 +1469,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                         
                         <input
                           autocomplete="off"
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
                           id="root_Name"
                           label="Name"
                           list="dummy-datalist"
@@ -1500,7 +1500,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
                           id="root_Height"
                           label="Height"
                           placeholder=""
@@ -1527,7 +1527,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
                           id="root_Weight"
                           label="Weight"
                           placeholder=""
@@ -1554,7 +1554,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
                           id="root_Description"
                           label="Description"
                           placeholder=""
@@ -1581,7 +1581,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
                           id="root_Category"
                           label="Category"
                           placeholder=""
@@ -1608,7 +1608,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
                           id="root_Abilities"
                           label="Abilities"
                           placeholder=""
@@ -1635,7 +1635,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
                           id="root_pokedex_number"
                           label="National Pokèdex Number"
                           placeholder=""
@@ -1695,7 +1695,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
                           id="root_first_seen"
                           label="First seen"
                           placeholder=""
@@ -1734,7 +1734,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
                           id="root_poke_password"
                           label="Poke Password"
                           placeholder=""
@@ -1776,7 +1776,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                               >
                                 <input
                                   autocomplete="off"
-                                  class="StyledTextInput-sc-1x30a0s-0 eRNDsB Select__SelectTextInput-sc-17idtfo-0 bIurki sc-higXBA gDWSrd"
+                                  class="StyledTextInput-sc-1x30a0s-0 ccRbRh Select__SelectTextInput-sc-17idtfo-0 bIurki sc-higXBA gDWSrd"
                                   id="root_environment__input"
                                   readonly=""
                                   tabindex="-1"
@@ -1934,7 +1934,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                         
                         <input
                           autocomplete="off"
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
                           id="root_Name"
                           label="Name"
                           list="dummy-datalist"
@@ -1965,7 +1965,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
                           id="root_Height"
                           label="Height"
                           placeholder=""
@@ -1992,7 +1992,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
                           id="root_Weight"
                           label="Weight"
                           placeholder=""
@@ -2019,7 +2019,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
                           id="root_Description"
                           label="Description"
                           placeholder=""
@@ -2046,7 +2046,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
                           id="root_Category"
                           label="Category"
                           placeholder=""
@@ -2073,7 +2073,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
                           id="root_Abilities"
                           label="Abilities"
                           placeholder=""
@@ -2100,7 +2100,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
                           id="root_pokedex_number"
                           label="National Pokèdex Number"
                           placeholder=""
@@ -2160,7 +2160,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
                           id="root_first_seen"
                           label="First seen"
                           placeholder=""
@@ -2199,7 +2199,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
                           id="root_poke_password"
                           label="Poke Password"
                           placeholder=""
@@ -2241,7 +2241,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                               >
                                 <input
                                   autocomplete="off"
-                                  class="StyledTextInput-sc-1x30a0s-0 eRNDsB Select__SelectTextInput-sc-17idtfo-0 bIurki sc-higXBA gDWSrd"
+                                  class="StyledTextInput-sc-1x30a0s-0 ccRbRh Select__SelectTextInput-sc-17idtfo-0 bIurki sc-higXBA gDWSrd"
                                   id="root_environment__input"
                                   readonly=""
                                   tabindex="-1"
@@ -2529,6 +2529,8 @@ exports[`Storyshots Core/Form With Extra Widgets 1`] = `
               Form.registerWidget
             </code>
              method.
+            <br />
+            
 Rendition contains widgets for rendering Markdown and Mermaid text formats that can be used in the following way:
           </p>
           
@@ -3220,7 +3222,7 @@ Rendition contains widgets for rendering Markdown and Mermaid text formats that 
                           role="tabpanel"
                         >
                           <textarea
-                            class="StyledTextArea-sc-17i3mwp-0 cICwEP sc-eJMQSu cfWEDV sc-nFpLZ jNUxxL"
+                            class="StyledTextArea-sc-17i3mwp-0 gFImaJ sc-eJMQSu cfWEDV sc-nFpLZ jNUxxL"
                             id="root_Mermaid"
                             label="Mermaid"
                             placeholder=""
@@ -3623,7 +3625,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                         
                         <input
                           autocomplete="off"
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
                           id="root_Name"
                           label="Name"
                           list="dummy-datalist"
@@ -3686,7 +3688,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                         Description
                       </label>
                       <textarea
-                        class="StyledTextArea-sc-17i3mwp-0 cICwEP sc-eJMQSu cfWEDV sc-nFpLZ jNUxxL form-control"
+                        class="StyledTextArea-sc-17i3mwp-0 gFImaJ sc-eJMQSu cfWEDV sc-nFpLZ jNUxxL form-control"
                         id="root_Description"
                         placeholder=""
                         rows="5"
@@ -3710,7 +3712,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
                           id="root_Abilities"
                           label="Abilities"
                           placeholder=""
@@ -3737,7 +3739,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-iNqMTl gZlZKg sc-jeGSBP gPfRGf"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-iNqMTl gZlZKg sc-jeGSBP gPfRGf"
                           id="root_Height"
                           label="Height"
                           placeholder=""
@@ -3764,7 +3766,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
                           id="root_Weight"
                           label="Weight"
                           placeholder=""
@@ -3791,7 +3793,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
                           id="root_Category"
                           label="Category"
                           placeholder=""
@@ -3818,7 +3820,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
                           id="root_pokedex_number"
                           label="National Pokèdex Number"
                           placeholder=""
@@ -3857,7 +3859,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
                           id="root_first_seen"
                           label="First seen"
                           placeholder=""
@@ -3899,7 +3901,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                         >
                           
                           <input
-                            class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-iNqMTl gBktVj sc-jeGSBP hZVWGl"
+                            class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-iNqMTl gBktVj sc-jeGSBP hZVWGl"
                             id="root_poke_password"
                             label="Poke Password"
                             placeholder=""
@@ -3962,7 +3964,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                               >
                                 <input
                                   autocomplete="off"
-                                  class="StyledTextInput-sc-1x30a0s-0 eRNDsB Select__SelectTextInput-sc-17idtfo-0 bIurki sc-higXBA jRjDwm"
+                                  class="StyledTextInput-sc-1x30a0s-0 ccRbRh Select__SelectTextInput-sc-17idtfo-0 bIurki sc-higXBA jRjDwm"
                                   id="root_environment__input"
                                   readonly=""
                                   tabindex="-1"
@@ -4139,7 +4141,7 @@ exports[`Storyshots Core/Form With Pattern Properties 1`] = `
                                     >
                                       <input
                                         autocomplete="off"
-                                        class="StyledTextInput-sc-1x30a0s-0 jUIQqT sc-iNqMTl bYipSQ sc-jeGSBP bkWmPY rendition-form-pattern-properties__key-field"
+                                        class="StyledTextInput-sc-1x30a0s-0 gCxMXz sc-iNqMTl bYipSQ sc-jeGSBP bkWmPY rendition-form-pattern-properties__key-field"
                                         disabled=""
                                         pattern="^[0-9]+$"
                                         placeholder="Key"
@@ -4153,7 +4155,7 @@ exports[`Storyshots Core/Form With Pattern Properties 1`] = `
                                     >
                                       <input
                                         autocomplete="off"
-                                        class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-iNqMTl gBktVj sc-jeGSBP bkWmPY rendition-form-pattern-properties__value-field"
+                                        class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-iNqMTl gBktVj sc-jeGSBP bkWmPY rendition-form-pattern-properties__value-field"
                                         id="foo"
                                         placeholder="Rule"
                                         value=""
@@ -4261,7 +4263,7 @@ exports[`Storyshots Core/Form With Titles 1`] = `
                               >
                                 
                                 <input
-                                  class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
+                                  class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
                                   id="root_vpn_endpoint"
                                   label="Endpoint"
                                   placeholder=""
@@ -4288,7 +4290,7 @@ exports[`Storyshots Core/Form With Titles 1`] = `
                               >
                                 
                                 <input
-                                  class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
+                                  class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
                                   id="root_vpn_certificate"
                                   label="Certificate"
                                   placeholder=""
@@ -4345,7 +4347,7 @@ exports[`Storyshots Core/Form With Titles 1`] = `
                                       >
                                         
                                         <input
-                                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
+                                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
                                           id="root_wifiNetwork_wifi_ssid"
                                           label="Network SSID"
                                           placeholder=""
@@ -4386,7 +4388,7 @@ exports[`Storyshots Core/Form With Titles 1`] = `
                                       >
                                         
                                         <input
-                                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
+                                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
                                           id="root_wifiNetwork_wifiSecurity_psk"
                                           label="Network Passphrase"
                                           placeholder=""
@@ -4486,7 +4488,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                         
                         <input
                           autocomplete="off"
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
                           id="root_Name"
                           label="Name"
                           list="dummy-datalist"
@@ -4534,7 +4536,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                         Description
                       </label>
                       <textarea
-                        class="StyledTextArea-sc-17i3mwp-0 cICwEP sc-eJMQSu cfWEDV sc-nFpLZ jNUxxL form-control"
+                        class="StyledTextArea-sc-17i3mwp-0 gFImaJ sc-eJMQSu cfWEDV sc-nFpLZ jNUxxL form-control"
                         id="root_Description"
                         placeholder=""
                         rows="5"
@@ -4558,7 +4560,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
                           id="root_Abilities"
                           label="Abilities"
                           placeholder=""
@@ -4585,7 +4587,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-iNqMTl gZlZKg sc-jeGSBP gPfRGf"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-iNqMTl gZlZKg sc-jeGSBP gPfRGf"
                           id="root_Height"
                           label="Height"
                           placeholder=""
@@ -4612,7 +4614,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
                           id="root_Weight"
                           label="Weight"
                           placeholder=""
@@ -4639,7 +4641,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
                           id="root_Category"
                           label="Category"
                           placeholder=""
@@ -4666,7 +4668,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
                           id="root_pokedex_number"
                           label="National Pokèdex Number"
                           placeholder=""
@@ -4705,7 +4707,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
                           id="root_first_seen"
                           label="First seen"
                           placeholder=""
@@ -4747,7 +4749,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                         >
                           
                           <input
-                            class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-iNqMTl gBktVj sc-jeGSBP hZVWGl"
+                            class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-iNqMTl gBktVj sc-jeGSBP hZVWGl"
                             id="root_poke_password"
                             label="Poke Password"
                             placeholder=""
@@ -4810,7 +4812,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                               >
                                 <input
                                   autocomplete="off"
-                                  class="StyledTextInput-sc-1x30a0s-0 eRNDsB Select__SelectTextInput-sc-17idtfo-0 bIurki sc-higXBA jRjDwm"
+                                  class="StyledTextInput-sc-1x30a0s-0 ccRbRh Select__SelectTextInput-sc-17idtfo-0 bIurki sc-higXBA jRjDwm"
                                   id="root_environment__input"
                                   readonly=""
                                   tabindex="-1"
@@ -5015,7 +5017,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                         
                         <input
                           autocomplete="off"
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
                           id="root_Name"
                           label="Name"
                           list="dummy-datalist"
@@ -5063,7 +5065,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                         Description
                       </label>
                       <textarea
-                        class="StyledTextArea-sc-17i3mwp-0 cICwEP sc-eJMQSu cfWEDV sc-nFpLZ jNUxxL form-control"
+                        class="StyledTextArea-sc-17i3mwp-0 gFImaJ sc-eJMQSu cfWEDV sc-nFpLZ jNUxxL form-control"
                         id="root_Description"
                         placeholder=""
                         rows="5"
@@ -5087,7 +5089,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
                           id="root_Abilities"
                           label="Abilities"
                           placeholder=""
@@ -5114,7 +5116,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-iNqMTl gZlZKg sc-jeGSBP gPfRGf"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-iNqMTl gZlZKg sc-jeGSBP gPfRGf"
                           id="root_Height"
                           label="Height"
                           placeholder=""
@@ -5141,7 +5143,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
                           id="root_Weight"
                           label="Weight"
                           placeholder=""
@@ -5168,7 +5170,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
                           id="root_Category"
                           label="Category"
                           placeholder=""
@@ -5195,7 +5197,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
                           id="root_pokedex_number"
                           label="National Pokèdex Number"
                           placeholder=""
@@ -5234,7 +5236,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-iNqMTl gBktVj sc-jeGSBP gPfRGf"
                           id="root_first_seen"
                           label="First seen"
                           placeholder=""
@@ -5276,7 +5278,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                         >
                           
                           <input
-                            class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-iNqMTl gBktVj sc-jeGSBP hZVWGl"
+                            class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-iNqMTl gBktVj sc-jeGSBP hZVWGl"
                             id="root_poke_password"
                             label="Poke Password"
                             placeholder=""
@@ -5339,7 +5341,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                               >
                                 <input
                                   autocomplete="off"
-                                  class="StyledTextInput-sc-1x30a0s-0 eRNDsB Select__SelectTextInput-sc-17idtfo-0 bIurki sc-higXBA jRjDwm"
+                                  class="StyledTextInput-sc-1x30a0s-0 ccRbRh Select__SelectTextInput-sc-17idtfo-0 bIurki sc-higXBA jRjDwm"
                                   id="root_environment__input"
                                   readonly=""
                                   tabindex="-1"

--- a/src/components/Input/__snapshots__/Input.stories.storyshot
+++ b/src/components/Input/__snapshots__/Input.stories.storyshot
@@ -10,7 +10,7 @@ exports[`Storyshots Core/Input Default 1`] = `
     >
       <input
         autocomplete="off"
-        class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-iNqMTl gBktVj sc-jeGSBP bkWmPY"
+        class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-iNqMTl gBktVj sc-jeGSBP bkWmPY"
         value=""
       />
     </div>
@@ -28,7 +28,7 @@ exports[`Storyshots Core/Input Emphasized 1`] = `
     >
       <input
         autocomplete="off"
-        class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-iNqMTl gZlZKg sc-jeGSBP bkWmPY"
+        class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-iNqMTl gZlZKg sc-jeGSBP bkWmPY"
         value=""
       />
     </div>
@@ -46,7 +46,7 @@ exports[`Storyshots Core/Input Monospace 1`] = `
     >
       <input
         autocomplete="off"
-        class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-iNqMTl hrXUkK sc-jeGSBP bkWmPY"
+        class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-iNqMTl hrXUkK sc-jeGSBP bkWmPY"
         value=""
       />
     </div>
@@ -64,7 +64,7 @@ exports[`Storyshots Core/Input With Placeholder 1`] = `
     >
       <input
         autocomplete="off"
-        class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-iNqMTl gBktVj sc-jeGSBP bkWmPY"
+        class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-iNqMTl gBktVj sc-jeGSBP bkWmPY"
         placeholder="This is a placeholder"
         value=""
       />

--- a/src/components/Select/__snapshots__/Select.stories.storyshot
+++ b/src/components/Select/__snapshots__/Select.stories.storyshot
@@ -24,7 +24,7 @@ exports[`Storyshots Core/Select Default 1`] = `
             >
               <input
                 autocomplete="off"
-                class="StyledTextInput-sc-1x30a0s-0 eRNDsB Select__SelectTextInput-sc-17idtfo-0 bIurki sc-higXBA gDWSrd"
+                class="StyledTextInput-sc-1x30a0s-0 ccRbRh Select__SelectTextInput-sc-17idtfo-0 bIurki sc-higXBA gDWSrd"
                 readonly=""
                 tabindex="-1"
                 type="text"
@@ -80,7 +80,7 @@ exports[`Storyshots Core/Select Emphasized 1`] = `
             >
               <input
                 autocomplete="off"
-                class="StyledTextInput-sc-1x30a0s-0 eRNDsB Select__SelectTextInput-sc-17idtfo-0 bIurki sc-higXBA jRjDwm"
+                class="StyledTextInput-sc-1x30a0s-0 ccRbRh Select__SelectTextInput-sc-17idtfo-0 bIurki sc-higXBA jRjDwm"
                 readonly=""
                 tabindex="-1"
                 type="text"
@@ -136,7 +136,7 @@ exports[`Storyshots Core/Select Invalid 1`] = `
             >
               <input
                 autocomplete="off"
-                class="StyledTextInput-sc-1x30a0s-0 eRNDsB Select__SelectTextInput-sc-17idtfo-0 bIurki sc-higXBA gDWSrd"
+                class="StyledTextInput-sc-1x30a0s-0 ccRbRh Select__SelectTextInput-sc-17idtfo-0 bIurki sc-higXBA gDWSrd"
                 readonly=""
                 tabindex="-1"
                 type="text"
@@ -192,7 +192,7 @@ exports[`Storyshots Core/Select Object Options 1`] = `
             >
               <input
                 autocomplete="off"
-                class="StyledTextInput-sc-1x30a0s-0 eRNDsB Select__SelectTextInput-sc-17idtfo-0 bIurki sc-higXBA gDWSrd"
+                class="StyledTextInput-sc-1x30a0s-0 ccRbRh Select__SelectTextInput-sc-17idtfo-0 bIurki sc-higXBA gDWSrd"
                 readonly=""
                 tabindex="-1"
                 type="text"
@@ -248,7 +248,7 @@ exports[`Storyshots Core/Select With Custom Option 1`] = `
             >
               <input
                 autocomplete="off"
-                class="StyledTextInput-sc-1x30a0s-0 eRNDsB Select__SelectTextInput-sc-17idtfo-0 bIurki sc-higXBA gDWSrd"
+                class="StyledTextInput-sc-1x30a0s-0 ccRbRh Select__SelectTextInput-sc-17idtfo-0 bIurki sc-higXBA gDWSrd"
                 readonly=""
                 tabindex="-1"
                 type="text"
@@ -304,7 +304,7 @@ exports[`Storyshots Core/Select With Placeholder 1`] = `
             >
               <input
                 autocomplete="off"
-                class="StyledTextInput-sc-1x30a0s-0 eRNDsB Select__SelectTextInput-sc-17idtfo-0 bIurki sc-higXBA gDWSrd"
+                class="StyledTextInput-sc-1x30a0s-0 ccRbRh Select__SelectTextInput-sc-17idtfo-0 bIurki sc-higXBA gDWSrd"
                 placeholder="Select one..."
                 readonly=""
                 tabindex="-1"

--- a/src/components/Textarea/__snapshots__/Textarea.stories.storyshot
+++ b/src/components/Textarea/__snapshots__/Textarea.stories.storyshot
@@ -6,7 +6,7 @@ exports[`Storyshots Core/Textarea Auto Rows 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-fXoxut gqvpza"
   >
     <textarea
-      class="StyledTextArea-sc-17i3mwp-0 cICwEP sc-eJMQSu cfWEDV sc-nFpLZ jNUxxL"
+      class="StyledTextArea-sc-17i3mwp-0 gFImaJ sc-eJMQSu cfWEDV sc-nFpLZ jNUxxL"
     />
   </div>
 </div>
@@ -18,7 +18,7 @@ exports[`Storyshots Core/Textarea Default 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-fXoxut gqvpza"
   >
     <textarea
-      class="StyledTextArea-sc-17i3mwp-0 cICwEP sc-eJMQSu cfWEDV sc-nFpLZ jNUxxL"
+      class="StyledTextArea-sc-17i3mwp-0 gFImaJ sc-eJMQSu cfWEDV sc-nFpLZ jNUxxL"
     />
   </div>
 </div>
@@ -30,7 +30,7 @@ exports[`Storyshots Core/Textarea Disabled 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-fXoxut gqvpza"
   >
     <textarea
-      class="StyledTextArea-sc-17i3mwp-0 izGVYB sc-eJMQSu crWXjy sc-nFpLZ jNUxxL"
+      class="StyledTextArea-sc-17i3mwp-0 fQPlXT sc-eJMQSu crWXjy sc-nFpLZ jNUxxL"
       disabled=""
     />
   </div>
@@ -43,7 +43,7 @@ exports[`Storyshots Core/Textarea Min Max Rows 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-fXoxut gqvpza"
   >
     <textarea
-      class="StyledTextArea-sc-17i3mwp-0 cICwEP sc-eJMQSu cfWEDV sc-nFpLZ jNUxxL"
+      class="StyledTextArea-sc-17i3mwp-0 gFImaJ sc-eJMQSu cfWEDV sc-nFpLZ jNUxxL"
       rows="4"
     />
   </div>
@@ -56,7 +56,7 @@ exports[`Storyshots Core/Textarea Monospace 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-fXoxut gqvpza"
   >
     <textarea
-      class="StyledTextArea-sc-17i3mwp-0 cICwEP sc-eJMQSu crbfos sc-nFpLZ jNUxxL"
+      class="StyledTextArea-sc-17i3mwp-0 gFImaJ sc-eJMQSu crbfos sc-nFpLZ jNUxxL"
       placeholder="Type something..."
     />
   </div>
@@ -69,7 +69,7 @@ exports[`Storyshots Core/Textarea Read Only 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-fXoxut gqvpza"
   >
     <textarea
-      class="StyledTextArea-sc-17i3mwp-0 cICwEP sc-eJMQSu cfWEDV sc-nFpLZ jNUxxL"
+      class="StyledTextArea-sc-17i3mwp-0 gFImaJ sc-eJMQSu cfWEDV sc-nFpLZ jNUxxL"
       readonly=""
     />
   </div>
@@ -82,7 +82,7 @@ exports[`Storyshots Core/Textarea With Placeholder 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-fXoxut gqvpza"
   >
     <textarea
-      class="StyledTextArea-sc-17i3mwp-0 cICwEP sc-eJMQSu cfWEDV sc-nFpLZ jNUxxL"
+      class="StyledTextArea-sc-17i3mwp-0 gFImaJ sc-eJMQSu cfWEDV sc-nFpLZ jNUxxL"
       placeholder="Type something..."
     />
   </div>

--- a/src/extra/Markdown/__snapshots__/Markdown.stories.storyshot
+++ b/src/extra/Markdown/__snapshots__/Markdown.stories.storyshot
@@ -386,6 +386,7 @@ exports[`Storyshots Extra/Markdown Default 1`] = `
           <em>
             This text will be italic
           </em>
+          <br />
           
 
           <em>
@@ -400,6 +401,7 @@ exports[`Storyshots Extra/Markdown Default 1`] = `
           <strong>
             This text will be bold
           </strong>
+          <br />
           
 
           <strong>
@@ -602,6 +604,8 @@ exports[`Storyshots Extra/Markdown Default 1`] = `
           class="sc-fKFyDc dToKui sc-cxFLnm kkkmRH"
         >
           I think you should use an
+          <br />
+          
 
           <code>
             &lt;addr&gt;
@@ -853,22 +857,27 @@ const foo = () =&gt; {
           <strong>
             An image:
           </strong>
+          <br />
           
 
+          <br />
           <br />
           
 
           <img
             src=""
           />
+          <br />
           
 
+          <br />
           <br />
           
 
           <em>
             A link:
           </em>
+          <br />
           
 
           <a

--- a/src/extra/Markdown/__snapshots__/spec.tsx.snap
+++ b/src/extra/Markdown/__snapshots__/spec.tsx.snap
@@ -2129,15 +2129,20 @@ exports[`Markdown component should not render raw html when disabled 1`] = `
           class=""
         >
           An image:
+          <br />
           
 
+          <br />
           
 
+          <br />
           
 
+          <br />
           
 
           A link:
+          <br />
           
 
           http://github.com/


### PR DESCRIPTION
Docs are no longer generated using build:docs.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

---

##### Contributor checklist
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
