### PR TITLE
Add Breadcrumbs component

### DIFF
--- a/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { Meta } from '@storybook/react';
+import { createTemplate, createStory } from '../../stories/utils';
+import { Breadcrumbs, BreadcrumbsProps } from '.';
+import { faRecycle } from '@fortawesome/free-solid-svg-icons/faRecycle';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
+export default {
+	title: 'Core/Breadcrumbs',
+	component: Breadcrumbs,
+	parameters: {
+		backgrounds: {
+			default: 'dark',
+		},
+	},
+} as Meta;
+
+const Template = createTemplate<BreadcrumbsProps>(Breadcrumbs);
+
+export const Default = createStory<BreadcrumbsProps>(Template, {
+	crumbs: [
+		{
+			text: 'route 1',
+			onClick: () => alert('click route 1'),
+		},
+		{
+			text: 'route 2',
+			onClick: () => alert('click route 2'),
+		},
+		{
+			text: 'route 3 with icon',
+			icon: <FontAwesomeIcon icon={faRecycle} />,
+			onClick: () => alert('click route 3'),
+		},
+	],
+});

--- a/src/components/Breadcrumbs/__snapshots__/Breadcrumbs.stories.storyshot
+++ b/src/components/Breadcrumbs/__snapshots__/Breadcrumbs.stories.storyshot
@@ -1,0 +1,137 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storyshots Core/Breadcrumbs Default 1`] = `
+<div>
+  <div
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-dWdcrH ScrBw"
+  >
+    <div
+      class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr fAzoTG"
+    >
+      <div
+        class="sc-fKFyDc jHCVxA sc-bBXqnf cNzyxC"
+      >
+        <div
+          class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr iIBJBt"
+        >
+          <div
+            class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cuSvIJ"
+          >
+            <div
+              class="sc-gKsewC cgpPfo sc-iBPRYJ dlUrgp sc-hHftDr sc-jLiVlK cLDXoV cBca-Di"
+            />
+            <a
+              class="sc-GTWni kMBmCU sc-gsxnyZ inhWwE"
+              color="primary.main"
+              style="display: inherit;"
+            >
+              <div
+                class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr kFVJVF"
+              >
+                <div
+                  class="sc-fKFyDc cKoSkI sc-bBXqnf kYwmpI"
+                >
+                  route 1
+                </div>
+              </div>
+            </a>
+          </div>
+          <div
+            class="sc-gKsewC cgpPfo sc-iBPRYJ dMkfug sc-hHftDr xhfhB"
+          >
+            <div
+              class="sc-gKsewC cgpPfo sc-iBPRYJ ihSNwK sc-hHftDr cLDXoV"
+            />
+          </div>
+        </div>
+      </div>
+      <div
+        class="sc-fKFyDc jHCVxA sc-bBXqnf cNzyxC"
+      >
+        <div
+          class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr iIBJBt"
+        >
+          <div
+            class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cuSvIJ"
+          >
+            <div
+              class="sc-gKsewC cgpPfo sc-iBPRYJ dlUrgp sc-hHftDr sc-jLiVlK cLDXoV cBca-Di"
+            />
+            <a
+              class="sc-GTWni kMBmCU sc-gsxnyZ inhWwE"
+              color="primary.main"
+              style="display: inherit;"
+            >
+              <div
+                class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr kFVJVF"
+              >
+                <div
+                  class="sc-fKFyDc cKoSkI sc-bBXqnf kYwmpI"
+                >
+                  route 2
+                </div>
+              </div>
+            </a>
+          </div>
+          <div
+            class="sc-gKsewC cgpPfo sc-iBPRYJ dMkfug sc-hHftDr xhfhB"
+          >
+            <div
+              class="sc-gKsewC cgpPfo sc-iBPRYJ ihSNwK sc-hHftDr cLDXoV"
+            />
+          </div>
+        </div>
+      </div>
+      <div
+        class="sc-fKFyDc euqOvB sc-bBXqnf ibWro"
+      >
+        <div
+          class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr iIBJBt"
+        >
+          <div
+            class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cuSvIJ"
+          >
+            <div
+              class="sc-gKsewC cgpPfo sc-iBPRYJ dlUrgp sc-hHftDr sc-jLiVlK cLDXoV isIksK"
+            />
+            <a
+              class="sc-GTWni kMBmCU sc-gsxnyZ inhWwE"
+              color="primary.main"
+              style="display: inherit;"
+            >
+              <div
+                class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr kFVJVF"
+              >
+                <div
+                  class="sc-gKsewC cgpPfo sc-iBPRYJ dlUrgp sc-hHftDr cLDXoV"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="svg-inline--fa fa-recycle fa-w-16 "
+                    data-icon="recycle"
+                    data-prefix="fas"
+                    focusable="false"
+                    role="img"
+                    viewBox="0 0 512 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M184.561 261.903c3.232 13.997-12.123 24.635-24.068 17.168l-40.736-25.455-50.867 81.402C55.606 356.273 70.96 384 96.012 384H148c6.627 0 12 5.373 12 12v40c0 6.627-5.373 12-12 12H96.115c-75.334 0-121.302-83.048-81.408-146.88l50.822-81.388-40.725-25.448c-12.081-7.547-8.966-25.961 4.879-29.158l110.237-25.45c8.611-1.988 17.201 3.381 19.189 11.99l25.452 110.237zm98.561-182.915l41.289 66.076-40.74 25.457c-12.051 7.528-9 25.953 4.879 29.158l110.237 25.45c8.672 1.999 17.215-3.438 19.189-11.99l25.45-110.237c3.197-13.844-11.99-24.719-24.068-17.168l-40.687 25.424-41.263-66.082c-37.521-60.033-125.209-60.171-162.816 0l-17.963 28.766c-3.51 5.62-1.8 13.021 3.82 16.533l33.919 21.195c5.62 3.512 13.024 1.803 16.536-3.817l17.961-28.743c12.712-20.341 41.973-19.676 54.257-.022zM497.288 301.12l-27.515-44.065c-3.511-5.623-10.916-7.334-16.538-3.821l-33.861 21.159c-5.62 3.512-7.33 10.915-3.818 16.536l27.564 44.112c13.257 21.211-2.057 48.96-27.136 48.96H320V336.02c0-14.213-17.242-21.383-27.313-11.313l-80 79.981c-6.249 6.248-6.249 16.379 0 22.627l80 79.989C302.689 517.308 320 510.3 320 495.989V448h95.88c75.274 0 121.335-82.997 81.408-146.88z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                </div>
+                <div
+                  class="sc-fKFyDc cKoSkI sc-bBXqnf kYwmpI"
+                >
+                  route 3 with icon
+                </div>
+              </div>
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/components/Breadcrumbs/index.tsx
+++ b/src/components/Breadcrumbs/index.tsx
@@ -1,0 +1,95 @@
+import * as React from 'react';
+import styled from 'styled-components';
+import { Link } from '../Link';
+import { Flex } from '../Flex';
+import { Txt } from '../Txt';
+import { useTheme } from '../../hooks/useTheme';
+
+const Circle = styled(Flex)<{ isLast: boolean; emphasized?: boolean }>`
+	border: 1px solid
+		${(props) =>
+			props.isLast
+				? props.theme.colors.quartenary.light
+				: props.theme.colors.text.light};
+	border-radius: 50%;
+	width: ${(props) => props.theme.space[props.emphasized ? 3 : 2]}px;
+	height: ${(props) => props.theme.space[props.emphasized ? 3 : 2]}px;
+	background: ${(props) =>
+		props.isLast
+			? props.theme.colors.quartenary.light
+			: props.theme.colors.text.light};
+`;
+
+export interface Crumb {
+	text: string;
+	icon?: React.ReactNode;
+	onClick?: () => void;
+}
+
+export interface BreadcrumbsProps {
+	/** List of objects of type Crumb: `{text: string; icon?: React.ReactNode; onClick?: () => void;}` */
+	crumbs: Crumb[];
+	/** If true, use a larger Breadcrumbs */
+	emphasized?: boolean;
+}
+
+const BreadcrumbContent = React.memo(
+	({ icon, text }: Pick<Crumb, 'icon' | 'text'>) => {
+		return (
+			<Flex alignItems="center" justifyContent="center">
+				{icon && <Flex mr={2}>{icon}</Flex>}
+				<Txt truncate>{text}</Txt>
+			</Flex>
+		);
+	},
+);
+
+export const Breadcrumbs = ({ crumbs, emphasized }: BreadcrumbsProps) => {
+	const theme = useTheme();
+	return (
+		<Flex flexDirection="column" flexWrap="wrap">
+			{crumbs.map((crumb, i) => {
+				const isLast = i === crumbs.length - 1;
+
+				return (
+					crumb && (
+						<Txt
+							bold={isLast}
+							fontSize={2}
+							color={isLast ? 'white' : 'secondary.semilight'}
+							key={crumb.text}
+						>
+							<Flex flexDirection="column">
+								<Flex alignItems="center">
+									<Circle isLast={isLast} emphasized={emphasized} mr={2} />
+									{crumb.onClick ? (
+										<Link
+											style={{ display: 'inherit', color: 'inherit' }}
+											onClick={crumb.onClick}
+										>
+											<BreadcrumbContent text={crumb.text} icon={crumb.icon} />
+										</Link>
+									) : (
+										<Flex>
+											<BreadcrumbContent text={crumb.text} icon={crumb.icon} />
+										</Flex>
+									)}
+								</Flex>
+								{!isLast && (
+									<Flex
+										mt={-2}
+										mb={-2}
+										width={theme.space[emphasized ? 3 : 2]}
+										justifyContent="center"
+									>
+										<Flex height={theme.space[4]} width="1px" bg="text.light" />
+									</Flex>
+								)}
+							</Flex>
+						</Txt>
+					)
+				);
+			})}
+		</Flex>
+	);
+};

