### PR TITLE
Add truncate property to Txt component

### DIFF
--- a/src/components/Accordion/__snapshots__/Accordion.stories.storyshot
+++ b/src/components/Accordion/__snapshots__/Accordion.stories.storyshot
@@ -26,7 +26,7 @@ exports[`Storyshots Core/Accordion Default 1`] = `
               class="sc-gKsewC cgpPfo sc-iBPRYJ GivMM sc-hHftDr cLDXoV"
             >
               <div
-                class="sc-fKFyDc ipClrT sc-bBXqnf cpINvR"
+                class="sc-fKFyDc euqOvB sc-bBXqnf cpINvR"
               >
                 Heading one
               </div>
@@ -59,13 +59,7 @@ exports[`Storyshots Core/Accordion Default 1`] = `
           <div
             aria-hidden="true"
             class="StyledBox-sc-13pk1d4-0 dYebPD Collapsible__AnimatedBox-sc-15kniua-0 euNsBL"
-          >
-            <div
-              class="sc-gKsewC cgpPfo sc-iBPRYJ dcxFGD"
-            >
-              First Panel
-            </div>
-          </div>
+          />
         </div>
       </div>
       <div
@@ -85,7 +79,7 @@ exports[`Storyshots Core/Accordion Default 1`] = `
               class="sc-gKsewC cgpPfo sc-iBPRYJ GivMM sc-hHftDr cLDXoV"
             >
               <div
-                class="sc-fKFyDc ipClrT sc-bBXqnf cpINvR"
+                class="sc-fKFyDc euqOvB sc-bBXqnf cpINvR"
               >
                 Second Heading
               </div>
@@ -118,13 +112,7 @@ exports[`Storyshots Core/Accordion Default 1`] = `
           <div
             aria-hidden="true"
             class="StyledBox-sc-13pk1d4-0 dYebPD Collapsible__AnimatedBox-sc-15kniua-0 euNsBL"
-          >
-            <div
-              class="sc-gKsewC cgpPfo sc-iBPRYJ dcxFGD"
-            >
-              Second Panel
-            </div>
-          </div>
+          />
         </div>
       </div>
     </div>

--- a/src/components/Alert/__snapshots__/Alert.stories.storyshot
+++ b/src/components/Alert/__snapshots__/Alert.stories.storyshot
@@ -9,7 +9,7 @@ exports[`Storyshots Core/Alert Default 1`] = `
       class="sc-gKsewC cgpPfo sc-iBPRYJ ipiHMM sc-hHftDr sc-dmlrTW cLDXoV cbtefT sc-lmoMRL cGXAYQ"
     >
       <div
-        class="sc-fKFyDc dToKui sc-bBXqnf ebpqPX"
+        class="sc-fKFyDc jHCVxA sc-bBXqnf ebpqPX"
       >
         <svg
           aria-hidden="true"
@@ -31,12 +31,12 @@ exports[`Storyshots Core/Alert Default 1`] = `
         class="sc-gKsewC dWcnb sc-iBPRYJ jyModB"
       >
         <span
-          class="sc-fKFyDc ipClrT sc-iwyYcG hQqijh"
+          class="sc-fKFyDc euqOvB sc-iwyYcG hQqijh"
         >
           Success!
         </span>
         <span
-          class="sc-fKFyDc dToKui sc-iwyYcG bUoHum"
+          class="sc-fKFyDc jHCVxA sc-iwyYcG bUoHum"
         >
           This is a default alert
         </span>
@@ -55,7 +55,7 @@ exports[`Storyshots Core/Alert Emphasized 1`] = `
       class="sc-gKsewC cgpPfo sc-iBPRYJ dQsSLq sc-hHftDr sc-dmlrTW cLDXoV hjYAKL sc-lmoMRL cGXAYQ"
     >
       <div
-        class="sc-fKFyDc dToKui sc-bBXqnf XVwEh"
+        class="sc-fKFyDc jHCVxA sc-bBXqnf XVwEh"
       >
         <svg
           aria-hidden="true"
@@ -77,12 +77,12 @@ exports[`Storyshots Core/Alert Emphasized 1`] = `
         class="sc-gKsewC dWcnb sc-iBPRYJ fLUuUH"
       >
         <span
-          class="sc-fKFyDc ipClrT sc-iwyYcG hQqijh"
+          class="sc-fKFyDc euqOvB sc-iwyYcG hQqijh"
         >
           Note!
         </span>
         <span
-          class="sc-fKFyDc dToKui sc-iwyYcG cRxeiz"
+          class="sc-fKFyDc jHCVxA sc-iwyYcG cRxeiz"
         >
           This is an emphasized alert
         </span>
@@ -101,7 +101,7 @@ exports[`Storyshots Core/Alert Plaintext 1`] = `
       class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV sc-lmoMRL cGXAYQ"
     >
       <div
-        class="sc-fKFyDc dToKui sc-bBXqnf XVwEh"
+        class="sc-fKFyDc jHCVxA sc-bBXqnf XVwEh"
       >
         <svg
           aria-hidden="true"
@@ -120,7 +120,7 @@ exports[`Storyshots Core/Alert Plaintext 1`] = `
         </svg>
       </div>
       <span
-        class="sc-fKFyDc dToKui sc-iwyYcG cRxeiz"
+        class="sc-fKFyDc jHCVxA sc-iwyYcG cRxeiz"
       >
         This is a plaintext alert
       </span>
@@ -138,7 +138,7 @@ exports[`Storyshots Core/Alert With Link 1`] = `
       class="sc-gKsewC cgpPfo sc-iBPRYJ ipiHMM sc-hHftDr sc-dmlrTW cLDXoV cbtefT sc-lmoMRL cGXAYQ"
     >
       <div
-        class="sc-fKFyDc dToKui sc-bBXqnf ebpqPX"
+        class="sc-fKFyDc jHCVxA sc-bBXqnf ebpqPX"
       >
         <svg
           aria-hidden="true"
@@ -160,12 +160,12 @@ exports[`Storyshots Core/Alert With Link 1`] = `
         class="sc-gKsewC dWcnb sc-iBPRYJ jyModB"
       >
         <span
-          class="sc-fKFyDc ipClrT sc-iwyYcG hQqijh"
+          class="sc-fKFyDc euqOvB sc-iwyYcG hQqijh"
         >
           Success!
         </span>
         <span
-          class="sc-fKFyDc dToKui sc-iwyYcG bUoHum"
+          class="sc-fKFyDc jHCVxA sc-iwyYcG bUoHum"
         >
           With a 
           <a
@@ -191,7 +191,7 @@ exports[`Storyshots Core/Alert Without Dismiss 1`] = `
       class="sc-gKsewC cgpPfo sc-iBPRYJ ipiHMM sc-hHftDr sc-dmlrTW cLDXoV cbtefT sc-lmoMRL cGXAYQ"
     >
       <div
-        class="sc-fKFyDc dToKui sc-bBXqnf ebpqPX"
+        class="sc-fKFyDc jHCVxA sc-bBXqnf ebpqPX"
       >
         <svg
           aria-hidden="true"
@@ -213,12 +213,12 @@ exports[`Storyshots Core/Alert Without Dismiss 1`] = `
         class="sc-gKsewC dWcnb sc-iBPRYJ jyModB"
       >
         <span
-          class="sc-fKFyDc ipClrT sc-iwyYcG hQqijh"
+          class="sc-fKFyDc euqOvB sc-iwyYcG hQqijh"
         >
           Success!
         </span>
         <span
-          class="sc-fKFyDc dToKui sc-iwyYcG bUoHum"
+          class="sc-fKFyDc jHCVxA sc-iwyYcG bUoHum"
         >
           Without a dismiss button
         </span>
@@ -237,7 +237,7 @@ exports[`Storyshots Core/Alert Without Prefix 1`] = `
       class="sc-gKsewC cgpPfo sc-iBPRYJ ipiHMM sc-hHftDr sc-dmlrTW cLDXoV cbtefT sc-lmoMRL cGXAYQ"
     >
       <div
-        class="sc-fKFyDc dToKui sc-bBXqnf ebpqPX"
+        class="sc-fKFyDc jHCVxA sc-bBXqnf ebpqPX"
       >
         <svg
           aria-hidden="true"
@@ -259,12 +259,12 @@ exports[`Storyshots Core/Alert Without Prefix 1`] = `
         class="sc-gKsewC dWcnb sc-iBPRYJ jyModB"
       >
         <span
-          class="sc-fKFyDc ipClrT sc-iwyYcG hQqijh"
+          class="sc-fKFyDc euqOvB sc-iwyYcG hQqijh"
         >
           Success!
         </span>
         <span
-          class="sc-fKFyDc dToKui sc-iwyYcG bUoHum"
+          class="sc-fKFyDc jHCVxA sc-iwyYcG bUoHum"
         >
           Without a prefix
         </span>

--- a/src/components/Avatar/__snapshots__/Avatar.stories.storyshot
+++ b/src/components/Avatar/__snapshots__/Avatar.stories.storyshot
@@ -39,7 +39,7 @@ exports[`Storyshots Core/Avatar Emphasized 1`] = `
       class="StyledBox-sc-13pk1d4-0 dKvtcX StyledAvatar-sc-1suyamb-1 sc-iWFSnp dyTeJE"
     >
       <div
-        class="sc-fKFyDc dToKui sc-bBXqnf dtyrhz"
+        class="sc-fKFyDc jHCVxA sc-bBXqnf dtyrhz"
       >
         JD
       </div>
@@ -57,7 +57,7 @@ exports[`Storyshots Core/Avatar With First Name 1`] = `
       class="StyledBox-sc-13pk1d4-0 fXtYff StyledAvatar-sc-1suyamb-1 sc-iWFSnp dyTeJE"
     >
       <div
-        class="sc-fKFyDc dToKui sc-bBXqnf dtyrhz"
+        class="sc-fKFyDc jHCVxA sc-bBXqnf dtyrhz"
       >
         J
       </div>
@@ -75,7 +75,7 @@ exports[`Storyshots Core/Avatar With Full Name 1`] = `
       class="StyledBox-sc-13pk1d4-0 fXtYff StyledAvatar-sc-1suyamb-1 sc-iWFSnp dyTeJE"
     >
       <div
-        class="sc-fKFyDc dToKui sc-bBXqnf dtyrhz"
+        class="sc-fKFyDc jHCVxA sc-bBXqnf dtyrhz"
       >
         JD
       </div>
@@ -106,7 +106,7 @@ exports[`Storyshots Core/Avatar With Last Name 1`] = `
       class="StyledBox-sc-13pk1d4-0 fXtYff StyledAvatar-sc-1suyamb-1 sc-iWFSnp dyTeJE"
     >
       <div
-        class="sc-fKFyDc dToKui sc-bBXqnf dtyrhz"
+        class="sc-fKFyDc jHCVxA sc-bBXqnf dtyrhz"
       >
         D
       </div>