--- a/src/components/Breadcrumbs/spec.tsx
+++ b/src/components/Breadcrumbs/spec.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { Provider } from '../../';
+import { Breadcrumbs } from './';
+import { Txt } from '../Txt';
+
+describe('Breadcrumbs component', () => {
+	describe('crumbs property', () => {
+		it('should render the Breadcrumbs with four routes', () => {
+			const crumbs = [
+				{ text: 'route 1' },
+				{ text: 'route 2' },
+				{ text: 'route 3' },
+				{ text: 'route 4' },
+			];
+			const component = mount(
+				<Provider>
+					<Breadcrumbs crumbs={crumbs} />
+				</Provider>,
+			);
+			const crumbsContent = component.findWhere(
+				(node) => node.is(Txt) && !!node.prop('truncate'),
+			);
+			expect(crumbsContent).toHaveLength(4);
+			crumbsContent.forEach((crumb, index) => {
+				expect(crumb.text()).toEqual(crumbs[index].text);
+			});
+		});
+	});
+});

--- a/src/components/Filters/__snapshots__/Filters.stories.storyshot
+++ b/src/components/Filters/__snapshots__/Filters.stories.storyshot
@@ -135,7 +135,7 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
           Bulbasaur
         </h2>
         <table
-          class="sc-jLiVlK dcJyny"
+          class="sc-bUrJUP cVQzsq"
         >
           <tbody>
             <tr>
@@ -217,7 +217,7 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
           Ivysaur
         </h2>
         <table
-          class="sc-jLiVlK dcJyny"
+          class="sc-bUrJUP cVQzsq"
         >
           <tbody>
             <tr>
@@ -299,7 +299,7 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
           Venusaur
         </h2>
         <table
-          class="sc-jLiVlK dcJyny"
+          class="sc-bUrJUP cVQzsq"
         >
           <tbody>
             <tr>
@@ -381,7 +381,7 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
           Charmander
         </h2>
         <table
-          class="sc-jLiVlK dcJyny"
+          class="sc-bUrJUP cVQzsq"
         >
           <tbody>
             <tr>
@@ -463,7 +463,7 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
           Charmeleon
         </h2>
         <table
-          class="sc-jLiVlK dcJyny"
+          class="sc-bUrJUP cVQzsq"
         >
           <tbody>
             <tr>
@@ -547,7 +547,7 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
           Charizard
         </h2>
         <table
-          class="sc-jLiVlK dcJyny"
+          class="sc-bUrJUP cVQzsq"
         >
           <tbody>
             <tr>
@@ -658,7 +658,7 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
           Squirtle
         </h2>
         <table
-          class="sc-jLiVlK dcJyny"
+          class="sc-bUrJUP cVQzsq"
         >
           <tbody>
             <tr>