--- a/src/components/Badge/__snapshots__/Badge.stories.storyshot
+++ b/src/components/Badge/__snapshots__/Badge.stories.storyshot
@@ -6,7 +6,7 @@ exports[`Storyshots Core/Badge Default 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-dWdcrH ScrBw"
   >
     <span
-      class="sc-fKFyDc dToKui sc-iwyYcG cxxFta sc-iJuUWI bYpSjD sc-giIncl dUYCyj"
+      class="sc-fKFyDc jHCVxA sc-iwyYcG cxxFta sc-iJuUWI bYpSjD sc-giIncl dUYCyj"
     >
       Badge
     </span>

--- a/src/components/Box/__snapshots__/Box.stories.storyshot
+++ b/src/components/Box/__snapshots__/Box.stories.storyshot
@@ -9,7 +9,7 @@ exports[`Storyshots Core/Box Default 1`] = `
       class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP"
     >
       <div
-        class="sc-fKFyDc dToKui sc-bBXqnf kYwmpI"
+        class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI"
       >
         I'm in a Box!
       </div>

--- a/src/components/Card/__snapshots__/Card.stories.storyshot
+++ b/src/components/Card/__snapshots__/Card.stories.storyshot
@@ -163,7 +163,7 @@ exports[`Storyshots Core/Card With Rows 1`] = `
               class="sc-iktFzd cJCAjm sc-hiSbYr ioExYC"
             />
             <span
-              class="sc-fKFyDc dToKui sc-iwyYcG bsaCCL sc-irlOZD iUVlhX text-with-copy"
+              class="sc-fKFyDc jHCVxA sc-iwyYcG bsaCCL sc-irlOZD iUVlhX text-with-copy"
               title="This value has been copied to your clipboard!"
             >
               <span

--- a/src/components/Copy/__snapshots__/Copy.stories.storyshot
+++ b/src/components/Copy/__snapshots__/Copy.stories.storyshot
@@ -107,7 +107,7 @@ exports[`Storyshots Core/Copy Default 1`] = `
       class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-AzgDb jAUQHL hGxA-dz"
     >
       <div
-        class="sc-fKFyDc dToKui sc-bBXqnf kYwmpI"
+        class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI"
       >
         Hover me and click on icon to copy
       </div>
@@ -187,12 +187,12 @@ exports[`Storyshots Core/Copy With Tag 1`] = `
           class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-clsHhM cLDXoV bjaVYF"
         >
           <div
-            class="sc-fKFyDc kIYkoy sc-bBXqnf iHGIIw"
+            class="sc-fKFyDc dTkenA sc-bBXqnf iHGIIw"
           >
             Type: 
           </div>
           <div
-            class="sc-fKFyDc ipClrT sc-bBXqnf iHGIIw"
+            class="sc-fKFyDc euqOvB sc-bBXqnf iHGIIw"
           >
             Beginner
           </div>

--- a/src/components/DataGrid/__snapshots__/DataGrid.stories.storyshot
+++ b/src/components/DataGrid/__snapshots__/DataGrid.stories.storyshot
@@ -21,7 +21,7 @@ exports[`Storyshots Core/DataGrid Default 1`] = `
               class="sc-gKsewC cgpPfo sc-iBPRYJ kKemJS"
             >
               <div
-                class="sc-fKFyDc kNlpHR sc-bBXqnf cLiasT"
+                class="sc-fKFyDc fPRqcz sc-bBXqnf cLiasT"
               >
                 1
               </div>
@@ -42,7 +42,7 @@ exports[`Storyshots Core/DataGrid Default 1`] = `
               class="sc-gKsewC cgpPfo sc-iBPRYJ kKemJS"
             >
               <div
-                class="sc-fKFyDc kNlpHR sc-bBXqnf cLiasT"
+                class="sc-fKFyDc fPRqcz sc-bBXqnf cLiasT"
               >
                 2
               </div>
@@ -63,7 +63,7 @@ exports[`Storyshots Core/DataGrid Default 1`] = `
               class="sc-gKsewC cgpPfo sc-iBPRYJ kKemJS"
             >
               <div
-                class="sc-fKFyDc kNlpHR sc-bBXqnf cLiasT"
+                class="sc-fKFyDc fPRqcz sc-bBXqnf cLiasT"
               >
                 3
               </div>
@@ -84,7 +84,7 @@ exports[`Storyshots Core/DataGrid Default 1`] = `
               class="sc-gKsewC cgpPfo sc-iBPRYJ kKemJS"
             >
               <div
-                class="sc-fKFyDc kNlpHR sc-bBXqnf cLiasT"
+                class="sc-fKFyDc fPRqcz sc-bBXqnf cLiasT"
               >
                 4
               </div>
@@ -105,7 +105,7 @@ exports[`Storyshots Core/DataGrid Default 1`] = `
               class="sc-gKsewC cgpPfo sc-iBPRYJ kKemJS"
             >
               <div
-                class="sc-fKFyDc kNlpHR sc-bBXqnf cLiasT"
+                class="sc-fKFyDc fPRqcz sc-bBXqnf cLiasT"
               >
                 5
               </div>
@@ -126,7 +126,7 @@ exports[`Storyshots Core/DataGrid Default 1`] = `
               class="sc-gKsewC cgpPfo sc-iBPRYJ kKemJS"
             >
               <div
-                class="sc-fKFyDc kNlpHR sc-bBXqnf cLiasT"
+                class="sc-fKFyDc fPRqcz sc-bBXqnf cLiasT"
               >
                 6
               </div>

--- a/src/components/Divider/__snapshots__/Divider.stories.storyshot
+++ b/src/components/Divider/__snapshots__/Divider.stories.storyshot
@@ -51,7 +51,7 @@ exports[`Storyshots Core/Divider With Text Content 1`] = `
         type="dashed"
       />
       <span
-        class="sc-fKFyDc dToKui sc-iwyYcG fZreIp"
+        class="sc-fKFyDc jHCVxA sc-iwyYcG fZreIp"
       >
         some text
       </span>

--- a/src/components/Filters/__snapshots__/Filters.stories.storyshot
+++ b/src/components/Filters/__snapshots__/Filters.stories.storyshot
@@ -626,7 +626,7 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
                     class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-clsHhM cLDXoV bjaVYF"
                   >
                     <div
-                      class="sc-fKFyDc ipClrT sc-bBXqnf iHGIIw"
+                      class="sc-fKFyDc euqOvB sc-bBXqnf iHGIIw"
                     >
                       10
                     </div>
@@ -639,7 +639,7 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
                     class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-clsHhM cLDXoV bjaVYF"
                   >
                     <div
-                      class="sc-fKFyDc ipClrT sc-bBXqnf iHGIIw"
+                      class="sc-fKFyDc euqOvB sc-bBXqnf iHGIIw"
                     >
                       Kanto
                     </div>
@@ -737,7 +737,7 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
                     class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-clsHhM cLDXoV bjaVYF"
                   >
                     <div
-                      class="sc-fKFyDc ipClrT sc-bBXqnf iHGIIw"
+                      class="sc-fKFyDc euqOvB sc-bBXqnf iHGIIw"
                     >
                       5
                     </div>
@@ -750,7 +750,7 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
                     class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-clsHhM cLDXoV bjaVYF"
                   >
                     <div
-                      class="sc-fKFyDc ipClrT sc-bBXqnf iHGIIw"
+                      class="sc-fKFyDc euqOvB sc-bBXqnf iHGIIw"
                     >
                       Johto
                     </div>
@@ -1709,7 +1709,7 @@ exports[`Storyshots Core/Filters Compact 1`] = `
                     class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-clsHhM cLDXoV bjaVYF"
                   >
                     <div
-                      class="sc-fKFyDc ipClrT sc-bBXqnf iHGIIw"
+                      class="sc-fKFyDc euqOvB sc-bBXqnf iHGIIw"
                     >
                       10
                     </div>
@@ -1722,7 +1722,7 @@ exports[`Storyshots Core/Filters Compact 1`] = `
                     class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-clsHhM cLDXoV bjaVYF"
                   >
                     <div
-                      class="sc-fKFyDc ipClrT sc-bBXqnf iHGIIw"
+                      class="sc-fKFyDc euqOvB sc-bBXqnf iHGIIw"
                     >
                       Kanto
                     </div>
@@ -1820,7 +1820,7 @@ exports[`Storyshots Core/Filters Compact 1`] = `
                     class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-clsHhM cLDXoV bjaVYF"
                   >
                     <div
-                      class="sc-fKFyDc ipClrT sc-bBXqnf iHGIIw"
+                      class="sc-fKFyDc euqOvB sc-bBXqnf iHGIIw"
                     >
                       5
                     </div>
@@ -1833,7 +1833,7 @@ exports[`Storyshots Core/Filters Compact 1`] = `
                     class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-clsHhM cLDXoV bjaVYF"
                   >
                     <div
-                      class="sc-fKFyDc ipClrT sc-bBXqnf iHGIIw"
+                      class="sc-fKFyDc euqOvB sc-bBXqnf iHGIIw"
                     >
                       Johto
                     </div>
@@ -2805,7 +2805,7 @@ exports[`Storyshots Core/Filters Default 1`] = `
                     class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-clsHhM cLDXoV bjaVYF"
                   >
                     <div
-                      class="sc-fKFyDc ipClrT sc-bBXqnf iHGIIw"
+                      class="sc-fKFyDc euqOvB sc-bBXqnf iHGIIw"
                     >
                       10
                     </div>
@@ -2818,7 +2818,7 @@ exports[`Storyshots Core/Filters Default 1`] = `
                     class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-clsHhM cLDXoV bjaVYF"
                   >
                     <div
-                      class="sc-fKFyDc ipClrT sc-bBXqnf iHGIIw"
+                      class="sc-fKFyDc euqOvB sc-bBXqnf iHGIIw"
                     >
                       Kanto
                     </div>
@@ -2916,7 +2916,7 @@ exports[`Storyshots Core/Filters Default 1`] = `
                     class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-clsHhM cLDXoV bjaVYF"
                   >
                     <div
-                      class="sc-fKFyDc ipClrT sc-bBXqnf iHGIIw"
+                      class="sc-fKFyDc euqOvB sc-bBXqnf iHGIIw"
                     >
                       5
                     </div>
@@ -2929,7 +2929,7 @@ exports[`Storyshots Core/Filters Default 1`] = `
                     class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-clsHhM cLDXoV bjaVYF"
                   >
                     <div
-                      class="sc-fKFyDc ipClrT sc-bBXqnf iHGIIw"
+                      class="sc-fKFyDc euqOvB sc-bBXqnf iHGIIw"
                     >
                       Johto
                     </div>
@@ -3905,7 +3905,7 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
                     class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-clsHhM cLDXoV bjaVYF"
                   >
                     <div
-                      class="sc-fKFyDc ipClrT sc-bBXqnf iHGIIw"
+                      class="sc-fKFyDc euqOvB sc-bBXqnf iHGIIw"
                     >
                       10
                     </div>
@@ -3918,7 +3918,7 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
                     class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-clsHhM cLDXoV bjaVYF"
                   >
                     <div
-                      class="sc-fKFyDc ipClrT sc-bBXqnf iHGIIw"
+                      class="sc-fKFyDc euqOvB sc-bBXqnf iHGIIw"
                     >
                       Kanto
                     </div>
@@ -4016,7 +4016,7 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
                     class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-clsHhM cLDXoV bjaVYF"
                   >
                     <div
-                      class="sc-fKFyDc ipClrT sc-bBXqnf iHGIIw"
+                      class="sc-fKFyDc euqOvB sc-bBXqnf iHGIIw"
                     >
                       5
                     </div>
@@ -4029,7 +4029,7 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
                     class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-clsHhM cLDXoV bjaVYF"
                   >
                     <div
-                      class="sc-fKFyDc ipClrT sc-bBXqnf iHGIIw"
+                      class="sc-fKFyDc euqOvB sc-bBXqnf iHGIIw"
                     >
                       Johto
                     </div>
@@ -4487,10 +4487,10 @@ exports[`Storyshots Core/Filters Render Modes 1`] = `
               class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV"
             >
               <div
-                class="sc-fKFyDc dToKui sc-bBXqnf zWvFq"
+                class="sc-fKFyDc jHCVxA sc-bBXqnf zWvFq"
               >
                 <span
-                  class="sc-fKFyDc ipClrT sc-iwyYcG bsaCCL"
+                  class="sc-fKFyDc euqOvB sc-iwyYcG bsaCCL"
                 >
                   Filters
                 </span>
@@ -4548,27 +4548,27 @@ exports[`Storyshots Core/Filters Render Modes 1`] = `
                   class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-clsHhM cLDXoV bjaVYF"
                 >
                   <div
-                    class="sc-fKFyDc kIYkoy sc-bBXqnf iHGIIw"
+                    class="sc-fKFyDc dTkenA sc-bBXqnf iHGIIw"
                   >
                     Pokemon Name is 
                   </div>
                   <div
-                    class="sc-fKFyDc ipClrT sc-bBXqnf iHGIIw"
+                    class="sc-fKFyDc euqOvB sc-bBXqnf iHGIIw"
                   >
                     Squirtle
                   </div>
                   <div
-                    class="sc-fKFyDc fDrOZM sc-bBXqnf iHGIIw"
+                    class="sc-fKFyDc krMjta sc-bBXqnf iHGIIw"
                   >
                       or  
                   </div>
                   <div
-                    class="sc-fKFyDc kIYkoy sc-bBXqnf iHGIIw"
+                    class="sc-fKFyDc dTkenA sc-bBXqnf iHGIIw"
                   >
                     Pokemon Name is 
                   </div>
                   <div
-                    class="sc-fKFyDc ipClrT sc-bBXqnf iHGIIw"
+                    class="sc-fKFyDc euqOvB sc-bBXqnf iHGIIw"
                   >
                     Pikachu
                   </div>
@@ -4682,7 +4682,7 @@ exports[`Storyshots Core/Filters Render Modes 1`] = `
                     class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-clsHhM cLDXoV bjaVYF"
                   >
                     <div
-                      class="sc-fKFyDc ipClrT sc-bBXqnf iHGIIw"
+                      class="sc-fKFyDc euqOvB sc-bBXqnf iHGIIw"
                     >
                       5
                     </div>
@@ -4695,7 +4695,7 @@ exports[`Storyshots Core/Filters Render Modes 1`] = `
                     class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-clsHhM cLDXoV bjaVYF"
                   >
                     <div
-                      class="sc-fKFyDc ipClrT sc-bBXqnf iHGIIw"
+                      class="sc-fKFyDc euqOvB sc-bBXqnf iHGIIw"
                     >
                       Johto
                     </div>

--- a/src/components/Form/__snapshots__/Form.stories.storyshot
+++ b/src/components/Form/__snapshots__/Form.stories.storyshot
@@ -48,7 +48,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                         
                         <input
                           autocomplete="off"
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Name"
                           label="Name"
                           list="dummy-datalist"
@@ -79,7 +79,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Height"
                           label="Height"
                           placeholder=""
@@ -106,7 +106,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Weight"
                           label="Weight"
                           placeholder=""
@@ -133,7 +133,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Description"
                           label="Description"
                           placeholder=""
@@ -160,7 +160,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Category"
                           label="Category"
                           placeholder=""
@@ -187,7 +187,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Abilities"
                           label="Abilities"
                           placeholder=""
@@ -214,7 +214,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_pokedex_number"
                           label="National Pokèdex Number"
                           placeholder=""
@@ -258,12 +258,12 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                         First seen
                       </label>
                       <div
-                        class="sc-fKFyDc dToKui sc-bBXqnf jWZcsF sc-bXDlPE cyautT rendition-form-description"
+                        class="sc-fKFyDc jHCVxA sc-bBXqnf jWZcsF sc-bXDlPE cyautT rendition-form-description"
                         id="root_first_seen__description"
                       >
                         <div>
                           <p
-                            class="sc-fKFyDc dToKui sc-cxFLnm kkkmRH"
+                            class="sc-fKFyDc jHCVxA sc-cxFLnm kkkmRH"
                           >
                             The first time you saw this pokèmon
                           </p>
@@ -274,7 +274,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_first_seen"
                           label="First seen"
                           placeholder=""
@@ -297,12 +297,12 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                         Poke Password
                       </label>
                       <div
-                        class="sc-fKFyDc dToKui sc-bBXqnf jWZcsF sc-bXDlPE cyautT rendition-form-description"
+                        class="sc-fKFyDc jHCVxA sc-bBXqnf jWZcsF sc-bXDlPE cyautT rendition-form-description"
                         id="root_poke_password__description"
                       >
                         <div>
                           <p
-                            class="sc-fKFyDc dToKui sc-cxFLnm kkkmRH"
+                            class="sc-fKFyDc jHCVxA sc-cxFLnm kkkmRH"
                           >
                             Password to access the pokèmon's abilities
                           </p>
@@ -313,7 +313,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_poke_password"
                           label="Poke Password"
                           placeholder=""
@@ -355,7 +355,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                               >
                                 <input
                                   autocomplete="off"
-                                  class="StyledTextInput-sc-1x30a0s-0 eRNDsB Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP kMEjWZ"
+                                  class="StyledTextInput-sc-1x30a0s-0 ccRbRh Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP kMEjWZ"
                                   id="root_environment__input"
                                   readonly=""
                                   tabindex="-1"
@@ -400,12 +400,12 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                           Tags
                         </legend>
                         <div
-                          class="sc-fKFyDc dToKui sc-bBXqnf jWZcsF sc-bXDlPE cyautT rendition-form-description"
+                          class="sc-fKFyDc jHCVxA sc-bBXqnf jWZcsF sc-bXDlPE cyautT rendition-form-description"
                           id="root_tags__description"
                         >
                           <div>
                             <p
-                              class="sc-fKFyDc dToKui sc-cxFLnm kkkmRH"
+                              class="sc-fKFyDc jHCVxA sc-cxFLnm kkkmRH"
                             >
                               Add useful tags to your pokèmon
                             </p>
@@ -458,7 +458,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
         class="sc-gKsewC dWcnb sc-iBPRYJ boyrPm"
       >
         <div
-          class="sc-fKFyDc dnBhvD sc-bBXqnf kYwmpI"
+          class="sc-fKFyDc jaKxkN sc-bBXqnf kYwmpI"
         >
           <pre>
             {}
@@ -518,7 +518,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                         
                         <input
                           autocomplete="off"
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Name"
                           label="Name"
                           list="dummy-datalist"
@@ -549,7 +549,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Height"
                           label="Height"
                           placeholder=""
@@ -576,7 +576,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Weight"
                           label="Weight"
                           placeholder=""
@@ -603,7 +603,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Description"
                           label="Description"
                           placeholder=""
@@ -630,7 +630,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Category"
                           label="Category"
                           placeholder=""
@@ -657,7 +657,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Abilities"
                           label="Abilities"
                           placeholder=""
@@ -684,7 +684,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_pokedex_number"
                           label="National Pokèdex Number"
                           placeholder=""
@@ -728,12 +728,12 @@ exports[`Storyshots Core/Form Default 1`] = `
                         First seen
                       </label>
                       <div
-                        class="sc-fKFyDc dToKui sc-bBXqnf jWZcsF sc-bXDlPE cyautT rendition-form-description"
+                        class="sc-fKFyDc jHCVxA sc-bBXqnf jWZcsF sc-bXDlPE cyautT rendition-form-description"
                         id="root_first_seen__description"
                       >
                         <div>
                           <p
-                            class="sc-fKFyDc dToKui sc-cxFLnm kkkmRH"
+                            class="sc-fKFyDc jHCVxA sc-cxFLnm kkkmRH"
                           >
                             The first time you saw this pokèmon
                           </p>
@@ -744,7 +744,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_first_seen"
                           label="First seen"
                           placeholder=""
@@ -767,12 +767,12 @@ exports[`Storyshots Core/Form Default 1`] = `
                         Poke Password
                       </label>
                       <div
-                        class="sc-fKFyDc dToKui sc-bBXqnf jWZcsF sc-bXDlPE cyautT rendition-form-description"
+                        class="sc-fKFyDc jHCVxA sc-bBXqnf jWZcsF sc-bXDlPE cyautT rendition-form-description"
                         id="root_poke_password__description"
                       >
                         <div>
                           <p
-                            class="sc-fKFyDc dToKui sc-cxFLnm kkkmRH"
+                            class="sc-fKFyDc jHCVxA sc-cxFLnm kkkmRH"
                           >
                             Password to access the pokèmon's abilities
                           </p>
@@ -783,7 +783,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_poke_password"
                           label="Poke Password"
                           placeholder=""
@@ -825,7 +825,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                               >
                                 <input
                                   autocomplete="off"
-                                  class="StyledTextInput-sc-1x30a0s-0 eRNDsB Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP kMEjWZ"
+                                  class="StyledTextInput-sc-1x30a0s-0 ccRbRh Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP kMEjWZ"
                                   id="root_environment__input"
                                   readonly=""
                                   tabindex="-1"
@@ -870,12 +870,12 @@ exports[`Storyshots Core/Form Default 1`] = `
                           Tags
                         </legend>
                         <div
-                          class="sc-fKFyDc dToKui sc-bBXqnf jWZcsF sc-bXDlPE cyautT rendition-form-description"
+                          class="sc-fKFyDc jHCVxA sc-bBXqnf jWZcsF sc-bXDlPE cyautT rendition-form-description"
                           id="root_tags__description"
                         >
                           <div>
                             <p
-                              class="sc-fKFyDc dToKui sc-cxFLnm kkkmRH"
+                              class="sc-fKFyDc jHCVxA sc-cxFLnm kkkmRH"
                             >
                               Add useful tags to your pokèmon
                             </p>
@@ -928,7 +928,7 @@ exports[`Storyshots Core/Form Default 1`] = `
         class="sc-gKsewC dWcnb sc-iBPRYJ boyrPm"
       >
         <div
-          class="sc-fKFyDc dnBhvD sc-bBXqnf kYwmpI"
+          class="sc-fKFyDc jaKxkN sc-bBXqnf kYwmpI"
         >
           <pre>
             {}
@@ -988,7 +988,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                         
                         <input
                           autocomplete="off"
-                          class="StyledTextInput-sc-1x30a0s-0 jUIQqT sc-jgHCyG kmycqX sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 gCxMXz sc-jgHCyG kmycqX sc-gTgzIj eNaHvD"
                           disabled=""
                           id="root_Name"
                           label="Name"
@@ -1020,7 +1020,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 jUIQqT sc-jgHCyG kmycqX sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 gCxMXz sc-jgHCyG kmycqX sc-gTgzIj eNaHvD"
                           disabled=""
                           id="root_Height"
                           label="Height"
@@ -1048,7 +1048,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 jUIQqT sc-jgHCyG kmycqX sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 gCxMXz sc-jgHCyG kmycqX sc-gTgzIj eNaHvD"
                           disabled=""
                           id="root_Weight"
                           label="Weight"
@@ -1076,7 +1076,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 jUIQqT sc-jgHCyG kmycqX sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 gCxMXz sc-jgHCyG kmycqX sc-gTgzIj eNaHvD"
                           disabled=""
                           id="root_Description"
                           label="Description"
@@ -1104,7 +1104,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 jUIQqT sc-jgHCyG kmycqX sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 gCxMXz sc-jgHCyG kmycqX sc-gTgzIj eNaHvD"
                           disabled=""
                           id="root_Category"
                           label="Category"
@@ -1132,7 +1132,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 jUIQqT sc-jgHCyG kmycqX sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 gCxMXz sc-jgHCyG kmycqX sc-gTgzIj eNaHvD"
                           disabled=""
                           id="root_Abilities"
                           label="Abilities"
@@ -1160,7 +1160,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 jUIQqT sc-jgHCyG kmycqX sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 gCxMXz sc-jgHCyG kmycqX sc-gTgzIj eNaHvD"
                           disabled=""
                           id="root_pokedex_number"
                           label="National Pokèdex Number"
@@ -1206,12 +1206,12 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                         First seen
                       </label>
                       <div
-                        class="sc-fKFyDc dToKui sc-bBXqnf jWZcsF sc-bXDlPE cyautT rendition-form-description"
+                        class="sc-fKFyDc jHCVxA sc-bBXqnf jWZcsF sc-bXDlPE cyautT rendition-form-description"
                         id="root_first_seen__description"
                       >
                         <div>
                           <p
-                            class="sc-fKFyDc dToKui sc-cxFLnm kkkmRH"
+                            class="sc-fKFyDc jHCVxA sc-cxFLnm kkkmRH"
                           >
                             The first time you saw this pokèmon
                           </p>
@@ -1222,7 +1222,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 jUIQqT sc-jgHCyG kmycqX sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 gCxMXz sc-jgHCyG kmycqX sc-gTgzIj eNaHvD"
                           disabled=""
                           id="root_first_seen"
                           label="First seen"
@@ -1246,12 +1246,12 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                         Poke Password
                       </label>
                       <div
-                        class="sc-fKFyDc dToKui sc-bBXqnf jWZcsF sc-bXDlPE cyautT rendition-form-description"
+                        class="sc-fKFyDc jHCVxA sc-bBXqnf jWZcsF sc-bXDlPE cyautT rendition-form-description"
                         id="root_poke_password__description"
                       >
                         <div>
                           <p
-                            class="sc-fKFyDc dToKui sc-cxFLnm kkkmRH"
+                            class="sc-fKFyDc jHCVxA sc-cxFLnm kkkmRH"
                           >
                             Password to access the pokèmon's abilities
                           </p>
@@ -1262,7 +1262,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 jUIQqT sc-jgHCyG kmycqX sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 gCxMXz sc-jgHCyG kmycqX sc-gTgzIj eNaHvD"
                           disabled=""
                           id="root_poke_password"
                           label="Poke Password"
@@ -1306,7 +1306,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                               >
                                 <input
                                   autocomplete="off"
-                                  class="StyledTextInput-sc-1x30a0s-0 eRNDsB Select__SelectTextInput-sc-17idtfo-0 cANsmG sc-jeGSBP kMEjWZ"
+                                  class="StyledTextInput-sc-1x30a0s-0 ccRbRh Select__SelectTextInput-sc-17idtfo-0 cANsmG sc-jeGSBP kMEjWZ"
                                   id="root_environment__input"
                                   readonly=""
                                   tabindex="-1"
@@ -1351,12 +1351,12 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                           Tags
                         </legend>
                         <div
-                          class="sc-fKFyDc dToKui sc-bBXqnf jWZcsF sc-bXDlPE cyautT rendition-form-description"
+                          class="sc-fKFyDc jHCVxA sc-bBXqnf jWZcsF sc-bXDlPE cyautT rendition-form-description"
                           id="root_tags__description"
                         >
                           <div>
                             <p
-                              class="sc-fKFyDc dToKui sc-cxFLnm kkkmRH"
+                              class="sc-fKFyDc jHCVxA sc-cxFLnm kkkmRH"
                             >
                               Add useful tags to your pokèmon
                             </p>
@@ -1409,7 +1409,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
         class="sc-gKsewC dWcnb sc-iBPRYJ boyrPm"
       >
         <div
-          class="sc-fKFyDc dnBhvD sc-bBXqnf kYwmpI"
+          class="sc-fKFyDc jaKxkN sc-bBXqnf kYwmpI"
         >
           <pre>
             {}
@@ -1469,7 +1469,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                         
                         <input
                           autocomplete="off"
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Name"
                           label="Name"
                           list="dummy-datalist"
@@ -1500,7 +1500,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Height"
                           label="Height"
                           placeholder=""
@@ -1527,7 +1527,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Weight"
                           label="Weight"
                           placeholder=""
@@ -1554,7 +1554,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Description"
                           label="Description"
                           placeholder=""
@@ -1581,7 +1581,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Category"
                           label="Category"
                           placeholder=""
@@ -1608,7 +1608,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Abilities"
                           label="Abilities"
                           placeholder=""
@@ -1635,7 +1635,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_pokedex_number"
                           label="National Pokèdex Number"
                           placeholder=""
@@ -1679,12 +1679,12 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                         First seen
                       </label>
                       <div
-                        class="sc-fKFyDc dToKui sc-bBXqnf jWZcsF sc-bXDlPE cyautT rendition-form-description"
+                        class="sc-fKFyDc jHCVxA sc-bBXqnf jWZcsF sc-bXDlPE cyautT rendition-form-description"
                         id="root_first_seen__description"
                       >
                         <div>
                           <p
-                            class="sc-fKFyDc dToKui sc-cxFLnm kkkmRH"
+                            class="sc-fKFyDc jHCVxA sc-cxFLnm kkkmRH"
                           >
                             The first time you saw this pokèmon
                           </p>
@@ -1695,7 +1695,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_first_seen"
                           label="First seen"
                           placeholder=""
@@ -1718,12 +1718,12 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                         Poke Password
                       </label>
                       <div
-                        class="sc-fKFyDc dToKui sc-bBXqnf jWZcsF sc-bXDlPE cyautT rendition-form-description"
+                        class="sc-fKFyDc jHCVxA sc-bBXqnf jWZcsF sc-bXDlPE cyautT rendition-form-description"
                         id="root_poke_password__description"
                       >
                         <div>
                           <p
-                            class="sc-fKFyDc dToKui sc-cxFLnm kkkmRH"
+                            class="sc-fKFyDc jHCVxA sc-cxFLnm kkkmRH"
                           >
                             Password to access the pokèmon's abilities
                           </p>
@@ -1734,7 +1734,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_poke_password"
                           label="Poke Password"
                           placeholder=""
@@ -1776,7 +1776,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                               >
                                 <input
                                   autocomplete="off"
-                                  class="StyledTextInput-sc-1x30a0s-0 eRNDsB Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP kMEjWZ"
+                                  class="StyledTextInput-sc-1x30a0s-0 ccRbRh Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP kMEjWZ"
                                   id="root_environment__input"
                                   readonly=""
                                   tabindex="-1"
@@ -1821,12 +1821,12 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                           Tags
                         </legend>
                         <div
-                          class="sc-fKFyDc dToKui sc-bBXqnf jWZcsF sc-bXDlPE cyautT rendition-form-description"
+                          class="sc-fKFyDc jHCVxA sc-bBXqnf jWZcsF sc-bXDlPE cyautT rendition-form-description"
                           id="root_tags__description"
                         >
                           <div>
                             <p
-                              class="sc-fKFyDc dToKui sc-cxFLnm kkkmRH"
+                              class="sc-fKFyDc jHCVxA sc-cxFLnm kkkmRH"
                             >
                               Add useful tags to your pokèmon
                             </p>
@@ -1874,7 +1874,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
         class="sc-gKsewC dWcnb sc-iBPRYJ boyrPm"
       >
         <div
-          class="sc-fKFyDc dnBhvD sc-bBXqnf kYwmpI"
+          class="sc-fKFyDc jaKxkN sc-bBXqnf kYwmpI"
         >
           <pre>
             {}
@@ -1934,7 +1934,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                         
                         <input
                           autocomplete="off"
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Name"
                           label="Name"
                           list="dummy-datalist"
@@ -1965,7 +1965,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Height"
                           label="Height"
                           placeholder=""
@@ -1992,7 +1992,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Weight"
                           label="Weight"
                           placeholder=""
@@ -2019,7 +2019,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Description"
                           label="Description"
                           placeholder=""
@@ -2046,7 +2046,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Category"
                           label="Category"
                           placeholder=""
@@ -2073,7 +2073,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Abilities"
                           label="Abilities"
                           placeholder=""
@@ -2100,7 +2100,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_pokedex_number"
                           label="National Pokèdex Number"
                           placeholder=""
@@ -2144,12 +2144,12 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                         First seen
                       </label>
                       <div
-                        class="sc-fKFyDc dToKui sc-bBXqnf jWZcsF sc-bXDlPE cyautT rendition-form-description"
+                        class="sc-fKFyDc jHCVxA sc-bBXqnf jWZcsF sc-bXDlPE cyautT rendition-form-description"
                         id="root_first_seen__description"
                       >
                         <div>
                           <p
-                            class="sc-fKFyDc dToKui sc-cxFLnm kkkmRH"
+                            class="sc-fKFyDc jHCVxA sc-cxFLnm kkkmRH"
                           >
                             The first time you saw this pokèmon
                           </p>
@@ -2160,7 +2160,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_first_seen"
                           label="First seen"
                           placeholder=""
@@ -2183,12 +2183,12 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                         Poke Password
                       </label>
                       <div
-                        class="sc-fKFyDc dToKui sc-bBXqnf jWZcsF sc-bXDlPE cyautT rendition-form-description"
+                        class="sc-fKFyDc jHCVxA sc-bBXqnf jWZcsF sc-bXDlPE cyautT rendition-form-description"
                         id="root_poke_password__description"
                       >
                         <div>
                           <p
-                            class="sc-fKFyDc dToKui sc-cxFLnm kkkmRH"
+                            class="sc-fKFyDc jHCVxA sc-cxFLnm kkkmRH"
                           >
                             Password to access the pokèmon's abilities
                           </p>
@@ -2199,7 +2199,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_poke_password"
                           label="Poke Password"
                           placeholder=""
@@ -2241,7 +2241,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                               >
                                 <input
                                   autocomplete="off"
-                                  class="StyledTextInput-sc-1x30a0s-0 eRNDsB Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP kMEjWZ"
+                                  class="StyledTextInput-sc-1x30a0s-0 ccRbRh Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP kMEjWZ"
                                   id="root_environment__input"
                                   readonly=""
                                   tabindex="-1"
@@ -2286,12 +2286,12 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                           Tags
                         </legend>
                         <div
-                          class="sc-fKFyDc dToKui sc-bBXqnf jWZcsF sc-bXDlPE cyautT rendition-form-description"
+                          class="sc-fKFyDc jHCVxA sc-bBXqnf jWZcsF sc-bXDlPE cyautT rendition-form-description"
                           id="root_tags__description"
                         >
                           <div>
                             <p
-                              class="sc-fKFyDc dToKui sc-cxFLnm kkkmRH"
+                              class="sc-fKFyDc jHCVxA sc-cxFLnm kkkmRH"
                             >
                               Add useful tags to your pokèmon
                             </p>
@@ -2350,7 +2350,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
         class="sc-gKsewC dWcnb sc-iBPRYJ boyrPm"
       >
         <div
-          class="sc-fKFyDc dnBhvD sc-bBXqnf kYwmpI"
+          class="sc-fKFyDc jaKxkN sc-bBXqnf kYwmpI"
         >
           <pre>
             {}
@@ -2490,7 +2490,7 @@ exports[`Storyshots Core/Form With Dependants 1`] = `
         class="sc-gKsewC dWcnb sc-iBPRYJ boyrPm"
       >
         <div
-          class="sc-fKFyDc dnBhvD sc-bBXqnf kYwmpI"
+          class="sc-fKFyDc jaKxkN sc-bBXqnf kYwmpI"
         >
           <pre>
             {}
@@ -2511,7 +2511,7 @@ exports[`Storyshots Core/Form With Extra Widgets 1`] = `
       class="sc-gKsewC cgpPfo sc-iBPRYJ gjBBNx"
     >
       <div
-        class="sc-fKFyDc dToKui sc-bBXqnf kYwmpI sc-bXDlPE cyautT"
+        class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-bXDlPE cyautT"
       >
         <div>
           <h1
@@ -2522,7 +2522,7 @@ exports[`Storyshots Core/Form With Extra Widgets 1`] = `
           
 
           <p
-            class="sc-fKFyDc dToKui sc-cxFLnm kkkmRH"
+            class="sc-fKFyDc jHCVxA sc-cxFLnm kkkmRH"
           >
             Additional widgets for handling different formats can be registered using the 
             <code>
@@ -3222,7 +3222,7 @@ Rendition contains widgets for rendering Markdown and Mermaid text formats that 
                           role="tabpanel"
                         >
                           <textarea
-                            class="StyledTextArea-sc-17i3mwp-0 cICwEP sc-laRPJI bNMKOQ sc-iNqMTl fXSmiS"
+                            class="StyledTextArea-sc-17i3mwp-0 gFImaJ sc-laRPJI bNMKOQ sc-iNqMTl fXSmiS"
                             id="root_Mermaid"
                             label="Mermaid"
                             placeholder=""
@@ -3565,7 +3565,7 @@ Rendition contains widgets for rendering Markdown and Mermaid text formats that 
         class="sc-gKsewC dWcnb sc-iBPRYJ boyrPm"
       >
         <div
-          class="sc-fKFyDc dnBhvD sc-bBXqnf kYwmpI"
+          class="sc-fKFyDc jaKxkN sc-bBXqnf kYwmpI"
         >
           <pre>
             {}
@@ -3625,7 +3625,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                         
                         <input
                           autocomplete="off"
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Name"
                           label="Name"
                           list="dummy-datalist"
@@ -3638,11 +3638,11 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                         id="dummy-datalist"
                       />
                       <div
-                        class="sc-fKFyDc dToKui sc-bBXqnf jhEXsA sc-bXDlPE cyautT rendition-form-help"
+                        class="sc-fKFyDc jHCVxA sc-bBXqnf jhEXsA sc-bXDlPE cyautT rendition-form-help"
                       >
                         <div>
                           <p
-                            class="sc-fKFyDc dToKui sc-cxFLnm eyKWrE"
+                            class="sc-fKFyDc jHCVxA sc-cxFLnm eyKWrE"
                           >
                             Once the 
                             <code>
@@ -3688,7 +3688,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                         Description
                       </label>
                       <textarea
-                        class="StyledTextArea-sc-17i3mwp-0 cICwEP sc-laRPJI bNMKOQ sc-iNqMTl fXSmiS form-control"
+                        class="StyledTextArea-sc-17i3mwp-0 gFImaJ sc-laRPJI bNMKOQ sc-iNqMTl fXSmiS form-control"
                         id="root_Description"
                         placeholder=""
                         rows="5"
@@ -3712,7 +3712,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Abilities"
                           label="Abilities"
                           placeholder=""
@@ -3739,7 +3739,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-jgHCyG jDTnAL sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG jDTnAL sc-gTgzIj eNaHvD"
                           id="root_Height"
                           label="Height"
                           placeholder=""
@@ -3766,7 +3766,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Weight"
                           label="Weight"
                           placeholder=""
@@ -3793,7 +3793,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Category"
                           label="Category"
                           placeholder=""
@@ -3820,7 +3820,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_pokedex_number"
                           label="National Pokèdex Number"
                           placeholder=""
@@ -3843,12 +3843,12 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                         First seen
                       </label>
                       <div
-                        class="sc-fKFyDc dToKui sc-bBXqnf jWZcsF sc-bXDlPE cyautT rendition-form-description"
+                        class="sc-fKFyDc jHCVxA sc-bBXqnf jWZcsF sc-bXDlPE cyautT rendition-form-description"
                         id="root_first_seen__description"
                       >
                         <div>
                           <p
-                            class="sc-fKFyDc dToKui sc-cxFLnm kkkmRH"
+                            class="sc-fKFyDc jHCVxA sc-cxFLnm kkkmRH"
                           >
                             The first time you saw this pokèmon
                           </p>
@@ -3859,7 +3859,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_first_seen"
                           label="First seen"
                           placeholder=""
@@ -3882,12 +3882,12 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                         Poke Password
                       </label>
                       <div
-                        class="sc-fKFyDc dToKui sc-bBXqnf jWZcsF sc-bXDlPE cyautT rendition-form-description"
+                        class="sc-fKFyDc jHCVxA sc-bBXqnf jWZcsF sc-bXDlPE cyautT rendition-form-description"
                         id="root_poke_password__description"
                       >
                         <div>
                           <p
-                            class="sc-fKFyDc dToKui sc-cxFLnm kkkmRH"
+                            class="sc-fKFyDc jHCVxA sc-cxFLnm kkkmRH"
                           >
                             Password to access the pokèmon's abilities
                           </p>
@@ -3901,7 +3901,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                         >
                           
                           <input
-                            class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-jgHCyG cnloRI sc-gTgzIj kDmtQx"
+                            class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj kDmtQx"
                             id="root_poke_password"
                             label="Poke Password"
                             placeholder=""
@@ -3964,7 +3964,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                               >
                                 <input
                                   autocomplete="off"
-                                  class="StyledTextInput-sc-1x30a0s-0 eRNDsB Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP iqwkEO"
+                                  class="StyledTextInput-sc-1x30a0s-0 ccRbRh Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP iqwkEO"
                                   id="root_environment__input"
                                   readonly=""
                                   tabindex="-1"
@@ -4009,12 +4009,12 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                           Tags
                         </legend>
                         <div
-                          class="sc-fKFyDc dToKui sc-bBXqnf jWZcsF sc-bXDlPE cyautT rendition-form-description"
+                          class="sc-fKFyDc jHCVxA sc-bBXqnf jWZcsF sc-bXDlPE cyautT rendition-form-description"
                           id="root_tags__description"
                         >
                           <div>
                             <p
-                              class="sc-fKFyDc dToKui sc-cxFLnm kkkmRH"
+                              class="sc-fKFyDc jHCVxA sc-cxFLnm kkkmRH"
                             >
                               Add useful tags to your pokèmon
                             </p>
@@ -4067,7 +4067,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
         class="sc-gKsewC dWcnb sc-iBPRYJ boyrPm"
       >
         <div
-          class="sc-fKFyDc dnBhvD sc-bBXqnf kYwmpI"
+          class="sc-fKFyDc jaKxkN sc-bBXqnf kYwmpI"
         >
           <pre>
             {}
@@ -4141,7 +4141,7 @@ exports[`Storyshots Core/Form With Pattern Properties 1`] = `
                                     >
                                       <input
                                         autocomplete="off"
-                                        class="StyledTextInput-sc-1x30a0s-0 jUIQqT sc-jgHCyG kmycqX sc-gTgzIj cjgnvU rendition-form-pattern-properties__key-field"
+                                        class="StyledTextInput-sc-1x30a0s-0 gCxMXz sc-jgHCyG kmycqX sc-gTgzIj cjgnvU rendition-form-pattern-properties__key-field"
                                         disabled=""
                                         pattern="^[0-9]+$"
                                         placeholder="Key"
@@ -4155,7 +4155,7 @@ exports[`Storyshots Core/Form With Pattern Properties 1`] = `
                                     >
                                       <input
                                         autocomplete="off"
-                                        class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-jgHCyG cnloRI sc-gTgzIj cjgnvU rendition-form-pattern-properties__value-field"
+                                        class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj cjgnvU rendition-form-pattern-properties__value-field"
                                         id="foo"
                                         placeholder="Rule"
                                         value=""
@@ -4186,7 +4186,7 @@ exports[`Storyshots Core/Form With Pattern Properties 1`] = `
         class="sc-gKsewC dWcnb sc-iBPRYJ boyrPm"
       >
         <div
-          class="sc-fKFyDc dnBhvD sc-bBXqnf kYwmpI"
+          class="sc-fKFyDc jaKxkN sc-bBXqnf kYwmpI"
         >
           <pre>
             {
@@ -4263,7 +4263,7 @@ exports[`Storyshots Core/Form With Titles 1`] = `
                               >
                                 
                                 <input
-                                  class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                                  class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                                   id="root_vpn_endpoint"
                                   label="Endpoint"
                                   placeholder=""
@@ -4290,7 +4290,7 @@ exports[`Storyshots Core/Form With Titles 1`] = `
                               >
                                 
                                 <input
-                                  class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                                  class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                                   id="root_vpn_certificate"
                                   label="Certificate"
                                   placeholder=""
@@ -4347,7 +4347,7 @@ exports[`Storyshots Core/Form With Titles 1`] = `
                                       >
                                         
                                         <input
-                                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                                           id="root_wifiNetwork_wifi_ssid"
                                           label="Network SSID"
                                           placeholder=""
@@ -4388,7 +4388,7 @@ exports[`Storyshots Core/Form With Titles 1`] = `
                                       >
                                         
                                         <input
-                                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                                           id="root_wifiNetwork_wifiSecurity_psk"
                                           label="Network Passphrase"
                                           placeholder=""
@@ -4422,7 +4422,7 @@ exports[`Storyshots Core/Form With Titles 1`] = `
         class="sc-gKsewC dWcnb sc-iBPRYJ boyrPm"
       >
         <div
-          class="sc-fKFyDc dnBhvD sc-bBXqnf kYwmpI"
+          class="sc-fKFyDc jaKxkN sc-bBXqnf kYwmpI"
         >
           <pre>
             {
@@ -4488,7 +4488,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                         
                         <input
                           autocomplete="off"
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Name"
                           label="Name"
                           list="dummy-datalist"
@@ -4536,7 +4536,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                         Description
                       </label>
                       <textarea
-                        class="StyledTextArea-sc-17i3mwp-0 cICwEP sc-laRPJI bNMKOQ sc-iNqMTl fXSmiS form-control"
+                        class="StyledTextArea-sc-17i3mwp-0 gFImaJ sc-laRPJI bNMKOQ sc-iNqMTl fXSmiS form-control"
                         id="root_Description"
                         placeholder=""
                         rows="5"
@@ -4560,7 +4560,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Abilities"
                           label="Abilities"
                           placeholder=""
@@ -4587,7 +4587,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-jgHCyG jDTnAL sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG jDTnAL sc-gTgzIj eNaHvD"
                           id="root_Height"
                           label="Height"
                           placeholder=""
@@ -4614,7 +4614,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Weight"
                           label="Weight"
                           placeholder=""
@@ -4641,7 +4641,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Category"
                           label="Category"
                           placeholder=""
@@ -4668,7 +4668,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_pokedex_number"
                           label="National Pokèdex Number"
                           placeholder=""
@@ -4691,12 +4691,12 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                         First seen
                       </label>
                       <div
-                        class="sc-fKFyDc dToKui sc-bBXqnf jWZcsF sc-bXDlPE cyautT rendition-form-description"
+                        class="sc-fKFyDc jHCVxA sc-bBXqnf jWZcsF sc-bXDlPE cyautT rendition-form-description"
                         id="root_first_seen__description"
                       >
                         <div>
                           <p
-                            class="sc-fKFyDc dToKui sc-cxFLnm kkkmRH"
+                            class="sc-fKFyDc jHCVxA sc-cxFLnm kkkmRH"
                           >
                             The first time you saw this pokèmon
                           </p>
@@ -4707,7 +4707,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_first_seen"
                           label="First seen"
                           placeholder=""
@@ -4730,12 +4730,12 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                         Poke Password
                       </label>
                       <div
-                        class="sc-fKFyDc dToKui sc-bBXqnf jWZcsF sc-bXDlPE cyautT rendition-form-description"
+                        class="sc-fKFyDc jHCVxA sc-bBXqnf jWZcsF sc-bXDlPE cyautT rendition-form-description"
                         id="root_poke_password__description"
                       >
                         <div>
                           <p
-                            class="sc-fKFyDc dToKui sc-cxFLnm kkkmRH"
+                            class="sc-fKFyDc jHCVxA sc-cxFLnm kkkmRH"
                           >
                             Password to access the pokèmon's abilities
                           </p>
@@ -4749,7 +4749,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                         >
                           
                           <input
-                            class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-jgHCyG cnloRI sc-gTgzIj kDmtQx"
+                            class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj kDmtQx"
                             id="root_poke_password"
                             label="Poke Password"
                             placeholder=""
@@ -4812,7 +4812,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                               >
                                 <input
                                   autocomplete="off"
-                                  class="StyledTextInput-sc-1x30a0s-0 eRNDsB Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP iqwkEO"
+                                  class="StyledTextInput-sc-1x30a0s-0 ccRbRh Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP iqwkEO"
                                   id="root_environment__input"
                                   readonly=""
                                   tabindex="-1"
@@ -4857,12 +4857,12 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                           Tags
                         </legend>
                         <div
-                          class="sc-fKFyDc dToKui sc-bBXqnf jWZcsF sc-bXDlPE cyautT rendition-form-description"
+                          class="sc-fKFyDc jHCVxA sc-bBXqnf jWZcsF sc-bXDlPE cyautT rendition-form-description"
                           id="root_tags__description"
                         >
                           <div>
                             <p
-                              class="sc-fKFyDc dToKui sc-cxFLnm kkkmRH"
+                              class="sc-fKFyDc jHCVxA sc-cxFLnm kkkmRH"
                             >
                               Add useful tags to your pokèmon
                             </p>
@@ -4915,7 +4915,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
         class="sc-gKsewC dWcnb sc-iBPRYJ boyrPm"
       >
         <div
-          class="sc-fKFyDc dnBhvD sc-bBXqnf kYwmpI"
+          class="sc-fKFyDc jaKxkN sc-bBXqnf kYwmpI"
         >
           <pre>
             {}
@@ -4973,7 +4973,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                         class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV sc-lmoMRL iMRgnB"
                       >
                         <div
-                          class="sc-fKFyDc dToKui sc-bBXqnf hsApDH"
+                          class="sc-fKFyDc jHCVxA sc-bBXqnf hsApDH"
                         >
                           <svg
                             aria-hidden="true"
@@ -4992,14 +4992,14 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                           </svg>
                         </div>
                         <span
-                          class="sc-fKFyDc dToKui sc-iwyYcG dgyEur"
+                          class="sc-fKFyDc jHCVxA sc-iwyYcG dgyEur"
                         >
                           <div
-                            class="sc-fKFyDc dToKui sc-bBXqnf kYwmpI sc-bXDlPE cyautT"
+                            class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-bXDlPE cyautT"
                           >
                             <div>
                               <p
-                                class="sc-fKFyDc dToKui sc-cxFLnm eyKWrE"
+                                class="sc-fKFyDc jHCVxA sc-cxFLnm eyKWrE"
                               >
                                 Once the 
                                 <code>
@@ -5017,7 +5017,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                         
                         <input
                           autocomplete="off"
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Name"
                           label="Name"
                           list="dummy-datalist"
@@ -5065,7 +5065,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                         Description
                       </label>
                       <textarea
-                        class="StyledTextArea-sc-17i3mwp-0 cICwEP sc-laRPJI bNMKOQ sc-iNqMTl fXSmiS form-control"
+                        class="StyledTextArea-sc-17i3mwp-0 gFImaJ sc-laRPJI bNMKOQ sc-iNqMTl fXSmiS form-control"
                         id="root_Description"
                         placeholder=""
                         rows="5"
@@ -5089,7 +5089,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Abilities"
                           label="Abilities"
                           placeholder=""
@@ -5116,7 +5116,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-jgHCyG jDTnAL sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG jDTnAL sc-gTgzIj eNaHvD"
                           id="root_Height"
                           label="Height"
                           placeholder=""
@@ -5143,7 +5143,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Weight"
                           label="Weight"
                           placeholder=""
@@ -5170,7 +5170,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Category"
                           label="Category"
                           placeholder=""
@@ -5197,7 +5197,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_pokedex_number"
                           label="National Pokèdex Number"
                           placeholder=""
@@ -5220,12 +5220,12 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                         First seen
                       </label>
                       <div
-                        class="sc-fKFyDc dToKui sc-bBXqnf jWZcsF sc-bXDlPE cyautT rendition-form-description"
+                        class="sc-fKFyDc jHCVxA sc-bBXqnf jWZcsF sc-bXDlPE cyautT rendition-form-description"
                         id="root_first_seen__description"
                       >
                         <div>
                           <p
-                            class="sc-fKFyDc dToKui sc-cxFLnm kkkmRH"
+                            class="sc-fKFyDc jHCVxA sc-cxFLnm kkkmRH"
                           >
                             The first time you saw this pokèmon
                           </p>
@@ -5236,7 +5236,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_first_seen"
                           label="First seen"
                           placeholder=""
@@ -5259,12 +5259,12 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                         Poke Password
                       </label>
                       <div
-                        class="sc-fKFyDc dToKui sc-bBXqnf jWZcsF sc-bXDlPE cyautT rendition-form-description"
+                        class="sc-fKFyDc jHCVxA sc-bBXqnf jWZcsF sc-bXDlPE cyautT rendition-form-description"
                         id="root_poke_password__description"
                       >
                         <div>
                           <p
-                            class="sc-fKFyDc dToKui sc-cxFLnm kkkmRH"
+                            class="sc-fKFyDc jHCVxA sc-cxFLnm kkkmRH"
                           >
                             Password to access the pokèmon's abilities
                           </p>
@@ -5278,7 +5278,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                         >
                           
                           <input
-                            class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-jgHCyG cnloRI sc-gTgzIj kDmtQx"
+                            class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj kDmtQx"
                             id="root_poke_password"
                             label="Poke Password"
                             placeholder=""
@@ -5341,7 +5341,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                               >
                                 <input
                                   autocomplete="off"
-                                  class="StyledTextInput-sc-1x30a0s-0 eRNDsB Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP iqwkEO"
+                                  class="StyledTextInput-sc-1x30a0s-0 ccRbRh Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP iqwkEO"
                                   id="root_environment__input"
                                   readonly=""
                                   tabindex="-1"
@@ -5386,12 +5386,12 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                           Tags
                         </legend>
                         <div
-                          class="sc-fKFyDc dToKui sc-bBXqnf jWZcsF sc-bXDlPE cyautT rendition-form-description"
+                          class="sc-fKFyDc jHCVxA sc-bBXqnf jWZcsF sc-bXDlPE cyautT rendition-form-description"
                           id="root_tags__description"
                         >
                           <div>
                             <p
-                              class="sc-fKFyDc dToKui sc-cxFLnm kkkmRH"
+                              class="sc-fKFyDc jHCVxA sc-cxFLnm kkkmRH"
                             >
                               Add useful tags to your pokèmon
                             </p>
@@ -5444,7 +5444,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
         class="sc-gKsewC dWcnb sc-iBPRYJ boyrPm"
       >
         <div
-          class="sc-fKFyDc dnBhvD sc-bBXqnf kYwmpI"
+          class="sc-fKFyDc jaKxkN sc-bBXqnf kYwmpI"
         >
           <pre>
             {}

--- a/src/components/Form/__snapshots__/spec.tsx.snap
+++ b/src/components/Form/__snapshots__/spec.tsx.snap
@@ -1,5 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Form component description keyword should support markdown 1`] = `"<div id=\\"root_foo__description\\" class=\\"sc-fKFyDc dToKui sc-bBXqnf jWZcsF sc-bXDlPE cyautT rendition-form-description\\"><div><p class=\\"sc-fKFyDc dToKui sc-cxFLnm kkkmRH\\">Lorem ipsum <em>dolor</em> sit amet</p></div></div>"`;
+exports[`Form component description keyword should support markdown 1`] = `"<div id=\\"root_foo__description\\" class=\\"sc-fKFyDc jHCVxA sc-bBXqnf jWZcsF sc-bXDlPE cyautT rendition-form-description\\"><div><p class=\\"sc-fKFyDc jHCVxA sc-cxFLnm kkkmRH\\">Lorem ipsum <em>dolor</em> sit amet</p></div></div>"`;
 
-exports[`Form component ui:help keyword should support markdown 1`] = `"<div class=\\"sc-fKFyDc dToKui sc-bBXqnf jhEXsA sc-bXDlPE cyautT rendition-form-help\\"><div><p class=\\"sc-fKFyDc dToKui sc-cxFLnm eyKWrE\\">Lorem ipsum <em>dolor</em> sit amet</p></div></div>"`;
+exports[`Form component ui:help keyword should support markdown 1`] = `"<div class=\\"sc-fKFyDc jHCVxA sc-bBXqnf jhEXsA sc-bXDlPE cyautT rendition-form-help\\"><div><p class=\\"sc-fKFyDc jHCVxA sc-cxFLnm eyKWrE\\">Lorem ipsum <em>dolor</em> sit amet</p></div></div>"`;

--- a/src/components/HighlightedName/__snapshots__/HighlightedName.stories.storyshot
+++ b/src/components/HighlightedName/__snapshots__/HighlightedName.stories.storyshot
@@ -6,7 +6,7 @@ exports[`Storyshots Core/HighlightedName Default 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-dWdcrH ScrBw"
   >
     <span
-      class="sc-fKFyDc dToKui sc-iwyYcG gAkelF sc-ikPAkQ gqEzvs sc-tYoTV hRuSZt"
+      class="sc-fKFyDc jHCVxA sc-iwyYcG gAkelF sc-ikPAkQ gqEzvs sc-tYoTV hRuSZt"
     >
       Frontend Service
     </span>
@@ -20,7 +20,7 @@ exports[`Storyshots Core/HighlightedName With Custom Colors 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-dWdcrH ScrBw"
   >
     <span
-      class="sc-fKFyDc dToKui sc-iwyYcG brBCdy sc-ikPAkQ gqEzvs sc-tYoTV bAnLdm"
+      class="sc-fKFyDc jHCVxA sc-iwyYcG brBCdy sc-ikPAkQ gqEzvs sc-tYoTV bAnLdm"
     >
       Frontend Service
     </span>

--- a/src/components/Input/__snapshots__/Input.stories.storyshot
+++ b/src/components/Input/__snapshots__/Input.stories.storyshot
@@ -10,7 +10,7 @@ exports[`Storyshots Core/Input Default 1`] = `
     >
       <input
         autocomplete="off"
-        class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-jgHCyG cnloRI sc-gTgzIj cjgnvU"
+        class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj cjgnvU"
         value=""
       />
     </div>
@@ -28,7 +28,7 @@ exports[`Storyshots Core/Input Emphasized 1`] = `
     >
       <input
         autocomplete="off"
-        class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-jgHCyG jDTnAL sc-gTgzIj cjgnvU"
+        class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG jDTnAL sc-gTgzIj cjgnvU"
         value=""
       />
     </div>
@@ -46,7 +46,7 @@ exports[`Storyshots Core/Input Monospace 1`] = `
     >
       <input
         autocomplete="off"
-        class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-jgHCyG fbrLsF sc-gTgzIj cjgnvU"
+        class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG fbrLsF sc-gTgzIj cjgnvU"
         value=""
       />
     </div>
@@ -64,7 +64,7 @@ exports[`Storyshots Core/Input With Placeholder 1`] = `
     >
       <input
         autocomplete="off"
-        class="StyledTextInput-sc-1x30a0s-0 DrHkh sc-jgHCyG cnloRI sc-gTgzIj cjgnvU"
+        class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj cjgnvU"
         placeholder="This is a placeholder"
         value=""
       />

--- a/src/components/List/__snapshots__/List.stories.storyshot
+++ b/src/components/List/__snapshots__/List.stories.storyshot
@@ -10,7 +10,7 @@ exports[`Storyshots Core/List Default 1`] = `
     >
       <li>
         <div
-          class="sc-fKFyDc dToKui sc-bBXqnf kYwmpI"
+          class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI"
         >
           You can put 
           <a
@@ -24,7 +24,7 @@ exports[`Storyshots Core/List Default 1`] = `
       </li>
       <li>
         <div
-          class="sc-fKFyDc dToKui sc-bBXqnf kYwmpI"
+          class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI"
         >
           And also some 
           <code>
@@ -34,11 +34,11 @@ exports[`Storyshots Core/List Default 1`] = `
       </li>
       <li>
         <div
-          class="sc-fKFyDc dToKui sc-bBXqnf kYwmpI"
+          class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI"
         >
           Multiline text
           <div
-            class="sc-fKFyDc dToKui sc-bBXqnf kYwmpI"
+            class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI"
           >
             that breaks into multiple lines
           </div>
@@ -59,7 +59,7 @@ exports[`Storyshots Core/List Ordered 1`] = `
     >
       <li>
         <div
-          class="sc-fKFyDc dToKui sc-bBXqnf kYwmpI"
+          class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI"
         >
           You can put 
           <a
@@ -73,7 +73,7 @@ exports[`Storyshots Core/List Ordered 1`] = `
       </li>
       <li>
         <div
-          class="sc-fKFyDc dToKui sc-bBXqnf kYwmpI"
+          class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI"
         >
           And also some 
           <code>
@@ -83,11 +83,11 @@ exports[`Storyshots Core/List Ordered 1`] = `
       </li>
       <li>
         <div
-          class="sc-fKFyDc dToKui sc-bBXqnf kYwmpI"
+          class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI"
         >
           Multiline text
           <div
-            class="sc-fKFyDc dToKui sc-bBXqnf kYwmpI"
+            class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI"
           >
             that breaks into multiple lines
           </div>

--- a/src/components/Notifications/__snapshots__/Notifications.stories.storyshot
+++ b/src/components/Notifications/__snapshots__/Notifications.stories.storyshot
@@ -33,7 +33,7 @@ exports[`Storyshots Core/Notifications Default 1`] = `
                 >
                   
                   <span
-                    class="sc-fKFyDc dToKui sc-iwyYcG bUoHum"
+                    class="sc-fKFyDc jHCVxA sc-iwyYcG bUoHum"
                   >
                     This is a notification
                   </span>
@@ -79,13 +79,13 @@ exports[`Storyshots Core/Notifications Default 1`] = `
                 >
                   
                   <span
-                    class="sc-fKFyDc dToKui sc-iwyYcG bUoHum"
+                    class="sc-fKFyDc jHCVxA sc-iwyYcG bUoHum"
                   >
                     <div
                       class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP"
                     >
                       <div
-                        class="sc-fKFyDc dToKui sc-bBXqnf hABGiJ"
+                        class="sc-fKFyDc jHCVxA sc-bBXqnf hABGiJ"
                       >
                         Some text for the user to read
                       </div>
@@ -188,7 +188,7 @@ exports[`Storyshots Core/Notifications Positioning 1`] = `
               >
                 
                 <span
-                  class="sc-fKFyDc dToKui sc-iwyYcG bUoHum"
+                  class="sc-fKFyDc jHCVxA sc-iwyYcG bUoHum"
                 >
                   top-left
                 </span>
@@ -238,7 +238,7 @@ exports[`Storyshots Core/Notifications Positioning 1`] = `
               >
                 
                 <span
-                  class="sc-fKFyDc dToKui sc-iwyYcG bUoHum"
+                  class="sc-fKFyDc jHCVxA sc-iwyYcG bUoHum"
                 >
                   top-right
                 </span>
@@ -288,7 +288,7 @@ exports[`Storyshots Core/Notifications Positioning 1`] = `
               >
                 
                 <span
-                  class="sc-fKFyDc dToKui sc-iwyYcG bUoHum"
+                  class="sc-fKFyDc jHCVxA sc-iwyYcG bUoHum"
                 >
                   bottom-left
                 </span>
@@ -338,7 +338,7 @@ exports[`Storyshots Core/Notifications Positioning 1`] = `
               >
                 
                 <span
-                  class="sc-fKFyDc dToKui sc-iwyYcG bUoHum"
+                  class="sc-fKFyDc jHCVxA sc-iwyYcG bUoHum"
                 >
                   bottom-right
                 </span>
@@ -388,7 +388,7 @@ exports[`Storyshots Core/Notifications Positioning 1`] = `
               >
                 
                 <span
-                  class="sc-fKFyDc dToKui sc-iwyYcG bUoHum"
+                  class="sc-fKFyDc jHCVxA sc-iwyYcG bUoHum"
                 >
                   top-center
                 </span>
@@ -441,7 +441,7 @@ exports[`Storyshots Core/Notifications Positioning 1`] = `
                 >
                   
                   <span
-                    class="sc-fKFyDc dToKui sc-iwyYcG bUoHum"
+                    class="sc-fKFyDc jHCVxA sc-iwyYcG bUoHum"
                   >
                     center
                   </span>
@@ -492,7 +492,7 @@ exports[`Storyshots Core/Notifications Positioning 1`] = `
               >
                 
                 <span
-                  class="sc-fKFyDc dToKui sc-iwyYcG bUoHum"
+                  class="sc-fKFyDc jHCVxA sc-iwyYcG bUoHum"
                 >
                   bottom-center
                 </span>
@@ -610,7 +610,7 @@ exports[`Storyshots Core/Notifications Types 1`] = `
                 class="sc-gKsewC cgpPfo sc-iBPRYJ dQsSLq sc-hHftDr sc-dmlrTW cLDXoV RAjJT sc-lmoMRL cGXAYQ sc-dwcuIR gpPHBo"
               >
                 <div
-                  class="sc-fKFyDc dToKui sc-bBXqnf XVwEh"
+                  class="sc-fKFyDc jHCVxA sc-bBXqnf XVwEh"
                 >
                   <svg
                     aria-hidden="true"
@@ -632,12 +632,12 @@ exports[`Storyshots Core/Notifications Types 1`] = `
                   class="sc-gKsewC dWcnb sc-iBPRYJ fLUuUH"
                 >
                   <span
-                    class="sc-fKFyDc ipClrT sc-iwyYcG hQqijh"
+                    class="sc-fKFyDc euqOvB sc-iwyYcG hQqijh"
                   >
                     Note!
                   </span>
                   <span
-                    class="sc-fKFyDc dToKui sc-iwyYcG cRxeiz"
+                    class="sc-fKFyDc jHCVxA sc-iwyYcG cRxeiz"
                   >
                     info
                   </span>
@@ -678,7 +678,7 @@ exports[`Storyshots Core/Notifications Types 1`] = `
                 class="sc-gKsewC cgpPfo sc-iBPRYJ fiWzOU sc-hHftDr sc-dmlrTW cLDXoV dcrGdQ sc-lmoMRL cGXAYQ sc-dwcuIR gpPHBo"
               >
                 <div
-                  class="sc-fKFyDc dToKui sc-bBXqnf hsApDH"
+                  class="sc-fKFyDc jHCVxA sc-bBXqnf hsApDH"
                 >
                   <svg
                     aria-hidden="true"
@@ -700,12 +700,12 @@ exports[`Storyshots Core/Notifications Types 1`] = `
                   class="sc-gKsewC dWcnb sc-iBPRYJ gaVVgz"
                 >
                   <span
-                    class="sc-fKFyDc ipClrT sc-iwyYcG hQqijh"
+                    class="sc-fKFyDc euqOvB sc-iwyYcG hQqijh"
                   >
                     Warning!
                   </span>
                   <span
-                    class="sc-fKFyDc dToKui sc-iwyYcG dgyEur"
+                    class="sc-fKFyDc jHCVxA sc-iwyYcG dgyEur"
                   >
                     warning
                   </span>
@@ -746,7 +746,7 @@ exports[`Storyshots Core/Notifications Types 1`] = `
                 class="sc-gKsewC cgpPfo sc-iBPRYJ ipiHMM sc-hHftDr sc-dmlrTW cLDXoV fNGbub sc-lmoMRL cGXAYQ sc-dwcuIR gpPHBo"
               >
                 <div
-                  class="sc-fKFyDc dToKui sc-bBXqnf ebpqPX"
+                  class="sc-fKFyDc jHCVxA sc-bBXqnf ebpqPX"
                 >
                   <svg
                     aria-hidden="true"
@@ -768,12 +768,12 @@ exports[`Storyshots Core/Notifications Types 1`] = `
                   class="sc-gKsewC dWcnb sc-iBPRYJ jyModB"
                 >
                   <span
-                    class="sc-fKFyDc ipClrT sc-iwyYcG hQqijh"
+                    class="sc-fKFyDc euqOvB sc-iwyYcG hQqijh"
                   >
                     Success!
                   </span>
                   <span
-                    class="sc-fKFyDc dToKui sc-iwyYcG gEoXrt"
+                    class="sc-fKFyDc jHCVxA sc-iwyYcG gEoXrt"
                   >
                     success
                   </span>
@@ -814,7 +814,7 @@ exports[`Storyshots Core/Notifications Types 1`] = `
                 class="sc-gKsewC cgpPfo sc-iBPRYJ cEHZTN sc-hHftDr sc-dmlrTW cLDXoV jwBGWI sc-lmoMRL cGXAYQ sc-dwcuIR gpPHBo"
               >
                 <div
-                  class="sc-fKFyDc dToKui sc-bBXqnf ifPkvS"
+                  class="sc-fKFyDc jHCVxA sc-bBXqnf ifPkvS"
                 >
                   <svg
                     aria-hidden="true"
@@ -836,12 +836,12 @@ exports[`Storyshots Core/Notifications Types 1`] = `
                   class="sc-gKsewC dWcnb sc-iBPRYJ cQdBWv"
                 >
                   <span
-                    class="sc-fKFyDc ipClrT sc-iwyYcG hQqijh"
+                    class="sc-fKFyDc euqOvB sc-iwyYcG hQqijh"
                   >
                     Danger!
                   </span>
                   <span
-                    class="sc-fKFyDc dToKui sc-iwyYcG llbUJj"
+                    class="sc-fKFyDc jHCVxA sc-iwyYcG llbUJj"
                   >
                     danger
                   </span>

--- a/src/components/Pager/__snapshots__/Pager.stories.storyshot
+++ b/src/components/Pager/__snapshots__/Pager.stories.storyshot
@@ -9,7 +9,7 @@ exports[`Storyshots Core/Pager Default 1`] = `
       class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr ZlJMD"
     >
       <div
-        class="sc-fKFyDc dToKui sc-bBXqnf zWvFq"
+        class="sc-fKFyDc jHCVxA sc-bBXqnf zWvFq"
       >
         <strong>
           51

--- a/src/components/Select/__snapshots__/Select.stories.storyshot
+++ b/src/components/Select/__snapshots__/Select.stories.storyshot
@@ -24,7 +24,7 @@ exports[`Storyshots Core/Select Default 1`] = `
             >
               <input
                 autocomplete="off"
-                class="StyledTextInput-sc-1x30a0s-0 eRNDsB Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP kMEjWZ"
+                class="StyledTextInput-sc-1x30a0s-0 ccRbRh Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP kMEjWZ"
                 readonly=""
                 tabindex="-1"
                 type="text"
@@ -80,7 +80,7 @@ exports[`Storyshots Core/Select Emphasized 1`] = `
             >
               <input
                 autocomplete="off"
-                class="StyledTextInput-sc-1x30a0s-0 eRNDsB Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP iqwkEO"
+                class="StyledTextInput-sc-1x30a0s-0 ccRbRh Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP iqwkEO"
                 readonly=""
                 tabindex="-1"
                 type="text"
@@ -136,7 +136,7 @@ exports[`Storyshots Core/Select Invalid 1`] = `
             >
               <input
                 autocomplete="off"
-                class="StyledTextInput-sc-1x30a0s-0 eRNDsB Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP kMEjWZ"
+                class="StyledTextInput-sc-1x30a0s-0 ccRbRh Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP kMEjWZ"
                 readonly=""
                 tabindex="-1"
                 type="text"
@@ -192,7 +192,7 @@ exports[`Storyshots Core/Select Object Options 1`] = `
             >
               <input
                 autocomplete="off"
-                class="StyledTextInput-sc-1x30a0s-0 eRNDsB Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP kMEjWZ"
+                class="StyledTextInput-sc-1x30a0s-0 ccRbRh Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP kMEjWZ"
                 readonly=""
                 tabindex="-1"
                 type="text"
@@ -248,7 +248,7 @@ exports[`Storyshots Core/Select With Custom Option 1`] = `
             >
               <input
                 autocomplete="off"
-                class="StyledTextInput-sc-1x30a0s-0 eRNDsB Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP kMEjWZ"
+                class="StyledTextInput-sc-1x30a0s-0 ccRbRh Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP kMEjWZ"
                 readonly=""
                 tabindex="-1"
                 type="text"
@@ -304,7 +304,7 @@ exports[`Storyshots Core/Select With Placeholder 1`] = `
             >
               <input
                 autocomplete="off"
-                class="StyledTextInput-sc-1x30a0s-0 eRNDsB Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP kMEjWZ"
+                class="StyledTextInput-sc-1x30a0s-0 ccRbRh Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP kMEjWZ"
                 placeholder="Select one..."
                 readonly=""
                 tabindex="-1"

--- a/src/components/Spinner/__snapshots__/Spinner.stories.storyshot
+++ b/src/components/Spinner/__snapshots__/Spinner.stories.storyshot
@@ -50,7 +50,7 @@ exports[`Storyshots Core/Spinner With Children 1`] = `
             class="sc-bQdQlF krrxhB"
           />
           <div
-            class="sc-fKFyDc dToKui sc-bBXqnf kCTWx"
+            class="sc-fKFyDc jHCVxA sc-bBXqnf kCTWx"
           >
             Spinning...
           </div>
@@ -83,10 +83,10 @@ exports[`Storyshots Core/Spinner With Component Label 1`] = `
         class="sc-bQdQlF krrxhB"
       />
       <div
-        class="sc-fKFyDc dToKui sc-bBXqnf kCTWx"
+        class="sc-fKFyDc jHCVxA sc-bBXqnf kCTWx"
       >
         <div
-          class="sc-fKFyDc dToKui sc-bBXqnf gUmJJR"
+          class="sc-fKFyDc jHCVxA sc-bBXqnf gUmJJR"
         >
           Building image 
           <button
@@ -115,7 +115,7 @@ exports[`Storyshots Core/Spinner With Label 1`] = `
         class="sc-bQdQlF krrxhB"
       />
       <div
-        class="sc-fKFyDc dToKui sc-bBXqnf kCTWx"
+        class="sc-fKFyDc jHCVxA sc-bBXqnf kCTWx"
       >
         Spinning...
       </div>

--- a/src/components/StatsBar/__snapshots__/StatsBar.stories.storyshot
+++ b/src/components/StatsBar/__snapshots__/StatsBar.stories.storyshot
@@ -12,7 +12,7 @@ exports[`Storyshots Core/StatsBar Cpu Temp 1`] = `
         class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze sc-hHftDr gCwwSM"
       >
         <span
-          class="sc-fKFyDc dToKui sc-iwyYcG bsaCCL"
+          class="sc-fKFyDc jHCVxA sc-iwyYcG bsaCCL"
         >
           <div
             class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr kwbnZN"
@@ -21,7 +21,7 @@ exports[`Storyshots Core/StatsBar Cpu Temp 1`] = `
               class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP"
             >
               <span
-                class="sc-fKFyDc dToKui sc-iwyYcG kOqgin"
+                class="sc-fKFyDc jHCVxA sc-iwyYcG kOqgin"
               >
                 <svg
                   aria-hidden="true"
@@ -40,13 +40,13 @@ exports[`Storyshots Core/StatsBar Cpu Temp 1`] = `
                 </svg>
               </span>
               <span
-                class="sc-fKFyDc dToKui sc-iwyYcG bsaCCL"
+                class="sc-fKFyDc jHCVxA sc-iwyYcG bsaCCL"
               >
                 Temperature
               </span>
             </div>
             <span
-              class="sc-fKFyDc dToKui sc-iwyYcG jKWtCF"
+              class="sc-fKFyDc jHCVxA sc-iwyYcG jKWtCF"
               style="line-height: 1;"
             >
               ​
@@ -54,7 +54,7 @@ exports[`Storyshots Core/StatsBar Cpu Temp 1`] = `
           </div>
         </span>
         <span
-          class="sc-fKFyDc dToKui sc-iwyYcG bsaCCL"
+          class="sc-fKFyDc jHCVxA sc-iwyYcG bsaCCL"
         >
           ~34C
         </span>
@@ -102,7 +102,7 @@ exports[`Storyshots Core/StatsBar Cpu Usage 1`] = `
         class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze sc-hHftDr gCwwSM"
       >
         <span
-          class="sc-fKFyDc dToKui sc-iwyYcG bsaCCL"
+          class="sc-fKFyDc jHCVxA sc-iwyYcG bsaCCL"
         >
           <div
             class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr kwbnZN"
@@ -111,7 +111,7 @@ exports[`Storyshots Core/StatsBar Cpu Usage 1`] = `
               class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP"
             >
               <span
-                class="sc-fKFyDc dToKui sc-iwyYcG kOqgin"
+                class="sc-fKFyDc jHCVxA sc-iwyYcG kOqgin"
               >
                 <svg
                   aria-hidden="true"
@@ -130,13 +130,13 @@ exports[`Storyshots Core/StatsBar Cpu Usage 1`] = `
                 </svg>
               </span>
               <span
-                class="sc-fKFyDc dToKui sc-iwyYcG bsaCCL"
+                class="sc-fKFyDc jHCVxA sc-iwyYcG bsaCCL"
               >
                 CPU
               </span>
             </div>
             <span
-              class="sc-fKFyDc dToKui sc-iwyYcG jKWtCF"
+              class="sc-fKFyDc jHCVxA sc-iwyYcG jKWtCF"
               style="line-height: 1;"
             >
               ​
@@ -144,7 +144,7 @@ exports[`Storyshots Core/StatsBar Cpu Usage 1`] = `
           </div>
         </span>
         <span
-          class="sc-fKFyDc dToKui sc-iwyYcG bsaCCL"
+          class="sc-fKFyDc jHCVxA sc-iwyYcG bsaCCL"
         >
           ~23%
         </span>
@@ -280,7 +280,7 @@ exports[`Storyshots Core/StatsBar Memory 1`] = `
         class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze sc-hHftDr gCwwSM"
       >
         <span
-          class="sc-fKFyDc dToKui sc-iwyYcG bsaCCL"
+          class="sc-fKFyDc jHCVxA sc-iwyYcG bsaCCL"
         >
           <div
             class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr kwbnZN"
@@ -289,7 +289,7 @@ exports[`Storyshots Core/StatsBar Memory 1`] = `
               class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP"
             >
               <span
-                class="sc-fKFyDc dToKui sc-iwyYcG kOqgin"
+                class="sc-fKFyDc jHCVxA sc-iwyYcG kOqgin"
               >
                 <svg
                   aria-hidden="true"
@@ -308,13 +308,13 @@ exports[`Storyshots Core/StatsBar Memory 1`] = `
                 </svg>
               </span>
               <span
-                class="sc-fKFyDc dToKui sc-iwyYcG bsaCCL"
+                class="sc-fKFyDc jHCVxA sc-iwyYcG bsaCCL"
               >
                 Memory
               </span>
             </div>
             <span
-              class="sc-fKFyDc dToKui sc-iwyYcG jKWtCF"
+              class="sc-fKFyDc jHCVxA sc-iwyYcG jKWtCF"
               style="line-height: 1;"
             >
               ​
@@ -322,16 +322,16 @@ exports[`Storyshots Core/StatsBar Memory 1`] = `
           </div>
         </span>
         <span
-          class="sc-fKFyDc dToKui sc-iwyYcG bsaCCL"
+          class="sc-fKFyDc jHCVxA sc-iwyYcG bsaCCL"
         >
           <span
-            class="sc-fKFyDc dToKui sc-iwyYcG bsaCCL"
+            class="sc-fKFyDc jHCVxA sc-iwyYcG bsaCCL"
           >
             453 MB
           </span>
           /
           <span
-            class="sc-fKFyDc dToKui sc-iwyYcG idZvUe"
+            class="sc-fKFyDc jHCVxA sc-iwyYcG idZvUe"
           >
             1 GB
           </span>
@@ -380,7 +380,7 @@ exports[`Storyshots Core/StatsBar Storage 1`] = `
         class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze sc-hHftDr gCwwSM"
       >
         <span
-          class="sc-fKFyDc dToKui sc-iwyYcG bsaCCL"
+          class="sc-fKFyDc jHCVxA sc-iwyYcG bsaCCL"
         >
           <div
             class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr kwbnZN"
@@ -389,7 +389,7 @@ exports[`Storyshots Core/StatsBar Storage 1`] = `
               class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP"
             >
               <span
-                class="sc-fKFyDc dToKui sc-iwyYcG kOqgin"
+                class="sc-fKFyDc jHCVxA sc-iwyYcG kOqgin"
               >
                 <svg
                   aria-hidden="true"
@@ -408,13 +408,13 @@ exports[`Storyshots Core/StatsBar Storage 1`] = `
                 </svg>
               </span>
               <span
-                class="sc-fKFyDc dToKui sc-iwyYcG bsaCCL"
+                class="sc-fKFyDc jHCVxA sc-iwyYcG bsaCCL"
               >
                 Storage
               </span>
             </div>
             <span
-              class="sc-fKFyDc dToKui sc-iwyYcG jKWtCF"
+              class="sc-fKFyDc jHCVxA sc-iwyYcG jKWtCF"
               style="line-height: 1;"
             >
               Storage block device
@@ -422,16 +422,16 @@ exports[`Storyshots Core/StatsBar Storage 1`] = `
           </div>
         </span>
         <span
-          class="sc-fKFyDc dToKui sc-iwyYcG bsaCCL"
+          class="sc-fKFyDc jHCVxA sc-iwyYcG bsaCCL"
         >
           <span
-            class="sc-fKFyDc dToKui sc-iwyYcG bsaCCL"
+            class="sc-fKFyDc jHCVxA sc-iwyYcG bsaCCL"
           >
             623 MB
           </span>
           /
           <span
-            class="sc-fKFyDc dToKui sc-iwyYcG idZvUe"
+            class="sc-fKFyDc jHCVxA sc-iwyYcG idZvUe"
           >
             1 GB
           </span>

--- a/src/components/Steps/__snapshots__/Steps.stories.storyshot
+++ b/src/components/Steps/__snapshots__/Steps.stories.storyshot
@@ -37,7 +37,7 @@ exports[`Storyshots Core/Steps Default 1`] = `
               </svg>
             </div>
             <div
-              class="sc-fKFyDc dToKui sc-bBXqnf lijGUI"
+              class="sc-fKFyDc jHCVxA sc-bBXqnf lijGUI"
             >
               These are
             </div>
@@ -95,7 +95,7 @@ exports[`Storyshots Core/Steps Default 1`] = `
               </svg>
             </div>
             <div
-              class="sc-fKFyDc dToKui sc-bBXqnf lijGUI"
+              class="sc-fKFyDc jHCVxA sc-bBXqnf lijGUI"
             >
               all completed
             </div>
@@ -153,7 +153,7 @@ exports[`Storyshots Core/Steps Default 1`] = `
               </svg>
             </div>
             <div
-              class="sc-fKFyDc dToKui sc-bBXqnf lijGUI"
+              class="sc-fKFyDc jHCVxA sc-bBXqnf lijGUI"
             >
               and not clickable
             </div>
@@ -202,7 +202,7 @@ exports[`Storyshots Core/Steps Ordered 1`] = `
               </svg>
             </div>
             <div
-              class="sc-fKFyDc dToKui sc-bBXqnf lijGUI"
+              class="sc-fKFyDc jHCVxA sc-bBXqnf lijGUI"
             >
               These are
             </div>
@@ -259,13 +259,13 @@ exports[`Storyshots Core/Steps Ordered 1`] = `
                 />
               </svg>
               <div
-                class="sc-fKFyDc dToKui sc-bBXqnf kYwmpI sc-ljRboo gzWrMP fa-layers-text fa-inverse"
+                class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-ljRboo gzWrMP fa-layers-text fa-inverse"
               >
                 2
               </div>
             </div>
             <div
-              class="sc-fKFyDc ipClrT sc-bBXqnf kYwmpI"
+              class="sc-fKFyDc euqOvB sc-bBXqnf kYwmpI"
             >
               all completed
             </div>
@@ -310,13 +310,13 @@ exports[`Storyshots Core/Steps Ordered 1`] = `
                 class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-jmhFOf gffKMv"
               />
               <div
-                class="sc-fKFyDc dToKui sc-bBXqnf kYwmpI sc-ljRboo gzWrMP fa-layers-text"
+                class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-ljRboo gzWrMP fa-layers-text"
               >
                 3
               </div>
             </div>
             <div
-              class="sc-fKFyDc dToKui sc-bBXqnf lijGUI"
+              class="sc-fKFyDc jHCVxA sc-bBXqnf lijGUI"
             >
               and not clickable
             </div>
@@ -340,7 +340,7 @@ exports[`Storyshots Core/Steps With Custom Title 1`] = `
         class="sc-gKsewC cgpPfo sc-iBPRYJ jDRXQs sc-hHftDr kFVJVF"
       >
         <div
-          class="sc-fKFyDc dToKui sc-bBXqnf bhypgL"
+          class="sc-fKFyDc jHCVxA sc-bBXqnf bhypgL"
         >
           <svg
             aria-hidden="true"
@@ -393,7 +393,7 @@ exports[`Storyshots Core/Steps With Custom Title 1`] = `
               </svg>
             </div>
             <div
-              class="sc-fKFyDc dToKui sc-bBXqnf lijGUI"
+              class="sc-fKFyDc jHCVxA sc-bBXqnf lijGUI"
             >
               These are
             </div>
@@ -451,7 +451,7 @@ exports[`Storyshots Core/Steps With Custom Title 1`] = `
               </svg>
             </div>
             <div
-              class="sc-fKFyDc dToKui sc-bBXqnf lijGUI"
+              class="sc-fKFyDc jHCVxA sc-bBXqnf lijGUI"
             >
               all completed
             </div>
@@ -509,7 +509,7 @@ exports[`Storyshots Core/Steps With Custom Title 1`] = `
               </svg>
             </div>
             <div
-              class="sc-fKFyDc dToKui sc-bBXqnf lijGUI"
+              class="sc-fKFyDc jHCVxA sc-bBXqnf lijGUI"
             >
               and not clickable
             </div>

--- a/src/components/Table/__snapshots__/Table.stories.storyshot
+++ b/src/components/Table/__snapshots__/Table.stories.storyshot
@@ -3402,7 +3402,7 @@ exports[`Storyshots Core/Table With Pager 1`] = `
       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze sc-hHftDr ZlJMD"
     >
       <div
-        class="sc-fKFyDc dToKui sc-bBXqnf zWvFq"
+        class="sc-fKFyDc jHCVxA sc-bBXqnf zWvFq"
       >
         <strong>
           1
@@ -3691,7 +3691,7 @@ exports[`Storyshots Core/Table With Pager 1`] = `
       class="sc-gKsewC cgpPfo sc-iBPRYJ GBkpW sc-hHftDr ZlJMD"
     >
       <div
-        class="sc-fKFyDc dToKui sc-bBXqnf zWvFq"
+        class="sc-fKFyDc jHCVxA sc-bBXqnf zWvFq"
       >
         <strong>
           1

--- a/src/components/Tabs/__snapshots__/Tabs.stories.storyshot
+++ b/src/components/Tabs/__snapshots__/Tabs.stories.storyshot
@@ -121,7 +121,7 @@ exports[`Storyshots Core/Tabs Compact 1`] = `
         role="tabpanel"
       >
         <div
-          class="sc-fKFyDc dToKui sc-bBXqnf iOjUUG"
+          class="sc-fKFyDc jHCVxA sc-bBXqnf iOjUUG"
         >
           Here is tab #1
         </div>
@@ -201,7 +201,7 @@ exports[`Storyshots Core/Tabs Default 1`] = `
         role="tabpanel"
       >
         <div
-          class="sc-fKFyDc dToKui sc-bBXqnf iOjUUG"
+          class="sc-fKFyDc jHCVxA sc-bBXqnf iOjUUG"
         >
           Here is tab #1
         </div>
@@ -281,7 +281,7 @@ exports[`Storyshots Core/Tabs With Long Titles 1`] = `
         role="tabpanel"
       >
         <div
-          class="sc-fKFyDc dToKui sc-bBXqnf iOjUUG"
+          class="sc-fKFyDc jHCVxA sc-bBXqnf iOjUUG"
         >
           Here is tab #1
         </div>

--- a/src/components/Tag/__snapshots__/Tag.stories.storyshot
+++ b/src/components/Tag/__snapshots__/Tag.stories.storyshot
@@ -16,12 +16,12 @@ exports[`Storyshots Core/Tag Clickable 1`] = `
           class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-clsHhM cLDXoV bjaVYF"
         >
           <div
-            class="sc-fKFyDc kIYkoy sc-bBXqnf iHGIIw"
+            class="sc-fKFyDc dTkenA sc-bBXqnf iHGIIw"
           >
             Tag: 
           </div>
           <div
-            class="sc-fKFyDc ipClrT sc-bBXqnf iHGIIw"
+            class="sc-fKFyDc euqOvB sc-bBXqnf iHGIIw"
           >
             Value
           </div>
@@ -44,12 +44,12 @@ exports[`Storyshots Core/Tag Closable 1`] = `
         class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-clsHhM cLDXoV bjaVYF"
       >
         <div
-          class="sc-fKFyDc kIYkoy sc-bBXqnf iHGIIw"
+          class="sc-fKFyDc dTkenA sc-bBXqnf iHGIIw"
         >
           Tag: 
         </div>
         <div
-          class="sc-fKFyDc ipClrT sc-bBXqnf iHGIIw"
+          class="sc-fKFyDc euqOvB sc-bBXqnf iHGIIw"
         >
           Value
         </div>
@@ -91,12 +91,12 @@ exports[`Storyshots Core/Tag Default 1`] = `
         class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-clsHhM cLDXoV bjaVYF"
       >
         <div
-          class="sc-fKFyDc kIYkoy sc-bBXqnf iHGIIw"
+          class="sc-fKFyDc dTkenA sc-bBXqnf iHGIIw"
         >
           Tag: 
         </div>
         <div
-          class="sc-fKFyDc ipClrT sc-bBXqnf iHGIIw"
+          class="sc-fKFyDc euqOvB sc-bBXqnf iHGIIw"
         >
           Value
         </div>
@@ -118,7 +118,7 @@ exports[`Storyshots Core/Tag Empty 1`] = `
         class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-clsHhM cLDXoV bjaVYF"
       >
         <div
-          class="sc-fKFyDc eWuelo sc-bBXqnf iHGIIw"
+          class="sc-fKFyDc kZwXGu sc-bBXqnf iHGIIw"
         >
           no value
         </div>
@@ -140,27 +140,27 @@ exports[`Storyshots Core/Tag Multiple Values 1`] = `
         class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-clsHhM cLDXoV bjaVYF"
       >
         <div
-          class="sc-fKFyDc kIYkoy sc-bBXqnf iHGIIw"
+          class="sc-fKFyDc dTkenA sc-bBXqnf iHGIIw"
         >
           Tag1 contains 
         </div>
         <div
-          class="sc-fKFyDc ipClrT sc-bBXqnf iHGIIw"
+          class="sc-fKFyDc euqOvB sc-bBXqnf iHGIIw"
         >
           value1
         </div>
         <div
-          class="sc-fKFyDc fDrOZM sc-bBXqnf iHGIIw"
+          class="sc-fKFyDc krMjta sc-bBXqnf iHGIIw"
         >
             or  
         </div>
         <div
-          class="sc-fKFyDc kIYkoy sc-bBXqnf iHGIIw"
+          class="sc-fKFyDc dTkenA sc-bBXqnf iHGIIw"
         >
           Tag2 contains 
         </div>
         <div
-          class="sc-fKFyDc ipClrT sc-bBXqnf iHGIIw"
+          class="sc-fKFyDc euqOvB sc-bBXqnf iHGIIw"
         >
           value2
         </div>
@@ -182,7 +182,7 @@ exports[`Storyshots Core/Tag Only Name 1`] = `
         class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-clsHhM cLDXoV bjaVYF"
       >
         <div
-          class="sc-fKFyDc ipClrT sc-bBXqnf iHGIIw"
+          class="sc-fKFyDc euqOvB sc-bBXqnf iHGIIw"
         >
           Name
         </div>
@@ -204,7 +204,7 @@ exports[`Storyshots Core/Tag Only Value 1`] = `
         class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-clsHhM cLDXoV bjaVYF"
       >
         <div
-          class="sc-fKFyDc ipClrT sc-bBXqnf iHGIIw"
+          class="sc-fKFyDc euqOvB sc-bBXqnf iHGIIw"
         >
           Value
         </div>

--- a/src/components/TextWithCopy/__snapshots__/TextWithCopy.stories.storyshot
+++ b/src/components/TextWithCopy/__snapshots__/TextWithCopy.stories.storyshot
@@ -6,7 +6,7 @@ exports[`Storyshots Core/TextWithCopy Always Show 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-dWdcrH ScrBw"
   >
     <span
-      class="sc-fKFyDc dToKui sc-iwyYcG bsaCCL sc-irlOZD iUVlhX text-with-copy"
+      class="sc-fKFyDc jHCVxA sc-iwyYcG bsaCCL sc-irlOZD iUVlhX text-with-copy"
     >
       <span
         class="text-with-copy__content"
@@ -47,7 +47,7 @@ exports[`Storyshots Core/TextWithCopy Code 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-dWdcrH ScrBw"
   >
     <span
-      class="sc-fKFyDc dToKui sc-iwyYcG bsaCCL sc-irlOZD gGDzwb text-with-copy"
+      class="sc-fKFyDc jHCVxA sc-iwyYcG bsaCCL sc-irlOZD gGDzwb text-with-copy"
       title="This value has been copied to your clipboard!"
     >
       <code
@@ -89,7 +89,7 @@ exports[`Storyshots Core/TextWithCopy Default 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-dWdcrH ScrBw"
   >
     <span
-      class="sc-fKFyDc dToKui sc-iwyYcG bsaCCL sc-irlOZD gGDzwb text-with-copy"
+      class="sc-fKFyDc jHCVxA sc-iwyYcG bsaCCL sc-irlOZD gGDzwb text-with-copy"
       title="This value has been copied to your clipboard!"
     >
       <span

--- a/src/components/Textarea/__snapshots__/Textarea.stories.storyshot
+++ b/src/components/Textarea/__snapshots__/Textarea.stories.storyshot
@@ -6,7 +6,7 @@ exports[`Storyshots Core/Textarea Auto Rows 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-dWdcrH ScrBw"
   >
     <textarea
-      class="StyledTextArea-sc-17i3mwp-0 cICwEP sc-laRPJI bNMKOQ sc-iNqMTl fXSmiS"
+      class="StyledTextArea-sc-17i3mwp-0 gFImaJ sc-laRPJI bNMKOQ sc-iNqMTl fXSmiS"
     />
   </div>
 </div>
@@ -18,7 +18,7 @@ exports[`Storyshots Core/Textarea Default 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-dWdcrH ScrBw"
   >
     <textarea
-      class="StyledTextArea-sc-17i3mwp-0 cICwEP sc-laRPJI bNMKOQ sc-iNqMTl fXSmiS"
+      class="StyledTextArea-sc-17i3mwp-0 gFImaJ sc-laRPJI bNMKOQ sc-iNqMTl fXSmiS"
     />
   </div>
 </div>
@@ -30,7 +30,7 @@ exports[`Storyshots Core/Textarea Disabled 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-dWdcrH ScrBw"
   >
     <textarea
-      class="StyledTextArea-sc-17i3mwp-0 izGVYB sc-laRPJI cfHALb sc-iNqMTl fXSmiS"
+      class="StyledTextArea-sc-17i3mwp-0 fQPlXT sc-laRPJI cfHALb sc-iNqMTl fXSmiS"
       disabled=""
     />
   </div>
@@ -43,7 +43,7 @@ exports[`Storyshots Core/Textarea Min Max Rows 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-dWdcrH ScrBw"
   >
     <textarea
-      class="StyledTextArea-sc-17i3mwp-0 cICwEP sc-laRPJI bNMKOQ sc-iNqMTl fXSmiS"
+      class="StyledTextArea-sc-17i3mwp-0 gFImaJ sc-laRPJI bNMKOQ sc-iNqMTl fXSmiS"
       rows="4"
     />
   </div>
@@ -56,7 +56,7 @@ exports[`Storyshots Core/Textarea Monospace 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-dWdcrH ScrBw"
   >
     <textarea
-      class="StyledTextArea-sc-17i3mwp-0 cICwEP sc-laRPJI fYiIrp sc-iNqMTl fXSmiS"
+      class="StyledTextArea-sc-17i3mwp-0 gFImaJ sc-laRPJI fYiIrp sc-iNqMTl fXSmiS"
       placeholder="Type something..."
     />
   </div>
@@ -69,7 +69,7 @@ exports[`Storyshots Core/Textarea Read Only 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-dWdcrH ScrBw"
   >
     <textarea
-      class="StyledTextArea-sc-17i3mwp-0 cICwEP sc-laRPJI bNMKOQ sc-iNqMTl fXSmiS"
+      class="StyledTextArea-sc-17i3mwp-0 gFImaJ sc-laRPJI bNMKOQ sc-iNqMTl fXSmiS"
       readonly=""
     />
   </div>
@@ -82,7 +82,7 @@ exports[`Storyshots Core/Textarea With Placeholder 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-dWdcrH ScrBw"
   >
     <textarea
-      class="StyledTextArea-sc-17i3mwp-0 cICwEP sc-laRPJI bNMKOQ sc-iNqMTl fXSmiS"
+      class="StyledTextArea-sc-17i3mwp-0 gFImaJ sc-laRPJI bNMKOQ sc-iNqMTl fXSmiS"
       placeholder="Type something..."
     />
   </div>

--- a/src/components/Txt/__snapshots__/Txt.stories.storyshot
+++ b/src/components/Txt/__snapshots__/Txt.stories.storyshot
@@ -6,7 +6,7 @@ exports[`Storyshots Core/Txt Default 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-dWdcrH ScrBw"
   >
     <div
-      class="sc-fKFyDc dToKui sc-bBXqnf kYwmpI"
+      class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI"
     >
       Standard
     </div>
@@ -20,7 +20,7 @@ exports[`Storyshots Core/Txt In Color 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-dWdcrH ScrBw"
   >
     <div
-      class="sc-fKFyDc dToKui sc-bBXqnf kRESjy"
+      class="sc-fKFyDc jHCVxA sc-bBXqnf kRESjy"
     >
       Colored text
     </div>
@@ -34,7 +34,7 @@ exports[`Storyshots Core/Txt Span Component 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-dWdcrH ScrBw"
   >
     <span
-      class="sc-fKFyDc kIYkoy sc-iwyYcG bsaCCL"
+      class="sc-fKFyDc dTkenA sc-iwyYcG bsaCCL"
     >
       Space   is   preserved
     </span>
@@ -48,7 +48,7 @@ exports[`Storyshots Core/Txt Styled 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-dWdcrH ScrBw"
   >
     <div
-      class="sc-fKFyDc iGtGWQ sc-bBXqnf kYwmpI"
+      class="sc-fKFyDc gWdjUC sc-bBXqnf kYwmpI"
     >
       Styled text
     </div>

--- a/src/components/Txt/index.tsx
+++ b/src/components/Txt/index.tsx
@@ -34,6 +34,14 @@ export const bold = (props: ThemedTxtProps) =>
 		  `
 		: null;
 
+export const truncate = (props: ThemedTxtProps) =>
+	props.truncate &&
+	css`
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	`;
+
 export const align = style({
 	key: 'text-align',
 	prop: 'align',
@@ -48,6 +56,8 @@ const BaseTxt = styled.div<TxtProps>`
 	${caps}
 	${bold}
 	${italic}
+
+	${truncate}
 `;
 
 const Factory = (tag?: string) => {
@@ -95,6 +105,8 @@ export interface InternalTxtProps extends React.HTMLAttributes<HTMLElement> {
 	whitespace?: Whitespace;
 	/** Align text inside the component, one of 'left', 'right', 'center', 'justify', 'justify-all', 'start', 'end', 'match-parent', 'inherit', 'initial', 'unset' */
 	align?: Align;
+	/** If true, replace the text not contained in the container with three dots */
+	truncate?: boolean;
 }
 
 export interface ThemedTxtProps extends InternalTxtProps {

--- a/src/extra/Markdown/__snapshots__/Markdown.stories.storyshot
+++ b/src/extra/Markdown/__snapshots__/Markdown.stories.storyshot
@@ -70,7 +70,7 @@ exports[`Storyshots Extra/Markdown Customized 1`] = `
                     class="sc-gKsewC cgpPfo sc-iBPRYJ kKemJS"
                   >
                     <div
-                      class="sc-fKFyDc dToKui sc-bBXqnf kYwmpI sc-bXDlPE cyautT"
+                      class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-bXDlPE cyautT"
                     >
                       <div>
                         <h1
@@ -82,7 +82,7 @@ exports[`Storyshots Extra/Markdown Customized 1`] = `
                           src="https://via.placeholder.com/150"
                         />
                         <p
-                          class="sc-fKFyDc dToKui sc-cxFLnm kkkmRH"
+                          class="sc-fKFyDc jHCVxA sc-cxFLnm kkkmRH"
                         >
                           A paragraph
                         </p>
@@ -107,12 +107,12 @@ exports[`Storyshots Extra/Markdown Customized 1`] = `
                     class="sc-gKsewC cgpPfo sc-iBPRYJ kKemJS"
                   >
                     <div
-                      class="sc-fKFyDc dToKui sc-bBXqnf kYwmpI sc-bXDlPE cyautT"
+                      class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-bXDlPE cyautT"
                     >
                       <div>
                         A title
                         <p
-                          class="sc-fKFyDc dToKui sc-cxFLnm kkkmRH"
+                          class="sc-fKFyDc jHCVxA sc-cxFLnm kkkmRH"
                         >
                           A paragraph
                         </p>
@@ -161,7 +161,7 @@ exports[`Storyshots Extra/Markdown Customized 1`] = `
                     class="sc-gKsewC cgpPfo sc-iBPRYJ kKemJS"
                   >
                     <div
-                      class="sc-fKFyDc dToKui sc-bBXqnf kYwmpI sc-bXDlPE cyautT"
+                      class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-bXDlPE cyautT"
                     >
                       <div>
                         <h1
@@ -173,7 +173,7 @@ exports[`Storyshots Extra/Markdown Customized 1`] = `
                           src="https://via.placeholder.com/150"
                         />
                         <p
-                          class="sc-fKFyDc dToKui sc-cxFLnm kkkmRH"
+                          class="sc-fKFyDc jHCVxA sc-cxFLnm kkkmRH"
                         >
                           A paragraph
                         </p>
@@ -198,7 +198,7 @@ exports[`Storyshots Extra/Markdown Customized 1`] = `
                     class="sc-gKsewC cgpPfo sc-iBPRYJ kKemJS"
                   >
                     <div
-                      class="sc-fKFyDc dToKui sc-bBXqnf kYwmpI sc-bXDlPE cyautT"
+                      class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-bXDlPE cyautT"
                     >
                       <div>
                         A title
@@ -246,7 +246,7 @@ exports[`Storyshots Extra/Markdown Customized 1`] = `
                     class="sc-gKsewC cgpPfo sc-iBPRYJ kKemJS"
                   >
                     <div
-                      class="sc-fKFyDc dToKui sc-bBXqnf kYwmpI sc-bXDlPE cyautT"
+                      class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-bXDlPE cyautT"
                     >
                       <div>
                         <h1
@@ -258,7 +258,7 @@ exports[`Storyshots Extra/Markdown Customized 1`] = `
                           src="https://via.placeholder.com/150"
                         />
                         <p
-                          class="sc-fKFyDc dToKui sc-cxFLnm kkkmRH"
+                          class="sc-fKFyDc jHCVxA sc-cxFLnm kkkmRH"
                         >
                           A paragraph
                         </p>
@@ -283,7 +283,7 @@ exports[`Storyshots Extra/Markdown Customized 1`] = `
                     class="sc-gKsewC cgpPfo sc-iBPRYJ kKemJS"
                   >
                     <div
-                      class="sc-fKFyDc dToKui sc-bBXqnf kYwmpI sc-bXDlPE cyautT"
+                      class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-bXDlPE cyautT"
                     >
                       <div>
                         <h1
@@ -312,7 +312,7 @@ exports[`Storyshots Extra/Markdown Default 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-dWdcrH ScrBw"
   >
     <div
-      class="sc-fKFyDc dToKui sc-bBXqnf kYwmpI sc-bXDlPE cyautT"
+      class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-bXDlPE cyautT"
     >
       <div>
         <h1
@@ -323,7 +323,7 @@ exports[`Storyshots Extra/Markdown Default 1`] = `
         
 
         <p
-          class="sc-fKFyDc dToKui sc-cxFLnm kkkmRH"
+          class="sc-fKFyDc jHCVxA sc-cxFLnm kkkmRH"
         >
           A simple component for rendering 
           <em>
@@ -381,7 +381,7 @@ exports[`Storyshots Extra/Markdown Default 1`] = `
         
 
         <p
-          class="sc-fKFyDc dToKui sc-cxFLnm kkkmRH"
+          class="sc-fKFyDc jHCVxA sc-cxFLnm kkkmRH"
         >
           <em>
             This text will be italic
@@ -396,7 +396,7 @@ exports[`Storyshots Extra/Markdown Default 1`] = `
         
 
         <p
-          class="sc-fKFyDc dToKui sc-cxFLnm kkkmRH"
+          class="sc-fKFyDc jHCVxA sc-cxFLnm kkkmRH"
         >
           <strong>
             This text will be bold
@@ -411,7 +411,7 @@ exports[`Storyshots Extra/Markdown Default 1`] = `
         
 
         <p
-          class="sc-fKFyDc dToKui sc-cxFLnm kkkmRH"
+          class="sc-fKFyDc jHCVxA sc-cxFLnm kkkmRH"
         >
           <em>
             You 
@@ -523,7 +523,7 @@ exports[`Storyshots Extra/Markdown Default 1`] = `
         
 
         <p
-          class="sc-fKFyDc dToKui sc-cxFLnm kkkmRH"
+          class="sc-fKFyDc jHCVxA sc-cxFLnm kkkmRH"
         >
           <img
             alt="Example Image"
@@ -540,7 +540,7 @@ exports[`Storyshots Extra/Markdown Default 1`] = `
         
 
         <p
-          class="sc-fKFyDc dToKui sc-cxFLnm kkkmRH"
+          class="sc-fKFyDc jHCVxA sc-cxFLnm kkkmRH"
         >
           <a
             class="sc-GTWni kMBmCU sc-gsxnyZ inhWwE"
@@ -554,7 +554,7 @@ exports[`Storyshots Extra/Markdown Default 1`] = `
         
 
         <p
-          class="sc-fKFyDc dToKui sc-cxFLnm kkkmRH"
+          class="sc-fKFyDc jHCVxA sc-cxFLnm kkkmRH"
         >
           <a
             class="sc-GTWni kMBmCU sc-gsxnyZ inhWwE"
@@ -574,7 +574,7 @@ exports[`Storyshots Extra/Markdown Default 1`] = `
         
 
         <p
-          class="sc-fKFyDc dToKui sc-cxFLnm kkkmRH"
+          class="sc-fKFyDc jHCVxA sc-cxFLnm kkkmRH"
         >
           As Ash Ketchum said:
         </p>
@@ -584,7 +584,7 @@ exports[`Storyshots Extra/Markdown Default 1`] = `
           
 
           <p
-            class="sc-fKFyDc dToKui sc-cxFLnm kkkmRH"
+            class="sc-fKFyDc jHCVxA sc-cxFLnm kkkmRH"
           >
             Do you always need a reason to help somebody?
           </p>
@@ -601,7 +601,7 @@ exports[`Storyshots Extra/Markdown Default 1`] = `
         
 
         <p
-          class="sc-fKFyDc dToKui sc-cxFLnm kkkmRH"
+          class="sc-fKFyDc jHCVxA sc-cxFLnm kkkmRH"
         >
           I think you should use an
           <br />
@@ -825,7 +825,7 @@ const foo = () =&gt; {
         
 
         <p
-          class="sc-fKFyDc dToKui sc-cxFLnm kkkmRH"
+          class="sc-fKFyDc jHCVxA sc-cxFLnm kkkmRH"
         >
           <del>
             Crossed out
@@ -834,7 +834,7 @@ const foo = () =&gt; {
         
 
         <p
-          class="sc-fKFyDc dToKui sc-cxFLnm kkkmRH"
+          class="sc-fKFyDc jHCVxA sc-cxFLnm kkkmRH"
         >
           Any word wrapped with two tildes (like 
           <code>
@@ -852,7 +852,7 @@ const foo = () =&gt; {
         
 
         <p
-          class="sc-fKFyDc dToKui sc-cxFLnm kkkmRH"
+          class="sc-fKFyDc jHCVxA sc-cxFLnm kkkmRH"
         >
           <strong>
             An image:
@@ -898,7 +898,7 @@ const foo = () =&gt; {
         
 
         <p
-          class="sc-fKFyDc dToKui sc-cxFLnm kkkmRH"
+          class="sc-fKFyDc jHCVxA sc-cxFLnm kkkmRH"
         >
           <kbd>
             cmd
@@ -928,11 +928,11 @@ exports[`Storyshots Extra/Markdown With Decorators 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-dWdcrH ScrBw"
   >
     <div
-      class="sc-fKFyDc dToKui sc-bBXqnf kYwmpI sc-bXDlPE cyautT"
+      class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-bXDlPE cyautT"
     >
       <div>
         <p
-          class="sc-fKFyDc dToKui sc-cxFLnm kkkmRH"
+          class="sc-fKFyDc jHCVxA sc-cxFLnm kkkmRH"
         >
           <span>
             
@@ -973,7 +973,7 @@ exports[`Storyshots Extra/Markdown With Decorators 1`] = `
         
 
         <p
-          class="sc-fKFyDc dToKui sc-cxFLnm kkkmRH"
+          class="sc-fKFyDc jHCVxA sc-cxFLnm kkkmRH"
         >
           <span>
             


### PR DESCRIPTION
Add truncate property to Txt component to truncate the text when bigger
than the container

Change-type: minor
Signed-off-by: Andrea Rosci <andrear@balena.io>


---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