@@ -769,7 +769,7 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
           Wartortle
         </h2>
         <table
-          class="sc-jLiVlK dcJyny"
+          class="sc-bUrJUP cVQzsq"
         >
           <tbody>
             <tr>
@@ -851,7 +851,7 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
           Blastoise
         </h2>
         <table
-          class="sc-jLiVlK dcJyny"
+          class="sc-bUrJUP cVQzsq"
         >
           <tbody>
             <tr>
@@ -933,7 +933,7 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
           Caterpie
         </h2>
         <table
-          class="sc-jLiVlK dcJyny"
+          class="sc-bUrJUP cVQzsq"
         >
           <tbody>
             <tr>
@@ -1015,7 +1015,7 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
           Staryu
         </h2>
         <table
-          class="sc-jLiVlK dcJyny"
+          class="sc-bUrJUP cVQzsq"
         >
           <tbody>
             <tr>
@@ -1218,7 +1218,7 @@ exports[`Storyshots Core/Filters Compact 1`] = `
           Bulbasaur
         </h2>
         <table
-          class="sc-jLiVlK dcJyny"
+          class="sc-bUrJUP cVQzsq"
         >
           <tbody>
             <tr>
@@ -1300,7 +1300,7 @@ exports[`Storyshots Core/Filters Compact 1`] = `
           Ivysaur
         </h2>
         <table
-          class="sc-jLiVlK dcJyny"
+          class="sc-bUrJUP cVQzsq"
         >
           <tbody>
             <tr>
@@ -1382,7 +1382,7 @@ exports[`Storyshots Core/Filters Compact 1`] = `
           Venusaur
         </h2>
         <table
-          class="sc-jLiVlK dcJyny"
+          class="sc-bUrJUP cVQzsq"
         >
           <tbody>
             <tr>
@@ -1464,7 +1464,7 @@ exports[`Storyshots Core/Filters Compact 1`] = `
           Charmander
         </h2>
         <table
-          class="sc-jLiVlK dcJyny"
+          class="sc-bUrJUP cVQzsq"
         >
           <tbody>
             <tr>
@@ -1546,7 +1546,7 @@ exports[`Storyshots Core/Filters Compact 1`] = `
           Charmeleon
         </h2>
         <table
-          class="sc-jLiVlK dcJyny"
+          class="sc-bUrJUP cVQzsq"
         >
           <tbody>
             <tr>
@@ -1630,7 +1630,7 @@ exports[`Storyshots Core/Filters Compact 1`] = `
           Charizard
         </h2>
         <table
-          class="sc-jLiVlK dcJyny"
+          class="sc-bUrJUP cVQzsq"
         >
           <tbody>
             <tr>
@@ -1741,7 +1741,7 @@ exports[`Storyshots Core/Filters Compact 1`] = `
           Squirtle
         </h2>
         <table
-          class="sc-jLiVlK dcJyny"
+          class="sc-bUrJUP cVQzsq"
         >
           <tbody>
             <tr>
@@ -1852,7 +1852,7 @@ exports[`Storyshots Core/Filters Compact 1`] = `
           Wartortle
         </h2>
         <table
-          class="sc-jLiVlK dcJyny"
+          class="sc-bUrJUP cVQzsq"
         >
           <tbody>
             <tr>
@@ -1934,7 +1934,7 @@ exports[`Storyshots Core/Filters Compact 1`] = `
           Blastoise
         </h2>
         <table
-          class="sc-jLiVlK dcJyny"
+          class="sc-bUrJUP cVQzsq"
         >
           <tbody>
             <tr>
@@ -2016,7 +2016,7 @@ exports[`Storyshots Core/Filters Compact 1`] = `
           Caterpie
         </h2>
         <table
-          class="sc-jLiVlK dcJyny"
+          class="sc-bUrJUP cVQzsq"
         >
           <tbody>
             <tr>
@@ -2098,7 +2098,7 @@ exports[`Storyshots Core/Filters Compact 1`] = `
           Staryu
         </h2>
         <table
-          class="sc-jLiVlK dcJyny"
+          class="sc-bUrJUP cVQzsq"
         >
           <tbody>
             <tr>
@@ -2314,7 +2314,7 @@ exports[`Storyshots Core/Filters Default 1`] = `
           Bulbasaur
         </h2>
         <table
-          class="sc-jLiVlK dcJyny"
+          class="sc-bUrJUP cVQzsq"
         >
           <tbody>
             <tr>
@@ -2396,7 +2396,7 @@ exports[`Storyshots Core/Filters Default 1`] = `
           Ivysaur
         </h2>
         <table
-          class="sc-jLiVlK dcJyny"
+          class="sc-bUrJUP cVQzsq"
         >
           <tbody>
             <tr>
@@ -2478,7 +2478,7 @@ exports[`Storyshots Core/Filters Default 1`] = `
           Venusaur
         </h2>
         <table
-          class="sc-jLiVlK dcJyny"
+          class="sc-bUrJUP cVQzsq"
         >
           <tbody>
             <tr>
@@ -2560,7 +2560,7 @@ exports[`Storyshots Core/Filters Default 1`] = `
           Charmander
         </h2>
         <table
-          class="sc-jLiVlK dcJyny"
+          class="sc-bUrJUP cVQzsq"
         >
           <tbody>
             <tr>
@@ -2642,7 +2642,7 @@ exports[`Storyshots Core/Filters Default 1`] = `
           Charmeleon
         </h2>
         <table
-          class="sc-jLiVlK dcJyny"
+          class="sc-bUrJUP cVQzsq"
         >
           <tbody>
             <tr>
@@ -2726,7 +2726,7 @@ exports[`Storyshots Core/Filters Default 1`] = `
           Charizard
         </h2>
         <table
-          class="sc-jLiVlK dcJyny"
+          class="sc-bUrJUP cVQzsq"
         >
           <tbody>
             <tr>
@@ -2837,7 +2837,7 @@ exports[`Storyshots Core/Filters Default 1`] = `
           Squirtle
         </h2>
         <table
-          class="sc-jLiVlK dcJyny"
+          class="sc-bUrJUP cVQzsq"
         >
           <tbody>
             <tr>
@@ -2948,7 +2948,7 @@ exports[`Storyshots Core/Filters Default 1`] = `
           Wartortle
         </h2>
         <table
-          class="sc-jLiVlK dcJyny"
+          class="sc-bUrJUP cVQzsq"
         >
           <tbody>
             <tr>
@@ -3030,7 +3030,7 @@ exports[`Storyshots Core/Filters Default 1`] = `
           Blastoise
         </h2>
         <table
-          class="sc-jLiVlK dcJyny"
+          class="sc-bUrJUP cVQzsq"
         >
           <tbody>
             <tr>
@@ -3112,7 +3112,7 @@ exports[`Storyshots Core/Filters Default 1`] = `
           Caterpie
         </h2>
         <table
-          class="sc-jLiVlK dcJyny"
+          class="sc-bUrJUP cVQzsq"
         >
           <tbody>
             <tr>
@@ -3194,7 +3194,7 @@ exports[`Storyshots Core/Filters Default 1`] = `
           Staryu
         </h2>
         <table
-          class="sc-jLiVlK dcJyny"
+          class="sc-bUrJUP cVQzsq"
         >
           <tbody>
             <tr>
@@ -3414,7 +3414,7 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
           Bulbasaur
         </h2>
         <table
-          class="sc-jLiVlK dcJyny"
+          class="sc-bUrJUP cVQzsq"
         >
           <tbody>
             <tr>
@@ -3496,7 +3496,7 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
           Ivysaur
         </h2>
         <table
-          class="sc-jLiVlK dcJyny"
+          class="sc-bUrJUP cVQzsq"
         >
           <tbody>
             <tr>
@@ -3578,7 +3578,7 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
           Venusaur
         </h2>
         <table
-          class="sc-jLiVlK dcJyny"
+          class="sc-bUrJUP cVQzsq"
         >
           <tbody>
             <tr>
@@ -3660,7 +3660,7 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
           Charmander
         </h2>
         <table
-          class="sc-jLiVlK dcJyny"
+          class="sc-bUrJUP cVQzsq"
         >
           <tbody>
             <tr>
@@ -3742,7 +3742,7 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
           Charmeleon
         </h2>
         <table
-          class="sc-jLiVlK dcJyny"
+          class="sc-bUrJUP cVQzsq"
         >
           <tbody>
             <tr>
@@ -3826,7 +3826,7 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
           Charizard
         </h2>
         <table
-          class="sc-jLiVlK dcJyny"
+          class="sc-bUrJUP cVQzsq"
         >
           <tbody>
             <tr>
@@ -3937,7 +3937,7 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
           Squirtle
         </h2>
         <table
-          class="sc-jLiVlK dcJyny"
+          class="sc-bUrJUP cVQzsq"
         >
           <tbody>
             <tr>
@@ -4048,7 +4048,7 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
           Wartortle
         </h2>
         <table
-          class="sc-jLiVlK dcJyny"
+          class="sc-bUrJUP cVQzsq"
         >
           <tbody>
             <tr>
@@ -4130,7 +4130,7 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
           Blastoise
         </h2>
         <table
-          class="sc-jLiVlK dcJyny"
+          class="sc-bUrJUP cVQzsq"
         >
           <tbody>
             <tr>
@@ -4212,7 +4212,7 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
           Caterpie
         </h2>
         <table
-          class="sc-jLiVlK dcJyny"
+          class="sc-bUrJUP cVQzsq"
         >
           <tbody>
             <tr>
@@ -4294,7 +4294,7 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
           Staryu
         </h2>
         <table
-          class="sc-jLiVlK dcJyny"
+          class="sc-bUrJUP cVQzsq"
         >
           <tbody>
             <tr>
@@ -4603,7 +4603,7 @@ exports[`Storyshots Core/Filters Render Modes 1`] = `
           Squirtle
         </h2>
         <table
-          class="sc-jLiVlK dcJyny"
+          class="sc-bUrJUP cVQzsq"
         >
           <tbody>
             <tr>

--- a/src/components/Form/__snapshots__/Form.stories.storyshot
+++ b/src/components/Form/__snapshots__/Form.stories.storyshot
@@ -3254,7 +3254,7 @@ Rendition contains widgets for rendering Markdown and Mermaid text formats that 
                         Markdown
                       </label>
                       <div
-                        class="sc-bUrJUP bSArhB"
+                        class="sc-tkKAw ddBawh"
                         id="simplemde-editor-1-wrapper"
                       >
                         <textarea
@@ -3545,7 +3545,7 @@ Rendition contains widgets for rendering Markdown and Mermaid text formats that 
                         Captcha
                       </label>
                       <div
-                        class="sc-tkKAw ihyLmG"
+                        class="sc-dRPiIx hnviSm"
                       />
                     </div>
                   </div>

--- a/src/extra/MarkdownEditor/__snapshots__/MarkdownEditor.stories.storyshot
+++ b/src/extra/MarkdownEditor/__snapshots__/MarkdownEditor.stories.storyshot
@@ -6,7 +6,7 @@ exports[`Storyshots Extra/MarkdownEditor Default 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-dWdcrH ScrBw"
   >
     <div
-      class="sc-bUrJUP bSArhB"
+      class="sc-tkKAw ddBawh"
       id="simplemde-editor-2-wrapper"
     >
       <textarea


### PR DESCRIPTION
Add Breadcrumbs component

Depends-on: #1234 
Change-type: minor
Signed-off-by: Andrea Rosci <andrear@balena.io>

Breadcrumbs:
<img width="324" alt="Screenshot 2020-12-28 at 13 34 12" src="https://user-images.githubusercontent.com/7238159/103216216-c8fb8600-4915-11eb-984a-076f071e17c3.png">

Breadcrumbs emphasized:
<img width="385" alt="Screenshot 2020-12-28 at 13 34 19" src="https://user-images.githubusercontent.com/7238159/103216209-c731c280-4915-11eb-8029-a3c0dbb56bad.png">

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
