### PR TITLE
Card: add actions, add divider prop and restyle

### DIFF
--- a/src/common-types.ts
+++ b/src/common-types.ts
@@ -133,3 +133,17 @@ export interface TooltipProps {
 export interface Tooltip {
 	tooltip?: string | TooltipProps;
 }
+
+export const orderedActionTypes: string[] = [
+	'none',
+	'primary',
+	'warning',
+	'danger',
+];
+export interface ActionButtonDefinition {
+	title: string;
+	onTriggerAction: (...args: any) => void;
+	type?: typeof orderedActionTypes[number];
+	disabled?: string | boolean;
+	hidden?: boolean;
+}

--- a/src/components/Accordion/__snapshots__/Accordion.stories.storyshot
+++ b/src/components/Accordion/__snapshots__/Accordion.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/Accordion Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 dYebPD"

--- a/src/components/Alert/__snapshots__/Alert.stories.storyshot
+++ b/src/components/Alert/__snapshots__/Alert.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/Alert Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="sc-gKsewC cgpPfo sc-iBPRYJ ipiHMM sc-hHftDr sc-dmlrTW cLDXoV cbtefT sc-lmoMRL cGXAYQ"
@@ -49,7 +49,7 @@ exports[`Storyshots Core/Alert Default 1`] = `
 exports[`Storyshots Core/Alert Emphasized 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="sc-gKsewC cgpPfo sc-iBPRYJ dQsSLq sc-hHftDr sc-dmlrTW cLDXoV hjYAKL sc-lmoMRL cGXAYQ"
@@ -95,7 +95,7 @@ exports[`Storyshots Core/Alert Emphasized 1`] = `
 exports[`Storyshots Core/Alert Plaintext 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV sc-lmoMRL cGXAYQ"
@@ -132,7 +132,7 @@ exports[`Storyshots Core/Alert Plaintext 1`] = `
 exports[`Storyshots Core/Alert With Link 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="sc-gKsewC cgpPfo sc-iBPRYJ ipiHMM sc-hHftDr sc-dmlrTW cLDXoV cbtefT sc-lmoMRL cGXAYQ"
@@ -169,7 +169,7 @@ exports[`Storyshots Core/Alert With Link 1`] = `
         >
           With a 
           <a
-            class="sc-eGCarw kBARfK sc-ctaXAZ bvFpzE"
+            class="sc-bXDlPE lhITcI sc-eGCarw CequI"
             color="primary.main"
             href="test"
           >
@@ -185,7 +185,7 @@ exports[`Storyshots Core/Alert With Link 1`] = `
 exports[`Storyshots Core/Alert Without Dismiss 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="sc-gKsewC cgpPfo sc-iBPRYJ ipiHMM sc-hHftDr sc-dmlrTW cLDXoV cbtefT sc-lmoMRL cGXAYQ"
@@ -231,7 +231,7 @@ exports[`Storyshots Core/Alert Without Dismiss 1`] = `
 exports[`Storyshots Core/Alert Without Prefix 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="sc-gKsewC cgpPfo sc-iBPRYJ ipiHMM sc-hHftDr sc-dmlrTW cLDXoV cbtefT sc-lmoMRL cGXAYQ"

--- a/src/components/Avatar/__snapshots__/Avatar.stories.storyshot
+++ b/src/components/Avatar/__snapshots__/Avatar.stories.storyshot
@@ -3,11 +3,11 @@
 exports[`Storyshots Core/Avatar Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     
     <div
-      class="StyledBox-sc-13pk1d4-0 fXtYff StyledAvatar-sc-1suyamb-1 sc-jLiVlK jjSmb"
+      class="StyledBox-sc-13pk1d4-0 fXtYff StyledAvatar-sc-1suyamb-1 sc-iWFSnp dyTeJE"
     >
       <svg
         aria-hidden="true"
@@ -33,10 +33,10 @@ exports[`Storyshots Core/Avatar Default 1`] = `
 exports[`Storyshots Core/Avatar Emphasized 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 dKvtcX StyledAvatar-sc-1suyamb-1 sc-jLiVlK jjSmb"
+      class="StyledBox-sc-13pk1d4-0 dKvtcX StyledAvatar-sc-1suyamb-1 sc-iWFSnp dyTeJE"
     >
       <div
         class="sc-fKFyDc jHCVxA sc-bBXqnf dtyrhz"
@@ -51,10 +51,10 @@ exports[`Storyshots Core/Avatar Emphasized 1`] = `
 exports[`Storyshots Core/Avatar With First Name 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 fXtYff StyledAvatar-sc-1suyamb-1 sc-jLiVlK jjSmb"
+      class="StyledBox-sc-13pk1d4-0 fXtYff StyledAvatar-sc-1suyamb-1 sc-iWFSnp dyTeJE"
     >
       <div
         class="sc-fKFyDc jHCVxA sc-bBXqnf dtyrhz"
@@ -69,10 +69,10 @@ exports[`Storyshots Core/Avatar With First Name 1`] = `
 exports[`Storyshots Core/Avatar With Full Name 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 fXtYff StyledAvatar-sc-1suyamb-1 sc-jLiVlK jjSmb"
+      class="StyledBox-sc-13pk1d4-0 fXtYff StyledAvatar-sc-1suyamb-1 sc-iWFSnp dyTeJE"
     >
       <div
         class="sc-fKFyDc jHCVxA sc-bBXqnf dtyrhz"
@@ -87,10 +87,10 @@ exports[`Storyshots Core/Avatar With Full Name 1`] = `
 exports[`Storyshots Core/Avatar With Image 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 fiIZgk StyledAvatar-sc-1suyamb-1 sc-jLiVlK jjSmb"
+      class="StyledBox-sc-13pk1d4-0 fiIZgk StyledAvatar-sc-1suyamb-1 sc-iWFSnp dyTeJE"
     />
     
   </div>
@@ -100,10 +100,10 @@ exports[`Storyshots Core/Avatar With Image 1`] = `
 exports[`Storyshots Core/Avatar With Last Name 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 fXtYff StyledAvatar-sc-1suyamb-1 sc-jLiVlK jjSmb"
+      class="StyledBox-sc-13pk1d4-0 fXtYff StyledAvatar-sc-1suyamb-1 sc-iWFSnp dyTeJE"
     >
       <div
         class="sc-fKFyDc jHCVxA sc-bBXqnf dtyrhz"

--- a/src/components/Badge/__snapshots__/Badge.stories.storyshot
+++ b/src/components/Badge/__snapshots__/Badge.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/Badge Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <span
       class="sc-fKFyDc jHCVxA sc-iwyYcG cxxFta sc-iJuUWI bYpSjD sc-giIncl dUYCyj"

--- a/src/components/Banner/__snapshots__/Banner.stories.storyshot
+++ b/src/components/Banner/__snapshots__/Banner.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/Banner Primary 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-ezrdKe cMsQud kYVOiM sc-bYEvPH izoiUm"

--- a/src/components/Box/__snapshots__/Box.stories.storyshot
+++ b/src/components/Box/__snapshots__/Box.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/Box Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP"

--- a/src/components/Breadcrumbs/__snapshots__/Breadcrumbs.stories.storyshot
+++ b/src/components/Breadcrumbs/__snapshots__/Breadcrumbs.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/Breadcrumbs Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="sc-gKsewC cgpPfo sc-iBPRYJ kCgyvI sc-hHftDr fAzoTG"
@@ -18,13 +18,13 @@ exports[`Storyshots Core/Breadcrumbs Default 1`] = `
             class="sc-gKsewC cgpPfo sc-iBPRYJ kCgyvI sc-hHftDr cuSvIJ"
           >
             <div
-              class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-bUrJUP cLDXoV hTVEJC"
+              class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-jLiVlK cLDXoV cBca-Di"
             />
             <div
               class="sc-gKsewC cgpPfo sc-iBPRYJ kMoFeH sc-hHftDr cLDXoV"
             >
               <a
-                class="sc-eGCarw kBARfK sc-ctaXAZ kwYpsz"
+                class="sc-bXDlPE lhITcI sc-eGCarw eyqESr"
                 color="primary.main"
                 style="display: inherit;"
               >
@@ -59,13 +59,13 @@ exports[`Storyshots Core/Breadcrumbs Default 1`] = `
             class="sc-gKsewC cgpPfo sc-iBPRYJ kCgyvI sc-hHftDr cuSvIJ"
           >
             <div
-              class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-bUrJUP cLDXoV hTVEJC"
+              class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-jLiVlK cLDXoV cBca-Di"
             />
             <div
               class="sc-gKsewC cgpPfo sc-iBPRYJ kMoFeH sc-hHftDr cLDXoV"
             >
               <a
-                class="sc-eGCarw kBARfK sc-ctaXAZ kwYpsz"
+                class="sc-bXDlPE lhITcI sc-eGCarw eyqESr"
                 color="primary.main"
                 style="display: inherit;"
               >
@@ -100,13 +100,13 @@ exports[`Storyshots Core/Breadcrumbs Default 1`] = `
             class="sc-gKsewC cgpPfo sc-iBPRYJ kCgyvI sc-hHftDr cuSvIJ"
           >
             <div
-              class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-bUrJUP cLDXoV hfZsPK"
+              class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-jLiVlK cLDXoV isIksK"
             />
             <div
               class="sc-gKsewC cgpPfo sc-iBPRYJ kMoFeH sc-hHftDr cLDXoV"
             >
               <a
-                class="sc-eGCarw kBARfK sc-ctaXAZ kwYpsz"
+                class="sc-bXDlPE lhITcI sc-eGCarw eyqESr"
                 color="primary.main"
                 style="display: inherit;"
               >
@@ -151,7 +151,7 @@ exports[`Storyshots Core/Breadcrumbs Default 1`] = `
 exports[`Storyshots Core/Breadcrumbs Wrapped 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="sc-gKsewC cgpPfo sc-iBPRYJ iYqXnW sc-hHftDr cLDXoV"
@@ -169,13 +169,13 @@ exports[`Storyshots Core/Breadcrumbs Wrapped 1`] = `
               class="sc-gKsewC cgpPfo sc-iBPRYJ kCgyvI sc-hHftDr cuSvIJ"
             >
               <div
-                class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-bUrJUP cLDXoV hTVEJC"
+                class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-jLiVlK cLDXoV cBca-Di"
               />
               <div
                 class="sc-gKsewC cgpPfo sc-iBPRYJ kMoFeH sc-hHftDr cLDXoV"
               >
                 <a
-                  class="sc-eGCarw kBARfK sc-ctaXAZ kwYpsz"
+                  class="sc-bXDlPE lhITcI sc-eGCarw eyqESr"
                   color="primary.main"
                   style="display: inherit;"
                 >
@@ -210,13 +210,13 @@ exports[`Storyshots Core/Breadcrumbs Wrapped 1`] = `
               class="sc-gKsewC cgpPfo sc-iBPRYJ kCgyvI sc-hHftDr cuSvIJ"
             >
               <div
-                class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-bUrJUP cLDXoV hTVEJC"
+                class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-jLiVlK cLDXoV cBca-Di"
               />
               <div
                 class="sc-gKsewC cgpPfo sc-iBPRYJ kMoFeH sc-hHftDr cLDXoV"
               >
                 <a
-                  class="sc-eGCarw kBARfK sc-ctaXAZ kwYpsz"
+                  class="sc-bXDlPE lhITcI sc-eGCarw eyqESr"
                   color="primary.main"
                   style="display: inherit;"
                 >
@@ -251,13 +251,13 @@ exports[`Storyshots Core/Breadcrumbs Wrapped 1`] = `
               class="sc-gKsewC cgpPfo sc-iBPRYJ kCgyvI sc-hHftDr cuSvIJ"
             >
               <div
-                class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-bUrJUP cLDXoV hfZsPK"
+                class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-jLiVlK cLDXoV isIksK"
               />
               <div
                 class="sc-gKsewC cgpPfo sc-iBPRYJ kMoFeH sc-hHftDr cLDXoV"
               >
                 <a
-                  class="sc-eGCarw kBARfK sc-ctaXAZ kwYpsz"
+                  class="sc-bXDlPE lhITcI sc-eGCarw eyqESr"
                   color="primary.main"
                   style="display: inherit;"
                 >

--- a/src/components/Button/__snapshots__/Button.stories.storyshot
+++ b/src/components/Button/__snapshots__/Button.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/Button Active 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <button
       class="StyledButton-sc-323bzc-0 djzULC sc-bqyKva sc-kstrdz gjQfnS EqQzD sc-dIUggk YDvpG"
@@ -18,7 +18,7 @@ exports[`Storyshots Core/Button Active 1`] = `
 exports[`Storyshots Core/Button Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <button
       class="StyledButton-sc-323bzc-0 cfpfuP sc-bqyKva sc-hBEYos gjQfnS kmijuE sc-dIUggk YDvpG"
@@ -33,7 +33,7 @@ exports[`Storyshots Core/Button Default 1`] = `
 exports[`Storyshots Core/Button Disabled 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <button
       class="StyledButton-sc-323bzc-0 soChx sc-bqyKva sc-hBEYos gjQfnS kmijuE sc-dIUggk YDvpG"
@@ -49,7 +49,7 @@ exports[`Storyshots Core/Button Disabled 1`] = `
 exports[`Storyshots Core/Button Icon Only 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <button
       class="StyledButton-sc-323bzc-0 LKyTv sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG"
@@ -78,7 +78,7 @@ exports[`Storyshots Core/Button Icon Only 1`] = `
 exports[`Storyshots Core/Button Link 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <a
       class="StyledButton-sc-323bzc-0 cfpfuP sc-bqyKva sc-hBEYos gjQfnS kmijuE sc-dIUggk YDvpG"
@@ -93,7 +93,7 @@ exports[`Storyshots Core/Button Link 1`] = `
 exports[`Storyshots Core/Button Outlined 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <button
       class="StyledButton-sc-323bzc-0 cfpfuP sc-bqyKva sc-hBEYos gjQfnS kmijuE sc-dIUggk YDvpG"
@@ -108,7 +108,7 @@ exports[`Storyshots Core/Button Outlined 1`] = `
 exports[`Storyshots Core/Button Plain 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <button
       class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG"
@@ -123,7 +123,7 @@ exports[`Storyshots Core/Button Plain 1`] = `
 exports[`Storyshots Core/Button Primary 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <button
       class="StyledButton-sc-323bzc-0 fGJlAh sc-bqyKva sc-kstrdz gjQfnS FUwNf sc-dIUggk YDvpG"
@@ -138,7 +138,7 @@ exports[`Storyshots Core/Button Primary 1`] = `
 exports[`Storyshots Core/Button Underlined 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <button
       class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe sc-idOhPF gjQfnS hgJIgM iZyZXn sc-dIUggk YDvpG"
@@ -153,7 +153,7 @@ exports[`Storyshots Core/Button Underlined 1`] = `
 exports[`Storyshots Core/Button With Confirmation 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <button
       class="StyledButton-sc-323bzc-0 bxeVfd sc-bqyKva sc-kstrdz gjQfnS ekgxxv sc-dIUggk YDvpG"
@@ -168,7 +168,7 @@ exports[`Storyshots Core/Button With Confirmation 1`] = `
 exports[`Storyshots Core/Button With Icon 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <button
       class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG"

--- a/src/components/ButtonGroup/__snapshots__/ButtonGroup.stories.storyshot
+++ b/src/components/ButtonGroup/__snapshots__/ButtonGroup.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/ButtonGroup Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-kLgntA cLDXoV bYsbUY"
@@ -34,7 +34,7 @@ exports[`Storyshots Core/ButtonGroup Default 1`] = `
 exports[`Storyshots Core/ButtonGroup With Icon Button 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-kLgntA cLDXoV bYsbUY"

--- a/src/components/Card/Card.stories.tsx
+++ b/src/components/Card/Card.stories.tsx
@@ -1,24 +1,9 @@
 import * as React from 'react';
-import { Link, Flex, Button, TextWithCopy } from '../..';
+import { Flex, Button } from '../..';
 import { Meta } from '@storybook/react';
 import { createTemplate, createStory } from '../../stories/utils';
 import { Card, CardProps } from './';
-
-const rows = [
-	<div>Lorem Ipsum dolor si amet</div>,
-	<Link href="www.balena.io">Link</Link>,
-	<TextWithCopy
-		showCopyButton="always"
-		copy="This value has been copied to your clipboard!"
-	>
-		Row with Copy component
-	</TextWithCopy>,
-	<Flex justifyContent="space-between">
-		<div>Row with</div>
-		<div>Flex</div>
-	</Flex>,
-	<div>Lorem Ipsum dolor si amet</div>,
-];
+import { Heading } from '../Heading';
 
 export default {
 	title: 'Core/Card',
@@ -44,23 +29,65 @@ export const Small = createStory<CardProps>(Template, {
 	children: `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam
   scelerisque euismod risus at gravida. Pellentesque a nunc semper,
   ultrices lacus nec, mattis mauris`,
-	small: [true, false, true, true],
+	emphasized: [true, false, true, true],
 });
 
 export const WithHeader = createStory<CardProps>(Template, {
-	title: 'Card with Button',
-	cta: (
-		<Button plain primary onClick={() => window.alert('Action with Button')}>
-			Update
-		</Button>
+	header: 'Card with title',
+	children: `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam
+  scelerisque euismod risus at gravida. Pellentesque a nunc semper,
+  ultrices lacus nec, mattis mauris`,
+});
+
+export const Emphasized = createStory<CardProps>(Template, {
+	header: 'Card with title',
+	emphasized: true,
+	children: `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam
+  scelerisque euismod risus at gravida. Pellentesque a nunc semper,
+  ultrices lacus nec, mattis mauris`,
+});
+
+export const WithActionHeader = createStory<CardProps>(Template, {
+	header: (
+		<Flex>
+			<Heading.h3>Card With action title</Heading.h3>
+			<Button
+				ml={2}
+				plain
+				primary
+				onClick={() => window.alert('Action with Button')}
+			>
+				Update
+			</Button>
+		</Flex>
 	),
 	children: `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam
   scelerisque euismod risus at gravida. Pellentesque a nunc semper,
   ultrices lacus nec, mattis mauris`,
 });
 
-export const WithRows = createStory<CardProps>(Template, {
-	title: 'Card with Button',
-	cta: <Link href="https://balena.io">Link</Link>,
-	rows,
+export const WithActions = createStory<CardProps>(Template, {
+	minHeight: '300px',
+	width: '600px',
+	header: 'Card with Actions',
+	children: `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam
+  scelerisque euismod risus at gravida. Pellentesque a nunc semper,
+  ultrices lacus nec, mattis mauris `,
+	actions: [
+		{
+			title: 'Normal action',
+			type: 'primary',
+			onTriggerAction: () => window.alert('Normal action'),
+		},
+		{
+			title: 'Warning action',
+			type: 'warning',
+			onTriggerAction: () => window.alert('Warning action'),
+		},
+		{
+			title: 'Danger action',
+			type: 'danger',
+			onTriggerAction: () => window.alert('Danger action'),
+		},
+	],
 });

--- a/src/components/Card/__snapshots__/Card.stories.storyshot
+++ b/src/components/Card/__snapshots__/Card.stories.storyshot
@@ -9,11 +9,52 @@ exports[`Storyshots Core/Card Default 1`] = `
       style="width: 400px; height: 400px;"
     >
       <div
+        class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-dmlrTW cLDXoV gKJALV sc-cTkwdZ kyJVgU sc-jNMdTA eIbWGx"
+      >
+        <div
+          class="sc-gKsewC dWcnb sc-iBPRYJ dWRxlP sc-hHftDr iIBJBt"
+        >
+          <div
+            class="sc-gKsewC dWcnb sc-iBPRYJ iTdmGI sc-hHftDr iIBJBt"
+          >
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam
+  scelerisque euismod risus at gravida. Pellentesque a nunc semper,
+  ultrices lacus nec, mattis mauris
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Core/Card Emphasized 1`] = `
+<div>
+  <div
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+  >
+    <div
+      style="width: 400px; height: 400px;"
+    >
+      <div
         class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-dmlrTW cLDXoV gKJALV sc-cTkwdZ ceEQCj sc-jNMdTA eIbWGx"
       >
         <div
           class="sc-gKsewC dWcnb sc-iBPRYJ dWRxlP sc-hHftDr iIBJBt"
         >
+          <div
+            class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze sc-hHftDr cLDXoV"
+          >
+            <div
+              class="sc-gKsewC cFuckZ sc-iBPRYJ dWRxlP sc-hHftDr kUtBaJ"
+            >
+              <h3
+                class="sc-iktFzd ePMNkU sc-cBNfnY hcRIY"
+              >
+                Card with title
+              </h3>
+            </div>
+          </div>
           <div
             class="sc-gKsewC dWcnb sc-iBPRYJ iTdmGI sc-hHftDr iIBJBt"
           >
@@ -37,11 +78,58 @@ exports[`Storyshots Core/Card Small 1`] = `
       style="width: 400px; height: 400px;"
     >
       <div
+        class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-dmlrTW cLDXoV gKJALV sc-cTkwdZ ceEQCj sc-jNMdTA eIbWGx"
+      >
+        <div
+          class="sc-gKsewC dWcnb sc-iBPRYJ dWRxlP sc-hHftDr iIBJBt"
+        >
+          <div
+            class="sc-gKsewC dWcnb sc-iBPRYJ iTdmGI sc-hHftDr iIBJBt"
+          >
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam
+  scelerisque euismod risus at gravida. Pellentesque a nunc semper,
+  ultrices lacus nec, mattis mauris
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Core/Card With Action Header 1`] = `
+<div>
+  <div
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+  >
+    <div
+      style="width: 400px; height: 400px;"
+    >
+      <div
         class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-dmlrTW cLDXoV gKJALV sc-cTkwdZ kyJVgU sc-jNMdTA eIbWGx"
       >
         <div
           class="sc-gKsewC dWcnb sc-iBPRYJ dWRxlP sc-hHftDr iIBJBt"
         >
+          <div
+            class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze sc-hHftDr cLDXoV"
+          >
+            <div
+              class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV"
+            >
+              <h3
+                class="sc-iktFzd ePMNkU sc-cBNfnY hcRIY"
+              >
+                Card With action title
+              </h3>
+              <button
+                class="StyledButton-sc-323bzc-0 fVClA-D sc-bqyKva sc-bkzZxe gjQfnS dvvpJt sc-dIUggk fiTZeL"
+                type="button"
+              >
+                Update
+              </button>
+            </div>
+          </div>
           <div
             class="sc-gKsewC dWcnb sc-iBPRYJ iTdmGI sc-hHftDr iIBJBt"
           >
@@ -65,29 +153,24 @@ exports[`Storyshots Core/Card With Actions 1`] = `
       style="width: 400px; height: 400px;"
     >
       <div
-        class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-dmlrTW cLDXoV gKJALV sc-cTkwdZ ceEQCj sc-jNMdTA jNzIec"
+        class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-dmlrTW cLDXoV gKJALV sc-cTkwdZ kyJVgU sc-jNMdTA bKdSdq"
       >
         <div
           class="sc-gKsewC dWcnb sc-iBPRYJ dWRxlP sc-hHftDr iIBJBt"
         >
           <div
-            class="sc-gKsewC cFuckZ sc-iBPRYJ dWRxlP sc-hHftDr kUtBaJ"
+            class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze sc-hHftDr cLDXoV"
           >
-            <h3
-              class="sc-gWHgXt eCVPSB sc-bZSQDF QBWsK"
+            <div
+              class="sc-gKsewC cFuckZ sc-iBPRYJ dWRxlP sc-hHftDr kUtBaJ"
             >
-              Card with Actions
-            </h3>
-            <button
-              class="StyledButton-sc-323bzc-0 fVClA-D sc-bqyKva sc-bkzZxe gjQfnS dvvpJt sc-dIUggk YDvpG"
-              type="button"
-            >
-              Update
-            </button>
+              <h3
+                class="sc-iktFzd ePMNkU sc-cBNfnY hcRIY"
+              >
+                Card with Actions
+              </h3>
+            </div>
           </div>
-          <hr
-            class="sc-iktFzd cJCAjm sc-hiSbYr gLVHRe"
-          />
           <div
             class="sc-gKsewC dWcnb sc-iBPRYJ iTdmGI sc-hHftDr iIBJBt"
           >
@@ -96,20 +179,34 @@ exports[`Storyshots Core/Card With Actions 1`] = `
   ultrices lacus nec, mattis mauris 
           </div>
           <div
-            class="sc-gKsewC cFuckZ sc-iBPRYJ dWRxlP sc-hHftDr gjyXnv"
+            class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr iIBJBt"
           >
-            <button
-              class="StyledButton-sc-323bzc-0 fGJlAh sc-bqyKva sc-kstrdz gjQfnS FUwNf sc-dIUggk deFJvX"
-              type="button"
+            <hr
+              class="sc-iUuytg kDfphZ sc-eggNIi kPInZt"
+              type="dashed"
+            />
+            <div
+              class="sc-gKsewC cFuckZ sc-iBPRYJ dWRxlP sc-hHftDr fqfxeY"
             >
-              Normal action
-            </button>
-            <button
-              class="StyledButton-sc-323bzc-0 bxeVfd sc-bqyKva sc-kstrdz gjQfnS ekgxxv sc-dIUggk fiTZeL"
-              type="button"
-            >
-              Danger action
-            </button>
+              <button
+                class="StyledButton-sc-323bzc-0 fGJlAh sc-bqyKva sc-kstrdz gjQfnS FUwNf sc-dIUggk gvyQgi"
+                type="button"
+              >
+                Normal action
+              </button>
+              <button
+                class="StyledButton-sc-323bzc-0 ilOOUu sc-bqyKva sc-kstrdz gjQfnS cevvyb sc-dIUggk gvyQgi"
+                type="button"
+              >
+                Warning action
+              </button>
+              <button
+                class="StyledButton-sc-323bzc-0 bxeVfd sc-bqyKva sc-kstrdz gjQfnS ekgxxv sc-dIUggk gvyQgi"
+                type="button"
+              >
+                Danger action
+              </button>
+            </div>
           </div>
         </div>
       </div>
@@ -127,138 +224,30 @@ exports[`Storyshots Core/Card With Header 1`] = `
       style="width: 400px; height: 400px;"
     >
       <div
-        class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-dmlrTW cLDXoV gKJALV sc-cTkwdZ ceEQCj sc-jNMdTA eIbWGx"
+        class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-dmlrTW cLDXoV gKJALV sc-cTkwdZ kyJVgU sc-jNMdTA eIbWGx"
       >
         <div
           class="sc-gKsewC dWcnb sc-iBPRYJ dWRxlP sc-hHftDr iIBJBt"
         >
           <div
-            class="sc-gKsewC cFuckZ sc-iBPRYJ dWRxlP sc-hHftDr kUtBaJ"
+            class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze sc-hHftDr cLDXoV"
           >
-            <h3
-              class="sc-gWHgXt eCVPSB sc-bZSQDF QBWsK"
+            <div
+              class="sc-gKsewC cFuckZ sc-iBPRYJ dWRxlP sc-hHftDr kUtBaJ"
             >
-              Card with Button
-            </h3>
-            <button
-              class="StyledButton-sc-323bzc-0 fVClA-D sc-bqyKva sc-bkzZxe gjQfnS dvvpJt sc-dIUggk YDvpG"
-              type="button"
-            >
-              Update
-            </button>
+              <h3
+                class="sc-iktFzd ePMNkU sc-cBNfnY hcRIY"
+              >
+                Card with title
+              </h3>
+            </div>
           </div>
-          <hr
-            class="sc-iktFzd cJCAjm sc-hiSbYr gLVHRe"
-          />
           <div
             class="sc-gKsewC dWcnb sc-iBPRYJ iTdmGI sc-hHftDr iIBJBt"
           >
             Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam
   scelerisque euismod risus at gravida. Pellentesque a nunc semper,
   ultrices lacus nec, mattis mauris
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Storyshots Core/Card With Rows 1`] = `
-<div>
-  <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
-  >
-    <div
-      style="width: 400px; height: 400px;"
-    >
-      <div
-        class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-dmlrTW cLDXoV gKJALV sc-cTkwdZ ceEQCj sc-jNMdTA eIbWGx"
-      >
-        <div
-          class="sc-gKsewC dWcnb sc-iBPRYJ dWRxlP sc-hHftDr iIBJBt"
-        >
-          <div
-            class="sc-gKsewC cFuckZ sc-iBPRYJ dWRxlP sc-hHftDr kUtBaJ"
-          >
-            <h3
-              class="sc-gWHgXt eCVPSB sc-bZSQDF QBWsK"
-            >
-              Card with Button
-            </h3>
-            <a
-              class="sc-eGCarw kBARfK sc-ctaXAZ bvFpzE"
-              color="primary.main"
-              href="https://balena.io"
-            >
-              Link
-            </a>
-          </div>
-          <hr
-            class="sc-iktFzd cJCAjm sc-hiSbYr gLVHRe"
-          />
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Storyshots Core/Card Without Divider 1`] = `
-<div>
-  <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
-  >
-    <div
-      style="width: 400px; height: 400px;"
-    >
-      <div
-        class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-dmlrTW cLDXoV gKJALV sc-cTkwdZ ceEQCj sc-jNMdTA jNzIec"
-      >
-        <div
-          class="sc-gKsewC dWcnb sc-iBPRYJ dWRxlP sc-hHftDr iIBJBt"
-        >
-          <div
-            class="sc-gKsewC cFuckZ sc-iBPRYJ dWRxlP sc-hHftDr kUtBaJ"
-          >
-            <h3
-              class="sc-gWHgXt eCVPSB sc-bZSQDF QBWsK"
-            >
-              Card with Actions
-            </h3>
-            <button
-              class="StyledButton-sc-323bzc-0 fVClA-D sc-bqyKva sc-bkzZxe gjQfnS dvvpJt sc-dIUggk YDvpG"
-              type="button"
-            >
-              Update
-            </button>
-          </div>
-          <hr
-            class="sc-iktFzd fsVFdB sc-hiSbYr fOJBek"
-            color="transparent"
-          />
-          <div
-            class="sc-gKsewC dWcnb sc-iBPRYJ iTdmGI sc-hHftDr iIBJBt"
-          >
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam
-  scelerisque euismod risus at gravida. Pellentesque a nunc semper,
-  ultrices lacus nec, mattis mauris 
-          </div>
-          <div
-            class="sc-gKsewC cFuckZ sc-iBPRYJ dWRxlP sc-hHftDr gjyXnv"
-          >
-            <button
-              class="StyledButton-sc-323bzc-0 fGJlAh sc-bqyKva sc-kstrdz gjQfnS FUwNf sc-dIUggk deFJvX"
-              type="button"
-            >
-              Normal action
-            </button>
-            <button
-              class="StyledButton-sc-323bzc-0 bxeVfd sc-bqyKva sc-kstrdz gjQfnS ekgxxv sc-dIUggk fiTZeL"
-              type="button"
-            >
-              Danger action
-            </button>
           </div>
         </div>
       </div>

--- a/src/components/Card/__snapshots__/Card.stories.storyshot
+++ b/src/components/Card/__snapshots__/Card.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/Card Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       style="width: 400px; height: 400px;"
@@ -31,7 +31,7 @@ exports[`Storyshots Core/Card Default 1`] = `
 exports[`Storyshots Core/Card Emphasized 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       style="width: 400px; height: 400px;"
@@ -72,7 +72,7 @@ exports[`Storyshots Core/Card Emphasized 1`] = `
 exports[`Storyshots Core/Card Small 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       style="width: 400px; height: 400px;"
@@ -100,7 +100,7 @@ exports[`Storyshots Core/Card Small 1`] = `
 exports[`Storyshots Core/Card With Action Header 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       style="width: 400px; height: 400px;"
@@ -147,7 +147,7 @@ exports[`Storyshots Core/Card With Action Header 1`] = `
 exports[`Storyshots Core/Card With Actions 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       style="width: 400px; height: 400px;"
@@ -218,7 +218,7 @@ exports[`Storyshots Core/Card With Actions 1`] = `
 exports[`Storyshots Core/Card With Header 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       style="width: 400px; height: 400px;"

--- a/src/components/Card/__snapshots__/Card.stories.storyshot
+++ b/src/components/Card/__snapshots__/Card.stories.storyshot
@@ -12,10 +12,10 @@ exports[`Storyshots Core/Card Default 1`] = `
         class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-dmlrTW cLDXoV gKJALV sc-cTkwdZ ceEQCj sc-jNMdTA eIbWGx"
       >
         <div
-          class="sc-gKsewC cgpPfo sc-iBPRYJ kCgyvI"
+          class="sc-gKsewC dWcnb sc-iBPRYJ dWRxlP sc-hHftDr iIBJBt"
         >
           <div
-            class="sc-gKsewC cgpPfo sc-iBPRYJ kKemJS"
+            class="sc-gKsewC dWcnb sc-iBPRYJ iTdmGI sc-hHftDr iIBJBt"
           >
             Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam
   scelerisque euismod risus at gravida. Pellentesque a nunc semper,
@@ -40,14 +40,76 @@ exports[`Storyshots Core/Card Small 1`] = `
         class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-dmlrTW cLDXoV gKJALV sc-cTkwdZ kyJVgU sc-jNMdTA eIbWGx"
       >
         <div
-          class="sc-gKsewC cgpPfo sc-iBPRYJ kCgyvI"
+          class="sc-gKsewC dWcnb sc-iBPRYJ dWRxlP sc-hHftDr iIBJBt"
         >
           <div
-            class="sc-gKsewC cgpPfo sc-iBPRYJ kKemJS"
+            class="sc-gKsewC dWcnb sc-iBPRYJ iTdmGI sc-hHftDr iIBJBt"
           >
             Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam
   scelerisque euismod risus at gravida. Pellentesque a nunc semper,
   ultrices lacus nec, mattis mauris
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Core/Card With Actions 1`] = `
+<div>
+  <div
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+  >
+    <div
+      style="width: 400px; height: 400px;"
+    >
+      <div
+        class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-dmlrTW cLDXoV gKJALV sc-cTkwdZ ceEQCj sc-jNMdTA jNzIec"
+      >
+        <div
+          class="sc-gKsewC dWcnb sc-iBPRYJ dWRxlP sc-hHftDr iIBJBt"
+        >
+          <div
+            class="sc-gKsewC cFuckZ sc-iBPRYJ dWRxlP sc-hHftDr kUtBaJ"
+          >
+            <h3
+              class="sc-gWHgXt eCVPSB sc-bZSQDF QBWsK"
+            >
+              Card with Actions
+            </h3>
+            <button
+              class="StyledButton-sc-323bzc-0 fVClA-D sc-bqyKva sc-bkzZxe gjQfnS dvvpJt sc-dIUggk YDvpG"
+              type="button"
+            >
+              Update
+            </button>
+          </div>
+          <hr
+            class="sc-iktFzd cJCAjm sc-hiSbYr gLVHRe"
+          />
+          <div
+            class="sc-gKsewC dWcnb sc-iBPRYJ iTdmGI sc-hHftDr iIBJBt"
+          >
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam
+  scelerisque euismod risus at gravida. Pellentesque a nunc semper,
+  ultrices lacus nec, mattis mauris 
+          </div>
+          <div
+            class="sc-gKsewC cFuckZ sc-iBPRYJ dWRxlP sc-hHftDr gjyXnv"
+          >
+            <button
+              class="StyledButton-sc-323bzc-0 fGJlAh sc-bqyKva sc-kstrdz gjQfnS FUwNf sc-dIUggk deFJvX"
+              type="button"
+            >
+              Normal action
+            </button>
+            <button
+              class="StyledButton-sc-323bzc-0 bxeVfd sc-bqyKva sc-kstrdz gjQfnS ekgxxv sc-dIUggk fiTZeL"
+              type="button"
+            >
+              Danger action
+            </button>
           </div>
         </div>
       </div>
@@ -68,16 +130,16 @@ exports[`Storyshots Core/Card With Header 1`] = `
         class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-dmlrTW cLDXoV gKJALV sc-cTkwdZ ceEQCj sc-jNMdTA eIbWGx"
       >
         <div
-          class="sc-gKsewC cgpPfo sc-iBPRYJ kCgyvI"
+          class="sc-gKsewC dWcnb sc-iBPRYJ dWRxlP sc-hHftDr iIBJBt"
         >
           <div
-            class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr kUtBaJ"
+            class="sc-gKsewC cFuckZ sc-iBPRYJ dWRxlP sc-hHftDr kUtBaJ"
           >
-            <h5
-              class="sc-gWHgXt vKAIQ sc-iBaPrD uJYVl"
+            <h3
+              class="sc-gWHgXt eCVPSB sc-bZSQDF QBWsK"
             >
               Card with Button
-            </h5>
+            </h3>
             <button
               class="StyledButton-sc-323bzc-0 fVClA-D sc-bqyKva sc-bkzZxe gjQfnS dvvpJt sc-dIUggk YDvpG"
               type="button"
@@ -89,7 +151,7 @@ exports[`Storyshots Core/Card With Header 1`] = `
             class="sc-iktFzd cJCAjm sc-hiSbYr gLVHRe"
           />
           <div
-            class="sc-gKsewC cgpPfo sc-iBPRYJ kKemJS"
+            class="sc-gKsewC dWcnb sc-iBPRYJ iTdmGI sc-hHftDr iIBJBt"
           >
             Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam
   scelerisque euismod risus at gravida. Pellentesque a nunc semper,
@@ -114,16 +176,16 @@ exports[`Storyshots Core/Card With Rows 1`] = `
         class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-dmlrTW cLDXoV gKJALV sc-cTkwdZ ceEQCj sc-jNMdTA eIbWGx"
       >
         <div
-          class="sc-gKsewC cgpPfo sc-iBPRYJ kCgyvI"
+          class="sc-gKsewC dWcnb sc-iBPRYJ dWRxlP sc-hHftDr iIBJBt"
         >
           <div
-            class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr kUtBaJ"
+            class="sc-gKsewC cFuckZ sc-iBPRYJ dWRxlP sc-hHftDr kUtBaJ"
           >
-            <h5
-              class="sc-gWHgXt vKAIQ sc-iBaPrD uJYVl"
+            <h3
+              class="sc-gWHgXt eCVPSB sc-bZSQDF QBWsK"
             >
               Card with Button
-            </h5>
+            </h3>
             <a
               class="sc-eGCarw kBARfK sc-ctaXAZ bvFpzE"
               color="primary.main"
@@ -135,93 +197,68 @@ exports[`Storyshots Core/Card With Rows 1`] = `
           <hr
             class="sc-iktFzd cJCAjm sc-hiSbYr gLVHRe"
           />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Core/Card Without Divider 1`] = `
+<div>
+  <div
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+  >
+    <div
+      style="width: 400px; height: 400px;"
+    >
+      <div
+        class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-dmlrTW cLDXoV gKJALV sc-cTkwdZ ceEQCj sc-jNMdTA jNzIec"
+      >
+        <div
+          class="sc-gKsewC dWcnb sc-iBPRYJ dWRxlP sc-hHftDr iIBJBt"
+        >
           <div
-            class="sc-gKsewC cgpPfo sc-iBPRYJ iTdmGI"
+            class="sc-gKsewC cFuckZ sc-iBPRYJ dWRxlP sc-hHftDr kUtBaJ"
           >
-            <div>
-              Lorem Ipsum dolor si amet
-            </div>
-          </div>
-          <div
-            class="sc-gKsewC cgpPfo sc-iBPRYJ iTdmGI"
-          >
-            <hr
-              class="sc-iktFzd cJCAjm sc-hiSbYr ioExYC"
-            />
-            <a
-              class="sc-eGCarw kBARfK sc-ctaXAZ bvFpzE"
-              color="primary.main"
-              href="www.balena.io"
+            <h3
+              class="sc-gWHgXt eCVPSB sc-bZSQDF QBWsK"
             >
-              Link
-            </a>
-          </div>
-          <div
-            class="sc-gKsewC cgpPfo sc-iBPRYJ iTdmGI"
-          >
-            <hr
-              class="sc-iktFzd cJCAjm sc-hiSbYr ioExYC"
-            />
-            <span
-              class="sc-fKFyDc jHCVxA sc-iwyYcG bsaCCL sc-kiYtDG htJzkp text-with-copy"
-              title="This value has been copied to your clipboard!"
+              Card with Actions
+            </h3>
+            <button
+              class="StyledButton-sc-323bzc-0 fVClA-D sc-bqyKva sc-bkzZxe gjQfnS dvvpJt sc-dIUggk YDvpG"
+              type="button"
             >
-              <span
-                class="text-with-copy__content"
-              >
-                Row with Copy component
-              </span>
-              <span
-                class="text-with-copy__copy_wrapper"
-              >
-                <div
-                  class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP text-with-copy__copy"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="svg-inline--fa fa-copy fa-w-14 "
-                    data-icon="copy"
-                    data-prefix="far"
-                    focusable="false"
-                    role="img"
-                    viewBox="0 0 448 512"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M433.941 65.941l-51.882-51.882A48 48 0 0 0 348.118 0H176c-26.51 0-48 21.49-48 48v48H48c-26.51 0-48 21.49-48 48v320c0 26.51 21.49 48 48 48h224c26.51 0 48-21.49 48-48v-48h80c26.51 0 48-21.49 48-48V99.882a48 48 0 0 0-14.059-33.941zM266 464H54a6 6 0 0 1-6-6V150a6 6 0 0 1 6-6h74v224c0 26.51 21.49 48 48 48h96v42a6 6 0 0 1-6 6zm128-96H182a6 6 0 0 1-6-6V54a6 6 0 0 1 6-6h106v88c0 13.255 10.745 24 24 24h88v202a6 6 0 0 1-6 6zm6-256h-64V48h9.632c1.591 0 3.117.632 4.243 1.757l48.368 48.368a6 6 0 0 1 1.757 4.243V112z"
-                      fill="currentColor"
-                    />
-                  </svg>
-                </div>
-              </span>
-            </span>
+              Update
+            </button>
+          </div>
+          <hr
+            class="sc-iktFzd fsVFdB sc-hiSbYr fOJBek"
+            color="transparent"
+          />
+          <div
+            class="sc-gKsewC dWcnb sc-iBPRYJ iTdmGI sc-hHftDr iIBJBt"
+          >
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam
+  scelerisque euismod risus at gravida. Pellentesque a nunc semper,
+  ultrices lacus nec, mattis mauris 
           </div>
           <div
-            class="sc-gKsewC cgpPfo sc-iBPRYJ iTdmGI"
+            class="sc-gKsewC cFuckZ sc-iBPRYJ dWRxlP sc-hHftDr gjyXnv"
           >
-            <hr
-              class="sc-iktFzd cJCAjm sc-hiSbYr ioExYC"
-            />
-            <div
-              class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr jkLErl"
+            <button
+              class="StyledButton-sc-323bzc-0 fGJlAh sc-bqyKva sc-kstrdz gjQfnS FUwNf sc-dIUggk deFJvX"
+              type="button"
             >
-              <div>
-                Row with
-              </div>
-              <div>
-                Flex
-              </div>
-            </div>
-          </div>
-          <div
-            class="sc-gKsewC cgpPfo sc-iBPRYJ iTdmGI"
-          >
-            <hr
-              class="sc-iktFzd cJCAjm sc-hiSbYr ioExYC"
-            />
-            <div>
-              Lorem Ipsum dolor si amet
-            </div>
+              Normal action
+            </button>
+            <button
+              class="StyledButton-sc-323bzc-0 bxeVfd sc-bqyKva sc-kstrdz gjQfnS ekgxxv sc-dIUggk fiTZeL"
+              type="button"
+            >
+              Danger action
+            </button>
           </div>
         </div>
       </div>

--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -1,82 +1,85 @@
-import map from 'lodash/map';
 import * as React from 'react';
 import styled from 'styled-components';
-import { RenditionSystemProps } from '../../common-types';
-
+import {
+	ActionButtonDefinition,
+	RenditionSystemProps,
+} from '../../common-types';
 import asRendition from '../../asRendition';
 import { DismissableContainer } from '../../internal/DismissableContainer';
-import { Box } from '../Box';
-import { Divider } from '../Divider';
 import { Flex, FlexProps } from '../Flex';
 import { Heading } from '../Heading';
 import { useBreakpoint } from '../../hooks/useBreakpoint';
+import { Divider } from '../Divider';
+import { ActionButtonGroup } from '../../internal/ActionButtonGroup';
 
 const Wrapper = styled(DismissableContainer)<WrapperProps>`
 	& {
-		padding: ${(props) => (props.small ? '24px' : '32px 44px')};
+		padding: ${(props) => (props.emphasized ? '32px 44px' : '24px')};
 	}
 `;
 
 const BaseCard = ({
-	title,
-	cta,
-	rows,
+	header,
 	children,
-	small,
+	emphasized,
+	actions,
 	...props
 }: InternalCardProps) => {
-	const hasHeader = title || cta;
-	const isSmall = useBreakpoint(small);
+	const isEmphasized = useBreakpoint(emphasized);
 
-	const Header = hasHeader && (
-		<React.Fragment>
-			<Flex justifyContent="space-between" alignItems="center">
-				<Heading.h5 fontSize={4}>{title}</Heading.h5>
-				{cta}
-			</Flex>
-			<Divider my={2} />
-		</React.Fragment>
+	const Header = header && (
+		<Flex mb={2}>
+			{typeof header === 'string' ? (
+				<Flex
+					flex="0 0 auto"
+					justifyContent="space-between"
+					alignItems="center"
+				>
+					<Heading.h3>{header}</Heading.h3>
+				</Flex>
+			) : (
+				header
+			)}
+		</Flex>
 	);
 
-	const Rows =
-		rows &&
-		map(rows, (row, index: number) => (
-			<Box key={index} fontSize={2}>
-				{index > 0 && <Divider />}
-				{row}
-			</Box>
-		));
-
 	const Body = children && (
-		<Box fontSize={2} height="100%">
+		<Flex flex="1" flexDirection="column" fontSize={2}>
 			{children}
-		</Box>
+		</Flex>
+	);
+
+	const Actions = actions && (
+		<Flex flexDirection="column">
+			<Divider mb={2} mt={3} type="dashed" />
+			<Flex flexWrap="wrap" flex="0 0 auto" justifyContent="flex-end">
+				<ActionButtonGroup actions={actions} />
+			</Flex>
+		</Flex>
 	);
 
 	return (
-		<Wrapper small={isSmall} {...props}>
-			<Box width="100%">
+		<Wrapper emphasized={isEmphasized} {...props}>
+			<Flex flexDirection="column" flex="1">
 				{Header}
-				{Rows}
 				{Body}
-			</Box>
+				{Actions}
+			</Flex>
 		</Wrapper>
 	);
 };
 
 interface WrapperProps extends FlexProps {
-	small?: boolean | boolean[];
+	emphasized?: boolean | boolean[];
 }
 
-export interface InternalCardProps extends WrapperProps {
-	/** The title of the card */
-	title?: string;
-	/** React component added to the header */
-	cta?: JSX.Element;
-	/** Subsections separated by a horizontal separator */
-	rows?: JSX.Element[];
+export interface InternalCardProps extends Omit<WrapperProps, 'title'> {
+	/** The header of the card */
+	header?: string | JSX.Element;
 	/** Any content that is internally wrapped in a Box */
 	children?: any;
+	/** Buttons placed on the bottom of the card */
+	actions?: ActionButtonDefinition[];
 }
 
 export type CardProps = InternalCardProps & RenditionSystemProps;

--- a/src/components/Checkbox/__snapshots__/Checkbox.stories.storyshot
+++ b/src/components/Checkbox/__snapshots__/Checkbox.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/Checkbox Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="sc-dOSReg dbySSX sc-bBrOnJ bcspbY"
@@ -31,7 +31,7 @@ exports[`Storyshots Core/Checkbox Default 1`] = `
 exports[`Storyshots Core/Checkbox Disabled 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="sc-dOSReg dbySSX sc-bBrOnJ bcspbY"
@@ -66,7 +66,7 @@ exports[`Storyshots Core/Checkbox Disabled 1`] = `
 exports[`Storyshots Core/Checkbox Reversed Label 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="sc-dOSReg dbySSX sc-bBrOnJ bcspbY"
@@ -97,7 +97,7 @@ exports[`Storyshots Core/Checkbox Reversed Label 1`] = `
 exports[`Storyshots Core/Checkbox Toggle 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="sc-dOSReg dbySSX sc-bBrOnJ bcspbY"
@@ -132,7 +132,7 @@ exports[`Storyshots Core/Checkbox Toggle 1`] = `
 exports[`Storyshots Core/Checkbox With Label 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="sc-dOSReg dbySSX sc-bBrOnJ bcspbY"

--- a/src/components/Container/__snapshots__/Container.stories.storyshot
+++ b/src/components/Container/__snapshots__/Container.stories.storyshot
@@ -9,7 +9,7 @@ exports[`Storyshots Core/Container Centered Content 1`] = `
       class="sc-gKsewC cgpPfo sc-iBPRYJ QCGZt sc-aKZfe leIoYi sc-kmASHI kBhFNE"
     >
       <h3
-        class="sc-gWHgXt eCVPSB sc-cBNfnY hJuLdz"
+        class="sc-iktFzd ePMNkU sc-jJEJSO kYibbK"
       >
         I am in a container
       </h3>
@@ -27,7 +27,7 @@ exports[`Storyshots Core/Container Default 1`] = `
       class="sc-gKsewC cgpPfo sc-iBPRYJ QCGZt sc-aKZfe TjqdR sc-kmASHI kBhFNE"
     >
       <h3
-        class="sc-gWHgXt eCVPSB sc-cBNfnY hJuLdz"
+        class="sc-iktFzd ePMNkU sc-jJEJSO kYibbK"
       >
         I am in a container
       </h3>

--- a/src/components/Container/__snapshots__/Container.stories.storyshot
+++ b/src/components/Container/__snapshots__/Container.stories.storyshot
@@ -3,10 +3,10 @@
 exports[`Storyshots Core/Container Centered Content 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
-      class="sc-gKsewC cgpPfo sc-iBPRYJ QCGZt sc-aKZfe leIoYi sc-kmASHI kBhFNE"
+      class="sc-gKsewC cgpPfo sc-iBPRYJ QCGZt sc-gsBrbv cLTACJ sc-aKZfe dnXERG"
     >
       <h3
         class="sc-iktFzd ePMNkU sc-jJEJSO kYibbK"
@@ -21,10 +21,10 @@ exports[`Storyshots Core/Container Centered Content 1`] = `
 exports[`Storyshots Core/Container Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
-      class="sc-gKsewC cgpPfo sc-iBPRYJ QCGZt sc-aKZfe TjqdR sc-kmASHI kBhFNE"
+      class="sc-gKsewC cgpPfo sc-iBPRYJ QCGZt sc-gsBrbv fHHEeu sc-aKZfe dnXERG"
     >
       <h3
         class="sc-iktFzd ePMNkU sc-jJEJSO kYibbK"

--- a/src/components/Copy/__snapshots__/Copy.stories.storyshot
+++ b/src/components/Copy/__snapshots__/Copy.stories.storyshot
@@ -3,16 +3,16 @@
 exports[`Storyshots Core/Copy Always Show 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-AzgDb jAUQHL hGxA-dz"
     >
       <div
-        class="sc-irlOZD IlvTR"
+        class="sc-iGctRS fBeMOH"
       >
         <div
-          class="sc-eWvPJL fbVfNP"
+          class="sc-irlOZD iSubxv"
         >
           <div
             data-display="table-head"
@@ -101,7 +101,7 @@ exports[`Storyshots Core/Copy Always Show 1`] = `
 exports[`Storyshots Core/Copy Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-AzgDb jAUQHL hGxA-dz"
@@ -138,7 +138,7 @@ exports[`Storyshots Core/Copy Default 1`] = `
 exports[`Storyshots Core/Copy Icon Only 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="sc-gKsewC cgpPfo sc-iBPRYJ frgkGL"
@@ -175,16 +175,16 @@ exports[`Storyshots Core/Copy Icon Only 1`] = `
 exports[`Storyshots Core/Copy With Tag 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-AzgDb jAUQHL hGxA-dz"
     >
       <div
-        class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV sc-GqfZa cHWpcm"
+        class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV sc-fbkhIv gnNozJ"
       >
         <div
-          class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-clsHhM cLDXoV bjaVYF"
+          class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-gGmIRh cLDXoV dgHkOy"
         >
           <div
             class="sc-fKFyDc dTkenA sc-bBXqnf iHGIIw"

--- a/src/components/DataGrid/__snapshots__/DataGrid.stories.storyshot
+++ b/src/components/DataGrid/__snapshots__/DataGrid.stories.storyshot
@@ -3,13 +3,13 @@
 exports[`Storyshots Core/DataGrid Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
-      class="sc-xyEjG eKBMup"
+      class="sc-kYrkKh kHQPPA"
     >
       <div
-        class="sc-dWdcrH ghmQbV"
+        class="sc-xyEjG jMDdrG"
       >
         <div
           class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-dmlrTW cLDXoV gKJALV sc-cTkwdZ kyJVgU sc-jNMdTA eIbWGx"
@@ -30,7 +30,7 @@ exports[`Storyshots Core/DataGrid Default 1`] = `
         </div>
       </div>
       <div
-        class="sc-dWdcrH ghmQbV"
+        class="sc-xyEjG jMDdrG"
       >
         <div
           class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-dmlrTW cLDXoV gKJALV sc-cTkwdZ kyJVgU sc-jNMdTA eIbWGx"
@@ -51,7 +51,7 @@ exports[`Storyshots Core/DataGrid Default 1`] = `
         </div>
       </div>
       <div
-        class="sc-dWdcrH ghmQbV"
+        class="sc-xyEjG jMDdrG"
       >
         <div
           class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-dmlrTW cLDXoV gKJALV sc-cTkwdZ kyJVgU sc-jNMdTA eIbWGx"
@@ -72,7 +72,7 @@ exports[`Storyshots Core/DataGrid Default 1`] = `
         </div>
       </div>
       <div
-        class="sc-dWdcrH ghmQbV"
+        class="sc-xyEjG jMDdrG"
       >
         <div
           class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-dmlrTW cLDXoV gKJALV sc-cTkwdZ kyJVgU sc-jNMdTA eIbWGx"
@@ -93,7 +93,7 @@ exports[`Storyshots Core/DataGrid Default 1`] = `
         </div>
       </div>
       <div
-        class="sc-dWdcrH ghmQbV"
+        class="sc-xyEjG jMDdrG"
       >
         <div
           class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-dmlrTW cLDXoV gKJALV sc-cTkwdZ kyJVgU sc-jNMdTA eIbWGx"
@@ -114,7 +114,7 @@ exports[`Storyshots Core/DataGrid Default 1`] = `
         </div>
       </div>
       <div
-        class="sc-dWdcrH ghmQbV"
+        class="sc-xyEjG jMDdrG"
       >
         <div
           class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-dmlrTW cLDXoV gKJALV sc-cTkwdZ kyJVgU sc-jNMdTA eIbWGx"

--- a/src/components/DataGrid/__snapshots__/DataGrid.stories.storyshot
+++ b/src/components/DataGrid/__snapshots__/DataGrid.stories.storyshot
@@ -12,7 +12,7 @@ exports[`Storyshots Core/DataGrid Default 1`] = `
         class="sc-dWdcrH ghmQbV"
       >
         <div
-          class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-dmlrTW cLDXoV gKJALV sc-cTkwdZ ceEQCj sc-jNMdTA eIbWGx"
+          class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-dmlrTW cLDXoV gKJALV sc-cTkwdZ kyJVgU sc-jNMdTA eIbWGx"
         >
           <div
             class="sc-gKsewC dWcnb sc-iBPRYJ dWRxlP sc-hHftDr iIBJBt"
@@ -33,7 +33,7 @@ exports[`Storyshots Core/DataGrid Default 1`] = `
         class="sc-dWdcrH ghmQbV"
       >
         <div
-          class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-dmlrTW cLDXoV gKJALV sc-cTkwdZ ceEQCj sc-jNMdTA eIbWGx"
+          class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-dmlrTW cLDXoV gKJALV sc-cTkwdZ kyJVgU sc-jNMdTA eIbWGx"
         >
           <div
             class="sc-gKsewC dWcnb sc-iBPRYJ dWRxlP sc-hHftDr iIBJBt"
@@ -54,7 +54,7 @@ exports[`Storyshots Core/DataGrid Default 1`] = `
         class="sc-dWdcrH ghmQbV"
       >
         <div
-          class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-dmlrTW cLDXoV gKJALV sc-cTkwdZ ceEQCj sc-jNMdTA eIbWGx"
+          class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-dmlrTW cLDXoV gKJALV sc-cTkwdZ kyJVgU sc-jNMdTA eIbWGx"
         >
           <div
             class="sc-gKsewC dWcnb sc-iBPRYJ dWRxlP sc-hHftDr iIBJBt"
@@ -75,7 +75,7 @@ exports[`Storyshots Core/DataGrid Default 1`] = `
         class="sc-dWdcrH ghmQbV"
       >
         <div
-          class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-dmlrTW cLDXoV gKJALV sc-cTkwdZ ceEQCj sc-jNMdTA eIbWGx"
+          class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-dmlrTW cLDXoV gKJALV sc-cTkwdZ kyJVgU sc-jNMdTA eIbWGx"
         >
           <div
             class="sc-gKsewC dWcnb sc-iBPRYJ dWRxlP sc-hHftDr iIBJBt"
@@ -96,7 +96,7 @@ exports[`Storyshots Core/DataGrid Default 1`] = `
         class="sc-dWdcrH ghmQbV"
       >
         <div
-          class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-dmlrTW cLDXoV gKJALV sc-cTkwdZ ceEQCj sc-jNMdTA eIbWGx"
+          class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-dmlrTW cLDXoV gKJALV sc-cTkwdZ kyJVgU sc-jNMdTA eIbWGx"
         >
           <div
             class="sc-gKsewC dWcnb sc-iBPRYJ dWRxlP sc-hHftDr iIBJBt"
@@ -117,7 +117,7 @@ exports[`Storyshots Core/DataGrid Default 1`] = `
         class="sc-dWdcrH ghmQbV"
       >
         <div
-          class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-dmlrTW cLDXoV gKJALV sc-cTkwdZ ceEQCj sc-jNMdTA eIbWGx"
+          class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-dmlrTW cLDXoV gKJALV sc-cTkwdZ kyJVgU sc-jNMdTA eIbWGx"
         >
           <div
             class="sc-gKsewC dWcnb sc-iBPRYJ dWRxlP sc-hHftDr iIBJBt"

--- a/src/components/DataGrid/__snapshots__/DataGrid.stories.storyshot
+++ b/src/components/DataGrid/__snapshots__/DataGrid.stories.storyshot
@@ -15,10 +15,10 @@ exports[`Storyshots Core/DataGrid Default 1`] = `
           class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-dmlrTW cLDXoV gKJALV sc-cTkwdZ ceEQCj sc-jNMdTA eIbWGx"
         >
           <div
-            class="sc-gKsewC cgpPfo sc-iBPRYJ kCgyvI"
+            class="sc-gKsewC dWcnb sc-iBPRYJ dWRxlP sc-hHftDr iIBJBt"
           >
             <div
-              class="sc-gKsewC cgpPfo sc-iBPRYJ kKemJS"
+              class="sc-gKsewC dWcnb sc-iBPRYJ iTdmGI sc-hHftDr iIBJBt"
             >
               <div
                 class="sc-fKFyDc fPRqcz sc-bBXqnf cLiasT"
@@ -36,10 +36,10 @@ exports[`Storyshots Core/DataGrid Default 1`] = `
           class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-dmlrTW cLDXoV gKJALV sc-cTkwdZ ceEQCj sc-jNMdTA eIbWGx"
         >
           <div
-            class="sc-gKsewC cgpPfo sc-iBPRYJ kCgyvI"
+            class="sc-gKsewC dWcnb sc-iBPRYJ dWRxlP sc-hHftDr iIBJBt"
           >
             <div
-              class="sc-gKsewC cgpPfo sc-iBPRYJ kKemJS"
+              class="sc-gKsewC dWcnb sc-iBPRYJ iTdmGI sc-hHftDr iIBJBt"
             >
               <div
                 class="sc-fKFyDc fPRqcz sc-bBXqnf cLiasT"
@@ -57,10 +57,10 @@ exports[`Storyshots Core/DataGrid Default 1`] = `
           class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-dmlrTW cLDXoV gKJALV sc-cTkwdZ ceEQCj sc-jNMdTA eIbWGx"
         >
           <div
-            class="sc-gKsewC cgpPfo sc-iBPRYJ kCgyvI"
+            class="sc-gKsewC dWcnb sc-iBPRYJ dWRxlP sc-hHftDr iIBJBt"
           >
             <div
-              class="sc-gKsewC cgpPfo sc-iBPRYJ kKemJS"
+              class="sc-gKsewC dWcnb sc-iBPRYJ iTdmGI sc-hHftDr iIBJBt"
             >
               <div
                 class="sc-fKFyDc fPRqcz sc-bBXqnf cLiasT"
@@ -78,10 +78,10 @@ exports[`Storyshots Core/DataGrid Default 1`] = `
           class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-dmlrTW cLDXoV gKJALV sc-cTkwdZ ceEQCj sc-jNMdTA eIbWGx"
         >
           <div
-            class="sc-gKsewC cgpPfo sc-iBPRYJ kCgyvI"
+            class="sc-gKsewC dWcnb sc-iBPRYJ dWRxlP sc-hHftDr iIBJBt"
           >
             <div
-              class="sc-gKsewC cgpPfo sc-iBPRYJ kKemJS"
+              class="sc-gKsewC dWcnb sc-iBPRYJ iTdmGI sc-hHftDr iIBJBt"
             >
               <div
                 class="sc-fKFyDc fPRqcz sc-bBXqnf cLiasT"
@@ -99,10 +99,10 @@ exports[`Storyshots Core/DataGrid Default 1`] = `
           class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-dmlrTW cLDXoV gKJALV sc-cTkwdZ ceEQCj sc-jNMdTA eIbWGx"
         >
           <div
-            class="sc-gKsewC cgpPfo sc-iBPRYJ kCgyvI"
+            class="sc-gKsewC dWcnb sc-iBPRYJ dWRxlP sc-hHftDr iIBJBt"
           >
             <div
-              class="sc-gKsewC cgpPfo sc-iBPRYJ kKemJS"
+              class="sc-gKsewC dWcnb sc-iBPRYJ iTdmGI sc-hHftDr iIBJBt"
             >
               <div
                 class="sc-fKFyDc fPRqcz sc-bBXqnf cLiasT"
@@ -120,10 +120,10 @@ exports[`Storyshots Core/DataGrid Default 1`] = `
           class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-dmlrTW cLDXoV gKJALV sc-cTkwdZ ceEQCj sc-jNMdTA eIbWGx"
         >
           <div
-            class="sc-gKsewC cgpPfo sc-iBPRYJ kCgyvI"
+            class="sc-gKsewC dWcnb sc-iBPRYJ dWRxlP sc-hHftDr iIBJBt"
           >
             <div
-              class="sc-gKsewC cgpPfo sc-iBPRYJ kKemJS"
+              class="sc-gKsewC dWcnb sc-iBPRYJ iTdmGI sc-hHftDr iIBJBt"
             >
               <div
                 class="sc-fKFyDc fPRqcz sc-bBXqnf cLiasT"

--- a/src/components/Divider/__snapshots__/Divider.stories.storyshot
+++ b/src/components/Divider/__snapshots__/Divider.stories.storyshot
@@ -6,7 +6,7 @@ exports[`Storyshots Core/Divider Dashed 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
   >
     <hr
-      class="sc-iktFzd cUYtuc sc-hiSbYr ioExYC"
+      class="sc-iUuytg kDfphZ sc-eggNIi escNXG"
       type="dashed"
     />
   </div>
@@ -19,7 +19,7 @@ exports[`Storyshots Core/Divider Default 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
   >
     <hr
-      class="sc-iktFzd cJCAjm sc-hiSbYr ioExYC"
+      class="sc-iUuytg fFHqGT sc-eggNIi escNXG"
     />
   </div>
 </div>
@@ -31,7 +31,7 @@ exports[`Storyshots Core/Divider With Custom Color 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
   >
     <hr
-      class="sc-iktFzd cbtjSH sc-hiSbYr bmzuUW"
+      class="sc-iUuytg tCbFq sc-eggNIi blChIG"
       color="#ccc"
     />
   </div>
@@ -44,10 +44,10 @@ exports[`Storyshots Core/Divider With Text Content 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
   >
     <div
-      class="sc-gKsewC cgpPfo sc-iBPRYJ kCgyvI sc-hHftDr bxfdfp sc-hiSbYr ioExYC"
+      class="sc-gKsewC cgpPfo sc-iBPRYJ kCgyvI sc-hHftDr bxfdfp sc-eggNIi escNXG"
     >
       <hr
-        class="sc-iktFzd sc-jJEJSO cUYtuc dceFUj"
+        class="sc-iUuytg sc-iBaPrD kDfphZ SWHog"
         type="dashed"
       />
       <span
@@ -56,7 +56,7 @@ exports[`Storyshots Core/Divider With Text Content 1`] = `
         some text
       </span>
       <hr
-        class="sc-iktFzd sc-jJEJSO cUYtuc dceFUj"
+        class="sc-iUuytg sc-iBaPrD kDfphZ SWHog"
         type="dashed"
       />
     </div>

--- a/src/components/Divider/__snapshots__/Divider.stories.storyshot
+++ b/src/components/Divider/__snapshots__/Divider.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/Divider Dashed 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <hr
       class="sc-iUuytg kDfphZ sc-eggNIi escNXG"
@@ -16,7 +16,7 @@ exports[`Storyshots Core/Divider Dashed 1`] = `
 exports[`Storyshots Core/Divider Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <hr
       class="sc-iUuytg fFHqGT sc-eggNIi escNXG"
@@ -28,7 +28,7 @@ exports[`Storyshots Core/Divider Default 1`] = `
 exports[`Storyshots Core/Divider With Custom Color 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <hr
       class="sc-iUuytg tCbFq sc-eggNIi blChIG"
@@ -41,7 +41,7 @@ exports[`Storyshots Core/Divider With Custom Color 1`] = `
 exports[`Storyshots Core/Divider With Text Content 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="sc-gKsewC cgpPfo sc-iBPRYJ kCgyvI sc-hHftDr bxfdfp sc-eggNIi escNXG"

--- a/src/components/DropDownButton/__snapshots__/DropDownButton.stories.storyshot
+++ b/src/components/DropDownButton/__snapshots__/DropDownButton.stories.storyshot
@@ -3,20 +3,20 @@
 exports[`Storyshots Core/DropDownButton Bordered List 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
-      class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-jONnTn fFdndA sc-bTvRPi habiYC"
+      class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-aemoO gwhdcy sc-eLgOdN cOTCjW"
     >
       <span>
         <button
-          class="StyledButton-sc-323bzc-0 cfpfuP sc-bqyKva sc-hBEYos gjQfnS kmijuE sc-dIUggk YDvpG sc-jHVexB jChkJc"
+          class="StyledButton-sc-323bzc-0 cfpfuP sc-bqyKva sc-hBEYos gjQfnS kmijuE sc-dIUggk YDvpG sc-TmcTc cpZqkq"
           type="button"
         >
           Dropdown
         </button>
         <button
-          class="StyledButton-sc-323bzc-0 gMxQVt sc-bqyKva sc-hBEYos gjQfnS kmijuE sc-dIUggk YDvpG sc-TmcTc fedNbr"
+          class="StyledButton-sc-323bzc-0 gMxQVt sc-bqyKva sc-hBEYos gjQfnS kmijuE sc-dIUggk YDvpG sc-dwfUOf fiIHsz"
           type="button"
         >
           <svg
@@ -44,20 +44,20 @@ exports[`Storyshots Core/DropDownButton Bordered List 1`] = `
 exports[`Storyshots Core/DropDownButton Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
-      class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-jONnTn fFdndA sc-bTvRPi habiYC"
+      class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-aemoO gwhdcy sc-eLgOdN cOTCjW"
     >
       <span>
         <button
-          class="StyledButton-sc-323bzc-0 cfpfuP sc-bqyKva sc-hBEYos gjQfnS kmijuE sc-dIUggk YDvpG sc-jHVexB jChkJc"
+          class="StyledButton-sc-323bzc-0 cfpfuP sc-bqyKva sc-hBEYos gjQfnS kmijuE sc-dIUggk YDvpG sc-TmcTc cpZqkq"
           type="button"
         >
           Dropdown
         </button>
         <button
-          class="StyledButton-sc-323bzc-0 gMxQVt sc-bqyKva sc-hBEYos gjQfnS kmijuE sc-dIUggk YDvpG sc-TmcTc fedNbr"
+          class="StyledButton-sc-323bzc-0 gMxQVt sc-bqyKva sc-hBEYos gjQfnS kmijuE sc-dIUggk YDvpG sc-dwfUOf fiIHsz"
           type="button"
         >
           <svg
@@ -85,13 +85,13 @@ exports[`Storyshots Core/DropDownButton Default 1`] = `
 exports[`Storyshots Core/DropDownButton Icon Only 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
-      class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-jONnTn fFdndA sc-bTvRPi habiYC"
+      class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-aemoO gwhdcy sc-eLgOdN cOTCjW"
     >
       <button
-        class="StyledButton-sc-323bzc-0 gZnGrv sc-bqyKva sc-kstrdz gjQfnS FUwNf sc-dIUggk YDvpG sc-eLgOdN kccRTp"
+        class="StyledButton-sc-323bzc-0 gZnGrv sc-bqyKva sc-kstrdz gjQfnS FUwNf sc-dIUggk YDvpG sc-hlTvYk kWZJVa"
         type="button"
       >
         <svg
@@ -119,13 +119,13 @@ exports[`Storyshots Core/DropDownButton Icon Only 1`] = `
 exports[`Storyshots Core/DropDownButton Joined 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
-      class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-jONnTn fFdndA sc-bTvRPi habiYC"
+      class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-aemoO gwhdcy sc-eLgOdN cOTCjW"
     >
       <button
-        class="StyledButton-sc-323bzc-0 cfpfuP sc-bqyKva sc-hBEYos gjQfnS kmijuE sc-dIUggk YDvpG sc-eLgOdN kccRTp"
+        class="StyledButton-sc-323bzc-0 cfpfuP sc-bqyKva sc-hBEYos gjQfnS kmijuE sc-dIUggk YDvpG sc-hlTvYk kWZJVa"
         type="button"
       >
         <div
@@ -161,18 +161,18 @@ exports[`Storyshots Core/DropDownButton Joined 1`] = `
 exports[`Storyshots Core/DropDownButton No List Formatting 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
-      class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-jONnTn fFdndA sc-bTvRPi habiYC"
+      class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-aemoO gwhdcy sc-eLgOdN cOTCjW"
     >
       <span>
         <button
-          class="StyledButton-sc-323bzc-0 fGJlAh sc-bqyKva sc-kstrdz gjQfnS FUwNf sc-dIUggk YDvpG sc-jHVexB jChkJc"
+          class="StyledButton-sc-323bzc-0 fGJlAh sc-bqyKva sc-kstrdz gjQfnS FUwNf sc-dIUggk YDvpG sc-TmcTc cpZqkq"
           type="button"
         />
         <button
-          class="StyledButton-sc-323bzc-0 gZnGrv sc-bqyKva sc-kstrdz gjQfnS FUwNf sc-dIUggk YDvpG sc-TmcTc fedNbr"
+          class="StyledButton-sc-323bzc-0 gZnGrv sc-bqyKva sc-kstrdz gjQfnS FUwNf sc-dIUggk YDvpG sc-dwfUOf fiIHsz"
           type="button"
         >
           <svg
@@ -201,13 +201,13 @@ exports[`Storyshots Core/DropDownButton No List Formatting 1`] = `
 exports[`Storyshots Core/DropDownButton With Primary Button 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
-      class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-jONnTn fFdndA sc-bTvRPi habiYC"
+      class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-aemoO gwhdcy sc-eLgOdN cOTCjW"
     >
       <button
-        class="StyledButton-sc-323bzc-0 fGJlAh sc-bqyKva sc-kstrdz gjQfnS FUwNf sc-dIUggk YDvpG sc-eLgOdN kccRTp"
+        class="StyledButton-sc-323bzc-0 fGJlAh sc-bqyKva sc-kstrdz gjQfnS FUwNf sc-dIUggk YDvpG sc-hlTvYk kWZJVa"
         type="button"
       >
         <div

--- a/src/components/Filters/FilterModal.tsx
+++ b/src/components/Filters/FilterModal.tsx
@@ -103,10 +103,17 @@ export const FilterModal = ({
 	};
 	return (
 		<Modal
-			title="Filter by"
-			cancel={onClose}
-			done={() => addFilter(filters)}
-			action="Save"
+			header="Filter by"
+			actions={[
+				{
+					title: 'Save',
+					onTriggerAction: () => addFilter(filters),
+				},
+				{
+					title: 'Cancel',
+					onTriggerAction: onClose,
+				},
+			]}
 		>
 			{filters.map(({ field, operator, value }, index) => {
 				const operators = SchemaSieve.getOperators(schema, field);

--- a/src/components/Filters/Summary.tsx
+++ b/src/components/Filters/Summary.tsx
@@ -57,10 +57,17 @@ class FilterSummary extends React.Component<
 			<Box p={3} mt={3} width="100%" bg="quartenary.light">
 				{this.state.showForm && (
 					<Modal
-						title="Save current view"
-						cancel={() => this.setState({ showForm: false })}
-						done={this.save}
-						action="Save"
+						header="Save current view"
+						actions={[
+							{
+								title: 'Save',
+								onTriggerAction: this.save,
+							},
+							{
+								title: 'Cancel',
+								onTriggerAction: () => this.setState({ showForm: false }),
+							},
+						]}
 					>
 						<form onSubmit={this.save}>
 							{!!scopes && scopes.length > 1 && (

--- a/src/components/Filters/__snapshots__/Filters.stories.storyshot
+++ b/src/components/Filters/__snapshots__/Filters.stories.storyshot
@@ -3,11 +3,11 @@
 exports[`Storyshots Core/Filters Button Props 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div>
       <div
-        class="sc-gKsewC cgpPfo sc-iBPRYJ fGRNFR sc-fbNXWD hmXMwI"
+        class="sc-gKsewC cgpPfo sc-iBPRYJ fGRNFR sc-fvhGYg bIfuIs"
       >
         <div
           class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr jkLErl"
@@ -43,7 +43,7 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
             </div>
           </button>
           <div
-            class="sc-fvhGYg gsSjFE"
+            class="sc-jQbIHB faHDUz"
           >
             <div
               class="sc-khAkjo iYewy sc-hTZhsR eZHrxK"
@@ -70,13 +70,13 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
             </div>
           </div>
           <div
-            class="sc-kIeTtH"
+            class="sc-bTvRPi"
           >
             <div
-              class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-jONnTn fFdndA sc-bTvRPi bWqood"
+              class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-aemoO gwhdcy sc-eLgOdN iaHxwt"
             >
               <button
-                class="StyledButton-sc-323bzc-0 jwdmhD sc-bqyKva sc-hBEYos gjQfnS Kqhdo sc-dIUggk YDvpG sc-eLgOdN kccRTp"
+                class="StyledButton-sc-323bzc-0 jwdmhD sc-bqyKva sc-hBEYos gjQfnS Kqhdo sc-dIUggk YDvpG sc-hlTvYk kWZJVa"
                 type="button"
               >
                 <div
@@ -135,7 +135,7 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
           Bulbasaur
         </h2>
         <table
-          class="sc-cHjxUU ftpDsJ"
+          class="sc-hYZPRl fFikJR"
         >
           <tbody>
             <tr>
@@ -217,7 +217,7 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
           Ivysaur
         </h2>
         <table
-          class="sc-cHjxUU ftpDsJ"
+          class="sc-hYZPRl fFikJR"
         >
           <tbody>
             <tr>
@@ -299,7 +299,7 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
           Venusaur
         </h2>
         <table
-          class="sc-cHjxUU ftpDsJ"
+          class="sc-hYZPRl fFikJR"
         >
           <tbody>
             <tr>
@@ -381,7 +381,7 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
           Charmander
         </h2>
         <table
-          class="sc-cHjxUU ftpDsJ"
+          class="sc-hYZPRl fFikJR"
         >
           <tbody>
             <tr>
@@ -463,7 +463,7 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
           Charmeleon
         </h2>
         <table
-          class="sc-cHjxUU ftpDsJ"
+          class="sc-hYZPRl fFikJR"
         >
           <tbody>
             <tr>
@@ -547,7 +547,7 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
           Charizard
         </h2>
         <table
-          class="sc-cHjxUU ftpDsJ"
+          class="sc-hYZPRl fFikJR"
         >
           <tbody>
             <tr>
@@ -620,10 +620,10 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
               </td>
               <td>
                 <div
-                  class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV sc-GqfZa cHWpcm"
+                  class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV sc-fbkhIv gnNozJ"
                 >
                   <div
-                    class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-clsHhM cLDXoV bjaVYF"
+                    class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-gGmIRh cLDXoV dgHkOy"
                   >
                     <div
                       class="sc-fKFyDc euqOvB sc-bBXqnf iHGIIw"
@@ -633,10 +633,10 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV sc-GqfZa cHWpcm"
+                  class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV sc-fbkhIv gnNozJ"
                 >
                   <div
-                    class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-clsHhM cLDXoV bjaVYF"
+                    class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-gGmIRh cLDXoV dgHkOy"
                   >
                     <div
                       class="sc-fKFyDc euqOvB sc-bBXqnf iHGIIw"
@@ -658,7 +658,7 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
           Squirtle
         </h2>
         <table
-          class="sc-cHjxUU ftpDsJ"
+          class="sc-hYZPRl fFikJR"
         >
           <tbody>
             <tr>
@@ -731,10 +731,10 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
               </td>
               <td>
                 <div
-                  class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV sc-GqfZa cHWpcm"
+                  class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV sc-fbkhIv gnNozJ"
                 >
                   <div
-                    class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-clsHhM cLDXoV bjaVYF"
+                    class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-gGmIRh cLDXoV dgHkOy"
                   >
                     <div
                       class="sc-fKFyDc euqOvB sc-bBXqnf iHGIIw"
@@ -744,10 +744,10 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV sc-GqfZa cHWpcm"
+                  class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV sc-fbkhIv gnNozJ"
                 >
                   <div
-                    class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-clsHhM cLDXoV bjaVYF"
+                    class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-gGmIRh cLDXoV dgHkOy"
                   >
                     <div
                       class="sc-fKFyDc euqOvB sc-bBXqnf iHGIIw"
@@ -769,7 +769,7 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
           Wartortle
         </h2>
         <table
-          class="sc-cHjxUU ftpDsJ"
+          class="sc-hYZPRl fFikJR"
         >
           <tbody>
             <tr>
@@ -851,7 +851,7 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
           Blastoise
         </h2>
         <table
-          class="sc-cHjxUU ftpDsJ"
+          class="sc-hYZPRl fFikJR"
         >
           <tbody>
             <tr>
@@ -933,7 +933,7 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
           Caterpie
         </h2>
         <table
-          class="sc-cHjxUU ftpDsJ"
+          class="sc-hYZPRl fFikJR"
         >
           <tbody>
             <tr>
@@ -1015,7 +1015,7 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
           Staryu
         </h2>
         <table
-          class="sc-cHjxUU ftpDsJ"
+          class="sc-hYZPRl fFikJR"
         >
           <tbody>
             <tr>
@@ -1100,11 +1100,11 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
 exports[`Storyshots Core/Filters Compact 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div>
       <div
-        class="sc-gKsewC cgpPfo sc-iBPRYJ fGRNFR sc-fbNXWD hmXMwI"
+        class="sc-gKsewC cgpPfo sc-iBPRYJ fGRNFR sc-fvhGYg bIfuIs"
       >
         <div
           class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr jkLErl"
@@ -1131,7 +1131,7 @@ exports[`Storyshots Core/Filters Compact 1`] = `
             </svg>
           </button>
           <div
-            class="sc-fvhGYg gsSjFE"
+            class="sc-jQbIHB faHDUz"
           >
             <div
               class="sc-khAkjo iYewy sc-hTZhsR eZHrxK"
@@ -1158,13 +1158,13 @@ exports[`Storyshots Core/Filters Compact 1`] = `
             </div>
           </div>
           <div
-            class="sc-kIeTtH"
+            class="sc-bTvRPi"
           >
             <div
-              class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-jONnTn fFdndA sc-bTvRPi krAhKg"
+              class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-aemoO gwhdcy sc-eLgOdN jxuGnI"
             >
               <button
-                class="StyledButton-sc-323bzc-0 jwdmhD sc-bqyKva sc-hBEYos gjQfnS Kqhdo sc-dIUggk YDvpG sc-eLgOdN kccRTp"
+                class="StyledButton-sc-323bzc-0 jwdmhD sc-bqyKva sc-hBEYos gjQfnS Kqhdo sc-dIUggk YDvpG sc-hlTvYk kWZJVa"
                 type="button"
               >
                 <div
@@ -1218,7 +1218,7 @@ exports[`Storyshots Core/Filters Compact 1`] = `
           Bulbasaur
         </h2>
         <table
-          class="sc-cHjxUU ftpDsJ"
+          class="sc-hYZPRl fFikJR"
         >
           <tbody>
             <tr>
@@ -1300,7 +1300,7 @@ exports[`Storyshots Core/Filters Compact 1`] = `
           Ivysaur
         </h2>
         <table
-          class="sc-cHjxUU ftpDsJ"
+          class="sc-hYZPRl fFikJR"
         >
           <tbody>
             <tr>
@@ -1382,7 +1382,7 @@ exports[`Storyshots Core/Filters Compact 1`] = `
           Venusaur
         </h2>
         <table
-          class="sc-cHjxUU ftpDsJ"
+          class="sc-hYZPRl fFikJR"
         >
           <tbody>
             <tr>
@@ -1464,7 +1464,7 @@ exports[`Storyshots Core/Filters Compact 1`] = `
           Charmander
         </h2>
         <table
-          class="sc-cHjxUU ftpDsJ"
+          class="sc-hYZPRl fFikJR"
         >
           <tbody>
             <tr>
@@ -1546,7 +1546,7 @@ exports[`Storyshots Core/Filters Compact 1`] = `
           Charmeleon
         </h2>
         <table
-          class="sc-cHjxUU ftpDsJ"
+          class="sc-hYZPRl fFikJR"
         >
           <tbody>
             <tr>
@@ -1630,7 +1630,7 @@ exports[`Storyshots Core/Filters Compact 1`] = `
           Charizard
         </h2>
         <table
-          class="sc-cHjxUU ftpDsJ"
+          class="sc-hYZPRl fFikJR"
         >
           <tbody>
             <tr>
@@ -1703,10 +1703,10 @@ exports[`Storyshots Core/Filters Compact 1`] = `
               </td>
               <td>
                 <div
-                  class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV sc-GqfZa cHWpcm"
+                  class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV sc-fbkhIv gnNozJ"
                 >
                   <div
-                    class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-clsHhM cLDXoV bjaVYF"
+                    class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-gGmIRh cLDXoV dgHkOy"
                   >
                     <div
                       class="sc-fKFyDc euqOvB sc-bBXqnf iHGIIw"
@@ -1716,10 +1716,10 @@ exports[`Storyshots Core/Filters Compact 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV sc-GqfZa cHWpcm"
+                  class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV sc-fbkhIv gnNozJ"
                 >
                   <div
-                    class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-clsHhM cLDXoV bjaVYF"
+                    class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-gGmIRh cLDXoV dgHkOy"
                   >
                     <div
                       class="sc-fKFyDc euqOvB sc-bBXqnf iHGIIw"
@@ -1741,7 +1741,7 @@ exports[`Storyshots Core/Filters Compact 1`] = `
           Squirtle
         </h2>
         <table
-          class="sc-cHjxUU ftpDsJ"
+          class="sc-hYZPRl fFikJR"
         >
           <tbody>
             <tr>
@@ -1814,10 +1814,10 @@ exports[`Storyshots Core/Filters Compact 1`] = `
               </td>
               <td>
                 <div
-                  class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV sc-GqfZa cHWpcm"
+                  class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV sc-fbkhIv gnNozJ"
                 >
                   <div
-                    class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-clsHhM cLDXoV bjaVYF"
+                    class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-gGmIRh cLDXoV dgHkOy"
                   >
                     <div
                       class="sc-fKFyDc euqOvB sc-bBXqnf iHGIIw"
@@ -1827,10 +1827,10 @@ exports[`Storyshots Core/Filters Compact 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV sc-GqfZa cHWpcm"
+                  class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV sc-fbkhIv gnNozJ"
                 >
                   <div
-                    class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-clsHhM cLDXoV bjaVYF"
+                    class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-gGmIRh cLDXoV dgHkOy"
                   >
                     <div
                       class="sc-fKFyDc euqOvB sc-bBXqnf iHGIIw"
@@ -1852,7 +1852,7 @@ exports[`Storyshots Core/Filters Compact 1`] = `
           Wartortle
         </h2>
         <table
-          class="sc-cHjxUU ftpDsJ"
+          class="sc-hYZPRl fFikJR"
         >
           <tbody>
             <tr>
@@ -1934,7 +1934,7 @@ exports[`Storyshots Core/Filters Compact 1`] = `
           Blastoise
         </h2>
         <table
-          class="sc-cHjxUU ftpDsJ"
+          class="sc-hYZPRl fFikJR"
         >
           <tbody>
             <tr>
@@ -2016,7 +2016,7 @@ exports[`Storyshots Core/Filters Compact 1`] = `
           Caterpie
         </h2>
         <table
-          class="sc-cHjxUU ftpDsJ"
+          class="sc-hYZPRl fFikJR"
         >
           <tbody>
             <tr>
@@ -2098,7 +2098,7 @@ exports[`Storyshots Core/Filters Compact 1`] = `
           Staryu
         </h2>
         <table
-          class="sc-cHjxUU ftpDsJ"
+          class="sc-hYZPRl fFikJR"
         >
           <tbody>
             <tr>
@@ -2183,11 +2183,11 @@ exports[`Storyshots Core/Filters Compact 1`] = `
 exports[`Storyshots Core/Filters Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div>
       <div
-        class="sc-gKsewC cgpPfo sc-iBPRYJ fGRNFR sc-fbNXWD hmXMwI"
+        class="sc-gKsewC cgpPfo sc-iBPRYJ fGRNFR sc-fvhGYg bIfuIs"
       >
         <div
           class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr jkLErl"
@@ -2222,7 +2222,7 @@ exports[`Storyshots Core/Filters Default 1`] = `
             </div>
           </button>
           <div
-            class="sc-fvhGYg gsSjFE"
+            class="sc-jQbIHB faHDUz"
           >
             <div
               class="sc-khAkjo iYewy sc-hTZhsR eZHrxK"
@@ -2249,13 +2249,13 @@ exports[`Storyshots Core/Filters Default 1`] = `
             </div>
           </div>
           <div
-            class="sc-kIeTtH"
+            class="sc-bTvRPi"
           >
             <div
-              class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-jONnTn fFdndA sc-bTvRPi krAhKg"
+              class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-aemoO gwhdcy sc-eLgOdN jxuGnI"
             >
               <button
-                class="StyledButton-sc-323bzc-0 jwdmhD sc-bqyKva sc-hBEYos gjQfnS Kqhdo sc-dIUggk YDvpG sc-eLgOdN kccRTp"
+                class="StyledButton-sc-323bzc-0 jwdmhD sc-bqyKva sc-hBEYos gjQfnS Kqhdo sc-dIUggk YDvpG sc-hlTvYk kWZJVa"
                 type="button"
               >
                 <div
@@ -2314,7 +2314,7 @@ exports[`Storyshots Core/Filters Default 1`] = `
           Bulbasaur
         </h2>
         <table
-          class="sc-cHjxUU ftpDsJ"
+          class="sc-hYZPRl fFikJR"
         >
           <tbody>
             <tr>
@@ -2396,7 +2396,7 @@ exports[`Storyshots Core/Filters Default 1`] = `
           Ivysaur
         </h2>
         <table
-          class="sc-cHjxUU ftpDsJ"
+          class="sc-hYZPRl fFikJR"
         >
           <tbody>
             <tr>
@@ -2478,7 +2478,7 @@ exports[`Storyshots Core/Filters Default 1`] = `
           Venusaur
         </h2>
         <table
-          class="sc-cHjxUU ftpDsJ"
+          class="sc-hYZPRl fFikJR"
         >
           <tbody>
             <tr>
@@ -2560,7 +2560,7 @@ exports[`Storyshots Core/Filters Default 1`] = `
           Charmander
         </h2>
         <table
-          class="sc-cHjxUU ftpDsJ"
+          class="sc-hYZPRl fFikJR"
         >
           <tbody>
             <tr>
@@ -2642,7 +2642,7 @@ exports[`Storyshots Core/Filters Default 1`] = `
           Charmeleon
         </h2>
         <table
-          class="sc-cHjxUU ftpDsJ"
+          class="sc-hYZPRl fFikJR"
         >
           <tbody>
             <tr>
@@ -2726,7 +2726,7 @@ exports[`Storyshots Core/Filters Default 1`] = `
           Charizard
         </h2>
         <table
-          class="sc-cHjxUU ftpDsJ"
+          class="sc-hYZPRl fFikJR"
         >
           <tbody>
             <tr>
@@ -2799,10 +2799,10 @@ exports[`Storyshots Core/Filters Default 1`] = `
               </td>
               <td>
                 <div
-                  class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV sc-GqfZa cHWpcm"
+                  class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV sc-fbkhIv gnNozJ"
                 >
                   <div
-                    class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-clsHhM cLDXoV bjaVYF"
+                    class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-gGmIRh cLDXoV dgHkOy"
                   >
                     <div
                       class="sc-fKFyDc euqOvB sc-bBXqnf iHGIIw"
@@ -2812,10 +2812,10 @@ exports[`Storyshots Core/Filters Default 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV sc-GqfZa cHWpcm"
+                  class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV sc-fbkhIv gnNozJ"
                 >
                   <div
-                    class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-clsHhM cLDXoV bjaVYF"
+                    class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-gGmIRh cLDXoV dgHkOy"
                   >
                     <div
                       class="sc-fKFyDc euqOvB sc-bBXqnf iHGIIw"
@@ -2837,7 +2837,7 @@ exports[`Storyshots Core/Filters Default 1`] = `
           Squirtle
         </h2>
         <table
-          class="sc-cHjxUU ftpDsJ"
+          class="sc-hYZPRl fFikJR"
         >
           <tbody>
             <tr>
@@ -2910,10 +2910,10 @@ exports[`Storyshots Core/Filters Default 1`] = `
               </td>
               <td>
                 <div
-                  class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV sc-GqfZa cHWpcm"
+                  class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV sc-fbkhIv gnNozJ"
                 >
                   <div
-                    class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-clsHhM cLDXoV bjaVYF"
+                    class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-gGmIRh cLDXoV dgHkOy"
                   >
                     <div
                       class="sc-fKFyDc euqOvB sc-bBXqnf iHGIIw"
@@ -2923,10 +2923,10 @@ exports[`Storyshots Core/Filters Default 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV sc-GqfZa cHWpcm"
+                  class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV sc-fbkhIv gnNozJ"
                 >
                   <div
-                    class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-clsHhM cLDXoV bjaVYF"
+                    class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-gGmIRh cLDXoV dgHkOy"
                   >
                     <div
                       class="sc-fKFyDc euqOvB sc-bBXqnf iHGIIw"
@@ -2948,7 +2948,7 @@ exports[`Storyshots Core/Filters Default 1`] = `
           Wartortle
         </h2>
         <table
-          class="sc-cHjxUU ftpDsJ"
+          class="sc-hYZPRl fFikJR"
         >
           <tbody>
             <tr>
@@ -3030,7 +3030,7 @@ exports[`Storyshots Core/Filters Default 1`] = `
           Blastoise
         </h2>
         <table
-          class="sc-cHjxUU ftpDsJ"
+          class="sc-hYZPRl fFikJR"
         >
           <tbody>
             <tr>
@@ -3112,7 +3112,7 @@ exports[`Storyshots Core/Filters Default 1`] = `
           Caterpie
         </h2>
         <table
-          class="sc-cHjxUU ftpDsJ"
+          class="sc-hYZPRl fFikJR"
         >
           <tbody>
             <tr>
@@ -3194,7 +3194,7 @@ exports[`Storyshots Core/Filters Default 1`] = `
           Staryu
         </h2>
         <table
-          class="sc-cHjxUU ftpDsJ"
+          class="sc-hYZPRl fFikJR"
         >
           <tbody>
             <tr>
@@ -3279,11 +3279,11 @@ exports[`Storyshots Core/Filters Default 1`] = `
 exports[`Storyshots Core/Filters Disabled 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div>
       <div
-        class="sc-gKsewC cgpPfo sc-iBPRYJ fGRNFR sc-fbNXWD hmXMwI"
+        class="sc-gKsewC cgpPfo sc-iBPRYJ fGRNFR sc-fvhGYg bIfuIs"
       >
         <div
           class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr jkLErl"
@@ -3319,7 +3319,7 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
             </div>
           </button>
           <div
-            class="sc-fvhGYg gsSjFE"
+            class="sc-jQbIHB faHDUz"
           >
             <div
               class="sc-khAkjo iYewy sc-hTZhsR eZHrxK"
@@ -3347,14 +3347,14 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
             </div>
           </div>
           <div
-            class="sc-kIeTtH"
+            class="sc-bTvRPi"
           >
             <div
-              class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-jONnTn fFdndA sc-bTvRPi krAhKg"
+              class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-aemoO gwhdcy sc-eLgOdN jxuGnI"
               disabled=""
             >
               <button
-                class="StyledButton-sc-323bzc-0 egqEJR sc-bqyKva sc-hBEYos gjQfnS Kqhdo sc-dIUggk YDvpG sc-eLgOdN kccRTp"
+                class="StyledButton-sc-323bzc-0 egqEJR sc-bqyKva sc-hBEYos gjQfnS Kqhdo sc-dIUggk YDvpG sc-hlTvYk kWZJVa"
                 disabled=""
                 type="button"
               >
@@ -3414,7 +3414,7 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
           Bulbasaur
         </h2>
         <table
-          class="sc-cHjxUU ftpDsJ"
+          class="sc-hYZPRl fFikJR"
         >
           <tbody>
             <tr>
@@ -3496,7 +3496,7 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
           Ivysaur
         </h2>
         <table
-          class="sc-cHjxUU ftpDsJ"
+          class="sc-hYZPRl fFikJR"
         >
           <tbody>
             <tr>
@@ -3578,7 +3578,7 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
           Venusaur
         </h2>
         <table
-          class="sc-cHjxUU ftpDsJ"
+          class="sc-hYZPRl fFikJR"
         >
           <tbody>
             <tr>
@@ -3660,7 +3660,7 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
           Charmander
         </h2>
         <table
-          class="sc-cHjxUU ftpDsJ"
+          class="sc-hYZPRl fFikJR"
         >
           <tbody>
             <tr>
@@ -3742,7 +3742,7 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
           Charmeleon
         </h2>
         <table
-          class="sc-cHjxUU ftpDsJ"
+          class="sc-hYZPRl fFikJR"
         >
           <tbody>
             <tr>
@@ -3826,7 +3826,7 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
           Charizard
         </h2>
         <table
-          class="sc-cHjxUU ftpDsJ"
+          class="sc-hYZPRl fFikJR"
         >
           <tbody>
             <tr>
@@ -3899,10 +3899,10 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
               </td>
               <td>
                 <div
-                  class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV sc-GqfZa cHWpcm"
+                  class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV sc-fbkhIv gnNozJ"
                 >
                   <div
-                    class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-clsHhM cLDXoV bjaVYF"
+                    class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-gGmIRh cLDXoV dgHkOy"
                   >
                     <div
                       class="sc-fKFyDc euqOvB sc-bBXqnf iHGIIw"
@@ -3912,10 +3912,10 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV sc-GqfZa cHWpcm"
+                  class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV sc-fbkhIv gnNozJ"
                 >
                   <div
-                    class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-clsHhM cLDXoV bjaVYF"
+                    class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-gGmIRh cLDXoV dgHkOy"
                   >
                     <div
                       class="sc-fKFyDc euqOvB sc-bBXqnf iHGIIw"
@@ -3937,7 +3937,7 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
           Squirtle
         </h2>
         <table
-          class="sc-cHjxUU ftpDsJ"
+          class="sc-hYZPRl fFikJR"
         >
           <tbody>
             <tr>
@@ -4010,10 +4010,10 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
               </td>
               <td>
                 <div
-                  class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV sc-GqfZa cHWpcm"
+                  class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV sc-fbkhIv gnNozJ"
                 >
                   <div
-                    class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-clsHhM cLDXoV bjaVYF"
+                    class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-gGmIRh cLDXoV dgHkOy"
                   >
                     <div
                       class="sc-fKFyDc euqOvB sc-bBXqnf iHGIIw"
@@ -4023,10 +4023,10 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV sc-GqfZa cHWpcm"
+                  class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV sc-fbkhIv gnNozJ"
                 >
                   <div
-                    class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-clsHhM cLDXoV bjaVYF"
+                    class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-gGmIRh cLDXoV dgHkOy"
                   >
                     <div
                       class="sc-fKFyDc euqOvB sc-bBXqnf iHGIIw"
@@ -4048,7 +4048,7 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
           Wartortle
         </h2>
         <table
-          class="sc-cHjxUU ftpDsJ"
+          class="sc-hYZPRl fFikJR"
         >
           <tbody>
             <tr>
@@ -4130,7 +4130,7 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
           Blastoise
         </h2>
         <table
-          class="sc-cHjxUU ftpDsJ"
+          class="sc-hYZPRl fFikJR"
         >
           <tbody>
             <tr>
@@ -4212,7 +4212,7 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
           Caterpie
         </h2>
         <table
-          class="sc-cHjxUU ftpDsJ"
+          class="sc-hYZPRl fFikJR"
         >
           <tbody>
             <tr>
@@ -4294,7 +4294,7 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
           Staryu
         </h2>
         <table
-          class="sc-cHjxUU ftpDsJ"
+          class="sc-hYZPRl fFikJR"
         >
           <tbody>
             <tr>
@@ -4379,11 +4379,11 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
 exports[`Storyshots Core/Filters Render Modes 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div>
       <div
-        class="sc-gKsewC cgpPfo sc-iBPRYJ fGRNFR sc-fbNXWD hmXMwI"
+        class="sc-gKsewC cgpPfo sc-iBPRYJ fGRNFR sc-fvhGYg bIfuIs"
       >
         <div
           class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr jkLErl"
@@ -4418,13 +4418,13 @@ exports[`Storyshots Core/Filters Render Modes 1`] = `
             </div>
           </button>
           <div
-            class="sc-kIeTtH"
+            class="sc-bTvRPi"
           >
             <div
-              class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-jONnTn fFdndA sc-bTvRPi krAhKg"
+              class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-aemoO gwhdcy sc-eLgOdN jxuGnI"
             >
               <button
-                class="StyledButton-sc-323bzc-0 jwdmhD sc-bqyKva sc-hBEYos gjQfnS Kqhdo sc-dIUggk YDvpG sc-eLgOdN kccRTp"
+                class="StyledButton-sc-323bzc-0 jwdmhD sc-bqyKva sc-hBEYos gjQfnS Kqhdo sc-dIUggk YDvpG sc-hlTvYk kWZJVa"
                 type="button"
               >
                 <div
@@ -4538,14 +4538,14 @@ exports[`Storyshots Core/Filters Render Modes 1`] = `
             class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr fZtgtW"
           >
             <div
-              class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV sc-GqfZa kHuITP"
+              class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV sc-fbkhIv ckRCPk"
             >
               <button
                 class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG"
                 type="button"
               >
                 <div
-                  class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-clsHhM cLDXoV bjaVYF"
+                  class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-gGmIRh cLDXoV dgHkOy"
                 >
                   <div
                     class="sc-fKFyDc dTkenA sc-bBXqnf iHGIIw"
@@ -4575,7 +4575,7 @@ exports[`Storyshots Core/Filters Render Modes 1`] = `
                 </div>
               </button>
               <button
-                class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk fBWcUT sc-fbkhIv hQBnSA"
+                class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk fBWcUT sc-clsHhM hUEyIR"
                 type="button"
               >
                 <svg
@@ -4603,7 +4603,7 @@ exports[`Storyshots Core/Filters Render Modes 1`] = `
           Squirtle
         </h2>
         <table
-          class="sc-cHjxUU ftpDsJ"
+          class="sc-hYZPRl fFikJR"
         >
           <tbody>
             <tr>
@@ -4676,10 +4676,10 @@ exports[`Storyshots Core/Filters Render Modes 1`] = `
               </td>
               <td>
                 <div
-                  class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV sc-GqfZa cHWpcm"
+                  class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV sc-fbkhIv gnNozJ"
                 >
                   <div
-                    class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-clsHhM cLDXoV bjaVYF"
+                    class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-gGmIRh cLDXoV dgHkOy"
                   >
                     <div
                       class="sc-fKFyDc euqOvB sc-bBXqnf iHGIIw"
@@ -4689,10 +4689,10 @@ exports[`Storyshots Core/Filters Render Modes 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV sc-GqfZa cHWpcm"
+                  class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV sc-fbkhIv gnNozJ"
                 >
                   <div
-                    class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-clsHhM cLDXoV bjaVYF"
+                    class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-gGmIRh cLDXoV dgHkOy"
                   >
                     <div
                       class="sc-fKFyDc euqOvB sc-bBXqnf iHGIIw"

--- a/src/components/Fixed/__snapshots__/Fixed.stories.storyshot
+++ b/src/components/Fixed/__snapshots__/Fixed.stories.storyshot
@@ -3,10 +3,10 @@
 exports[`Storyshots Core/Fixed Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
-      class="sc-fWSCIC kOzbwX sc-dwfUOf ePNRlD"
+      class="sc-GqfZa bAZMtD sc-fWSCIC iZXHeR"
     />
   </div>
 </div>

--- a/src/components/Flex/__snapshots__/Flex.stories.storyshot
+++ b/src/components/Flex/__snapshots__/Flex.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/Flex Column Direction 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr iIBJBt"
@@ -28,7 +28,7 @@ exports[`Storyshots Core/Flex Column Direction 1`] = `
 exports[`Storyshots Core/Flex Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV"
@@ -53,7 +53,7 @@ exports[`Storyshots Core/Flex Default 1`] = `
 exports[`Storyshots Core/Flex Flex On Children 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr fZtgtW"
@@ -86,7 +86,7 @@ exports[`Storyshots Core/Flex Flex On Children 1`] = `
 exports[`Storyshots Core/Flex Justified 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr jkLErl"
@@ -111,7 +111,7 @@ exports[`Storyshots Core/Flex Justified 1`] = `
 exports[`Storyshots Core/Flex Wrap 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr fZtgtW"

--- a/src/components/Form/__snapshots__/Form.stories.storyshot
+++ b/src/components/Form/__snapshots__/Form.stories.storyshot
@@ -2575,7 +2575,7 @@ exports[`Storyshots Core/Form With Extra Widgets 1`] = `
       >
         <div>
           <h1
-            class="sc-gWHgXt eCVPSB sc-citwmv gCCLOD"
+            class="sc-iktFzd ePMNkU sc-hiSbYr hwRkKu"
           >
             Extra widgets
           </h1>

--- a/src/components/Form/__snapshots__/Form.stories.storyshot
+++ b/src/components/Form/__snapshots__/Form.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/Form Custom Submit Text 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV"
@@ -12,7 +12,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
         class="sc-gKsewC dWcnb sc-iBPRYJ jsPsJf"
       >
         <div
-          class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-kYrkKh fXKnbV"
+          class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hzMMCg juuWBr"
         >
           <form
             class="rjsf"
@@ -22,7 +22,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
             >
               <section>
                 <legend
-                  class="sc-dkIXFM ceKNxn"
+                  class="sc-dtTInj cRySGv"
                   id="root__title"
                 >
                   Pokèmon
@@ -37,7 +37,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-string rendition-form__field--root_Name"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_Name"
                       >
                         Name
@@ -69,7 +69,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-number rendition-form__field--root_Height"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_Height"
                       >
                         Height
@@ -96,7 +96,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-number rendition-form__field--root_Weight"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_Weight"
                       >
                         Weight
@@ -123,7 +123,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-string rendition-form__field--root_Description"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_Description"
                       >
                         Description
@@ -150,7 +150,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-string rendition-form__field--root_Category"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_Category"
                       >
                         Category
@@ -177,7 +177,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-string rendition-form__field--root_Abilities"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_Abilities"
                       >
                         Abilities
@@ -204,7 +204,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-number rendition-form__field--root_pokedex_number"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_pokedex_number"
                       >
                         National Pokèdex Number
@@ -252,17 +252,17 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-string rendition-form__field--root_first_seen"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_first_seen"
                       >
                         First seen
                       </label>
                       <div
-                        class="sc-gKsewC cgpPfo sc-iBPRYJ ildvdb sc-hHftDr jpCUGc sc-dtTInj bKkgfk rendition-form-description"
+                        class="sc-gKsewC cgpPfo sc-iBPRYJ ildvdb sc-hHftDr jpCUGc sc-fHuLdG dFHllN rendition-form-description"
                         id="root_first_seen__description"
                       >
                         <div
-                          class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-hYZPRl gyTNli"
+                          class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-dRPiIx qUHcx"
                         >
                           <div>
                             <p
@@ -295,17 +295,17 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-string rendition-form__field--root_poke_password"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_poke_password"
                       >
                         Poke Password
                       </label>
                       <div
-                        class="sc-gKsewC cgpPfo sc-iBPRYJ ildvdb sc-hHftDr jpCUGc sc-dtTInj bKkgfk rendition-form-description"
+                        class="sc-gKsewC cgpPfo sc-iBPRYJ ildvdb sc-hHftDr jpCUGc sc-fHuLdG dFHllN rendition-form-description"
                         id="root_poke_password__description"
                       >
                         <div
-                          class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-hYZPRl gyTNli"
+                          class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-dRPiIx qUHcx"
                         >
                           <div>
                             <p
@@ -338,7 +338,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-string rendition-form__field--root_environment"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_environment"
                       >
                         environment
@@ -402,17 +402,17 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                     >
                       <div>
                         <legend
-                          class="sc-dkIXFM ceKNxn"
+                          class="sc-dtTInj cRySGv"
                           id="root_tags__title"
                         >
                           Tags
                         </legend>
                         <div
-                          class="sc-gKsewC cgpPfo sc-iBPRYJ ildvdb sc-hHftDr jpCUGc sc-dtTInj bKkgfk rendition-form-description"
+                          class="sc-gKsewC cgpPfo sc-iBPRYJ ildvdb sc-hHftDr jpCUGc sc-fHuLdG dFHllN rendition-form-description"
                           id="root_tags__description"
                         >
                           <div
-                            class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-hYZPRl gyTNli"
+                            class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-dRPiIx qUHcx"
                           >
                             <div>
                               <p
@@ -485,7 +485,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
 exports[`Storyshots Core/Form Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV"
@@ -494,7 +494,7 @@ exports[`Storyshots Core/Form Default 1`] = `
         class="sc-gKsewC dWcnb sc-iBPRYJ jsPsJf"
       >
         <div
-          class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-kYrkKh fXKnbV"
+          class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hzMMCg juuWBr"
         >
           <form
             class="rjsf"
@@ -504,7 +504,7 @@ exports[`Storyshots Core/Form Default 1`] = `
             >
               <section>
                 <legend
-                  class="sc-dkIXFM ceKNxn"
+                  class="sc-dtTInj cRySGv"
                   id="root__title"
                 >
                   Pokèmon
@@ -519,7 +519,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-string rendition-form__field--root_Name"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_Name"
                       >
                         Name
@@ -551,7 +551,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-number rendition-form__field--root_Height"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_Height"
                       >
                         Height
@@ -578,7 +578,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-number rendition-form__field--root_Weight"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_Weight"
                       >
                         Weight
@@ -605,7 +605,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-string rendition-form__field--root_Description"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_Description"
                       >
                         Description
@@ -632,7 +632,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-string rendition-form__field--root_Category"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_Category"
                       >
                         Category
@@ -659,7 +659,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-string rendition-form__field--root_Abilities"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_Abilities"
                       >
                         Abilities
@@ -686,7 +686,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-number rendition-form__field--root_pokedex_number"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_pokedex_number"
                       >
                         National Pokèdex Number
@@ -734,17 +734,17 @@ exports[`Storyshots Core/Form Default 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-string rendition-form__field--root_first_seen"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_first_seen"
                       >
                         First seen
                       </label>
                       <div
-                        class="sc-gKsewC cgpPfo sc-iBPRYJ ildvdb sc-hHftDr jpCUGc sc-dtTInj bKkgfk rendition-form-description"
+                        class="sc-gKsewC cgpPfo sc-iBPRYJ ildvdb sc-hHftDr jpCUGc sc-fHuLdG dFHllN rendition-form-description"
                         id="root_first_seen__description"
                       >
                         <div
-                          class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-hYZPRl gyTNli"
+                          class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-dRPiIx qUHcx"
                         >
                           <div>
                             <p
@@ -777,17 +777,17 @@ exports[`Storyshots Core/Form Default 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-string rendition-form__field--root_poke_password"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_poke_password"
                       >
                         Poke Password
                       </label>
                       <div
-                        class="sc-gKsewC cgpPfo sc-iBPRYJ ildvdb sc-hHftDr jpCUGc sc-dtTInj bKkgfk rendition-form-description"
+                        class="sc-gKsewC cgpPfo sc-iBPRYJ ildvdb sc-hHftDr jpCUGc sc-fHuLdG dFHllN rendition-form-description"
                         id="root_poke_password__description"
                       >
                         <div
-                          class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-hYZPRl gyTNli"
+                          class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-dRPiIx qUHcx"
                         >
                           <div>
                             <p
@@ -820,7 +820,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-string rendition-form__field--root_environment"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_environment"
                       >
                         environment
@@ -884,17 +884,17 @@ exports[`Storyshots Core/Form Default 1`] = `
                     >
                       <div>
                         <legend
-                          class="sc-dkIXFM ceKNxn"
+                          class="sc-dtTInj cRySGv"
                           id="root_tags__title"
                         >
                           Tags
                         </legend>
                         <div
-                          class="sc-gKsewC cgpPfo sc-iBPRYJ ildvdb sc-hHftDr jpCUGc sc-dtTInj bKkgfk rendition-form-description"
+                          class="sc-gKsewC cgpPfo sc-iBPRYJ ildvdb sc-hHftDr jpCUGc sc-fHuLdG dFHllN rendition-form-description"
                           id="root_tags__description"
                         >
                           <div
-                            class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-hYZPRl gyTNli"
+                            class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-dRPiIx qUHcx"
                           >
                             <div>
                               <p
@@ -967,7 +967,7 @@ exports[`Storyshots Core/Form Default 1`] = `
 exports[`Storyshots Core/Form Disabled 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV"
@@ -976,7 +976,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
         class="sc-gKsewC dWcnb sc-iBPRYJ jsPsJf"
       >
         <div
-          class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-kYrkKh fXKnbV"
+          class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hzMMCg juuWBr"
         >
           <form
             class="rjsf"
@@ -986,7 +986,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
             >
               <section>
                 <legend
-                  class="sc-dkIXFM ceKNxn"
+                  class="sc-dtTInj cRySGv"
                   id="root__title"
                 >
                   Pokèmon
@@ -1001,7 +1001,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-string rendition-form__field--root_Name"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_Name"
                       >
                         Name
@@ -1034,7 +1034,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-number rendition-form__field--root_Height"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_Height"
                       >
                         Height
@@ -1062,7 +1062,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-number rendition-form__field--root_Weight"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_Weight"
                       >
                         Weight
@@ -1090,7 +1090,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-string rendition-form__field--root_Description"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_Description"
                       >
                         Description
@@ -1118,7 +1118,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-string rendition-form__field--root_Category"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_Category"
                       >
                         Category
@@ -1146,7 +1146,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-string rendition-form__field--root_Abilities"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_Abilities"
                       >
                         Abilities
@@ -1174,7 +1174,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-number rendition-form__field--root_pokedex_number"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_pokedex_number"
                       >
                         National Pokèdex Number
@@ -1224,17 +1224,17 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-string rendition-form__field--root_first_seen"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_first_seen"
                       >
                         First seen
                       </label>
                       <div
-                        class="sc-gKsewC cgpPfo sc-iBPRYJ ildvdb sc-hHftDr jpCUGc sc-dtTInj bKkgfk rendition-form-description"
+                        class="sc-gKsewC cgpPfo sc-iBPRYJ ildvdb sc-hHftDr jpCUGc sc-fHuLdG dFHllN rendition-form-description"
                         id="root_first_seen__description"
                       >
                         <div
-                          class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-hYZPRl gyTNli"
+                          class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-dRPiIx qUHcx"
                         >
                           <div>
                             <p
@@ -1268,17 +1268,17 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-string rendition-form__field--root_poke_password"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_poke_password"
                       >
                         Poke Password
                       </label>
                       <div
-                        class="sc-gKsewC cgpPfo sc-iBPRYJ ildvdb sc-hHftDr jpCUGc sc-dtTInj bKkgfk rendition-form-description"
+                        class="sc-gKsewC cgpPfo sc-iBPRYJ ildvdb sc-hHftDr jpCUGc sc-fHuLdG dFHllN rendition-form-description"
                         id="root_poke_password__description"
                       >
                         <div
-                          class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-hYZPRl gyTNli"
+                          class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-dRPiIx qUHcx"
                         >
                           <div>
                             <p
@@ -1312,7 +1312,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-string rendition-form__field--root_environment"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_environment"
                       >
                         environment
@@ -1377,17 +1377,17 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                     >
                       <div>
                         <legend
-                          class="sc-dkIXFM ceKNxn"
+                          class="sc-dtTInj cRySGv"
                           id="root_tags__title"
                         >
                           Tags
                         </legend>
                         <div
-                          class="sc-gKsewC cgpPfo sc-iBPRYJ ildvdb sc-hHftDr jpCUGc sc-dtTInj bKkgfk rendition-form-description"
+                          class="sc-gKsewC cgpPfo sc-iBPRYJ ildvdb sc-hHftDr jpCUGc sc-fHuLdG dFHllN rendition-form-description"
                           id="root_tags__description"
                         >
                           <div
-                            class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-hYZPRl gyTNli"
+                            class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-dRPiIx qUHcx"
                           >
                             <div>
                               <p
@@ -1460,7 +1460,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
 exports[`Storyshots Core/Form Hidden Submit 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV"
@@ -1469,7 +1469,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
         class="sc-gKsewC dWcnb sc-iBPRYJ jsPsJf"
       >
         <div
-          class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-kYrkKh fXKnbV"
+          class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hzMMCg juuWBr"
         >
           <form
             class="rjsf"
@@ -1479,7 +1479,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
             >
               <section>
                 <legend
-                  class="sc-dkIXFM ceKNxn"
+                  class="sc-dtTInj cRySGv"
                   id="root__title"
                 >
                   Pokèmon
@@ -1494,7 +1494,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-string rendition-form__field--root_Name"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_Name"
                       >
                         Name
@@ -1526,7 +1526,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-number rendition-form__field--root_Height"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_Height"
                       >
                         Height
@@ -1553,7 +1553,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-number rendition-form__field--root_Weight"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_Weight"
                       >
                         Weight
@@ -1580,7 +1580,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-string rendition-form__field--root_Description"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_Description"
                       >
                         Description
@@ -1607,7 +1607,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-string rendition-form__field--root_Category"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_Category"
                       >
                         Category
@@ -1634,7 +1634,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-string rendition-form__field--root_Abilities"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_Abilities"
                       >
                         Abilities
@@ -1661,7 +1661,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-number rendition-form__field--root_pokedex_number"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_pokedex_number"
                       >
                         National Pokèdex Number
@@ -1709,17 +1709,17 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-string rendition-form__field--root_first_seen"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_first_seen"
                       >
                         First seen
                       </label>
                       <div
-                        class="sc-gKsewC cgpPfo sc-iBPRYJ ildvdb sc-hHftDr jpCUGc sc-dtTInj bKkgfk rendition-form-description"
+                        class="sc-gKsewC cgpPfo sc-iBPRYJ ildvdb sc-hHftDr jpCUGc sc-fHuLdG dFHllN rendition-form-description"
                         id="root_first_seen__description"
                       >
                         <div
-                          class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-hYZPRl gyTNli"
+                          class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-dRPiIx qUHcx"
                         >
                           <div>
                             <p
@@ -1752,17 +1752,17 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-string rendition-form__field--root_poke_password"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_poke_password"
                       >
                         Poke Password
                       </label>
                       <div
-                        class="sc-gKsewC cgpPfo sc-iBPRYJ ildvdb sc-hHftDr jpCUGc sc-dtTInj bKkgfk rendition-form-description"
+                        class="sc-gKsewC cgpPfo sc-iBPRYJ ildvdb sc-hHftDr jpCUGc sc-fHuLdG dFHllN rendition-form-description"
                         id="root_poke_password__description"
                       >
                         <div
-                          class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-hYZPRl gyTNli"
+                          class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-dRPiIx qUHcx"
                         >
                           <div>
                             <p
@@ -1795,7 +1795,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-string rendition-form__field--root_environment"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_environment"
                       >
                         environment
@@ -1859,17 +1859,17 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                     >
                       <div>
                         <legend
-                          class="sc-dkIXFM ceKNxn"
+                          class="sc-dtTInj cRySGv"
                           id="root_tags__title"
                         >
                           Tags
                         </legend>
                         <div
-                          class="sc-gKsewC cgpPfo sc-iBPRYJ ildvdb sc-hHftDr jpCUGc sc-dtTInj bKkgfk rendition-form-description"
+                          class="sc-gKsewC cgpPfo sc-iBPRYJ ildvdb sc-hHftDr jpCUGc sc-fHuLdG dFHllN rendition-form-description"
                           id="root_tags__description"
                         >
                           <div
-                            class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-hYZPRl gyTNli"
+                            class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-dRPiIx qUHcx"
                           >
                             <div>
                               <p
@@ -1937,7 +1937,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
 exports[`Storyshots Core/Form Secondary Action 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV"
@@ -1946,7 +1946,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
         class="sc-gKsewC dWcnb sc-iBPRYJ jsPsJf"
       >
         <div
-          class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-kYrkKh fXKnbV"
+          class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hzMMCg juuWBr"
         >
           <form
             class="rjsf"
@@ -1956,7 +1956,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
             >
               <section>
                 <legend
-                  class="sc-dkIXFM ceKNxn"
+                  class="sc-dtTInj cRySGv"
                   id="root__title"
                 >
                   Pokèmon
@@ -1971,7 +1971,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-string rendition-form__field--root_Name"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_Name"
                       >
                         Name
@@ -2003,7 +2003,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-number rendition-form__field--root_Height"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_Height"
                       >
                         Height
@@ -2030,7 +2030,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-number rendition-form__field--root_Weight"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_Weight"
                       >
                         Weight
@@ -2057,7 +2057,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-string rendition-form__field--root_Description"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_Description"
                       >
                         Description
@@ -2084,7 +2084,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-string rendition-form__field--root_Category"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_Category"
                       >
                         Category
@@ -2111,7 +2111,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-string rendition-form__field--root_Abilities"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_Abilities"
                       >
                         Abilities
@@ -2138,7 +2138,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-number rendition-form__field--root_pokedex_number"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_pokedex_number"
                       >
                         National Pokèdex Number
@@ -2186,17 +2186,17 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-string rendition-form__field--root_first_seen"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_first_seen"
                       >
                         First seen
                       </label>
                       <div
-                        class="sc-gKsewC cgpPfo sc-iBPRYJ ildvdb sc-hHftDr jpCUGc sc-dtTInj bKkgfk rendition-form-description"
+                        class="sc-gKsewC cgpPfo sc-iBPRYJ ildvdb sc-hHftDr jpCUGc sc-fHuLdG dFHllN rendition-form-description"
                         id="root_first_seen__description"
                       >
                         <div
-                          class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-hYZPRl gyTNli"
+                          class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-dRPiIx qUHcx"
                         >
                           <div>
                             <p
@@ -2229,17 +2229,17 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-string rendition-form__field--root_poke_password"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_poke_password"
                       >
                         Poke Password
                       </label>
                       <div
-                        class="sc-gKsewC cgpPfo sc-iBPRYJ ildvdb sc-hHftDr jpCUGc sc-dtTInj bKkgfk rendition-form-description"
+                        class="sc-gKsewC cgpPfo sc-iBPRYJ ildvdb sc-hHftDr jpCUGc sc-fHuLdG dFHllN rendition-form-description"
                         id="root_poke_password__description"
                       >
                         <div
-                          class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-hYZPRl gyTNli"
+                          class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-dRPiIx qUHcx"
                         >
                           <div>
                             <p
@@ -2272,7 +2272,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-string rendition-form__field--root_environment"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_environment"
                       >
                         environment
@@ -2336,17 +2336,17 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                     >
                       <div>
                         <legend
-                          class="sc-dkIXFM ceKNxn"
+                          class="sc-dtTInj cRySGv"
                           id="root_tags__title"
                         >
                           Tags
                         </legend>
                         <div
-                          class="sc-gKsewC cgpPfo sc-iBPRYJ ildvdb sc-hHftDr jpCUGc sc-dtTInj bKkgfk rendition-form-description"
+                          class="sc-gKsewC cgpPfo sc-iBPRYJ ildvdb sc-hHftDr jpCUGc sc-fHuLdG dFHllN rendition-form-description"
                           id="root_tags__description"
                         >
                           <div
-                            class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-hYZPRl gyTNli"
+                            class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-dRPiIx qUHcx"
                           >
                             <div>
                               <p
@@ -2425,7 +2425,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
 exports[`Storyshots Core/Form With Dependants 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV"
@@ -2434,7 +2434,7 @@ exports[`Storyshots Core/Form With Dependants 1`] = `
         class="sc-gKsewC dWcnb sc-iBPRYJ jsPsJf"
       >
         <div
-          class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-kYrkKh fXKnbV"
+          class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hzMMCg juuWBr"
         >
           <form
             class="rjsf"
@@ -2454,7 +2454,7 @@ exports[`Storyshots Core/Form With Dependants 1`] = `
                     >
                       <div>
                         <legend
-                          class="sc-dkIXFM ceKNxn"
+                          class="sc-dtTInj cRySGv"
                           id="root_application_config_variable__title"
                         >
                           Application configuration variables
@@ -2498,7 +2498,7 @@ exports[`Storyshots Core/Form With Dependants 1`] = `
                     >
                       <div>
                         <legend
-                          class="sc-dkIXFM ceKNxn"
+                          class="sc-dtTInj cRySGv"
                           id="root_application_environment_variable__title"
                         >
                           Application environment variables
@@ -2565,13 +2565,13 @@ exports[`Storyshots Core/Form With Dependants 1`] = `
 exports[`Storyshots Core/Form With Extra Widgets 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="sc-gKsewC cgpPfo sc-iBPRYJ gjBBNx"
     >
       <div
-        class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-hYZPRl gyTNli"
+        class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-dRPiIx qUHcx"
       >
         <div>
           <h1
@@ -3260,7 +3260,7 @@ Rendition contains widgets for rendering Markdown and Mermaid text formats that 
         class="sc-gKsewC dWcnb sc-iBPRYJ jsPsJf"
       >
         <div
-          class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-kYrkKh fXKnbV"
+          class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hzMMCg juuWBr"
         >
           <form
             class="rjsf"
@@ -3279,7 +3279,7 @@ Rendition contains widgets for rendering Markdown and Mermaid text formats that 
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-string rendition-form__field--root_Mermaid"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_Mermaid"
                       >
                         Mermaid
@@ -3340,7 +3340,7 @@ Rendition contains widgets for rendering Markdown and Mermaid text formats that 
                         </div>
                       </div>
                       <a
-                        class="sc-eGCarw kBARfK sc-ctaXAZ dZrgeb"
+                        class="sc-bXDlPE lhITcI sc-eGCarw kjnpKH"
                         color="primary.main"
                         href="https://mermaidjs.github.io/"
                         rel="noopener"
@@ -3357,13 +3357,13 @@ Rendition contains widgets for rendering Markdown and Mermaid text formats that 
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-string rendition-form__field--root_Markdown"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_Markdown"
                       >
                         Markdown
                       </label>
                       <div
-                        class="sc-tkKAw ddBawh"
+                        class="sc-bUrJUP bSArhB"
                         id="simplemde-editor-1-wrapper"
                       >
                         <textarea
@@ -3648,13 +3648,13 @@ Rendition contains widgets for rendering Markdown and Mermaid text formats that 
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-string rendition-form__field--root_Captcha"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_Captcha"
                       >
                         Captcha
                       </label>
                       <div
-                        class="sc-dRPiIx hnviSm"
+                        class="sc-tkKAw ihyLmG"
                       />
                     </div>
                   </div>
@@ -3689,7 +3689,7 @@ Rendition contains widgets for rendering Markdown and Mermaid text formats that 
 exports[`Storyshots Core/Form With Help Text 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV"
@@ -3698,7 +3698,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
         class="sc-gKsewC dWcnb sc-iBPRYJ jsPsJf"
       >
         <div
-          class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-kYrkKh fXKnbV"
+          class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hzMMCg juuWBr"
         >
           <form
             class="rjsf"
@@ -3708,7 +3708,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
             >
               <section>
                 <legend
-                  class="sc-dkIXFM ceKNxn"
+                  class="sc-dtTInj cRySGv"
                   id="root__title"
                 >
                   Pokèmon
@@ -3723,7 +3723,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-string rendition-form__field--root_Name"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_Name"
                       >
                         Name
@@ -3747,11 +3747,11 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                         id="dummy-datalist"
                       />
                       <div
-                        class="sc-gKsewC cgpPfo sc-iBPRYJ ildvdb sc-hHftDr jpCUGc sc-dtTInj goZdpp rendition-form-help"
+                        class="sc-gKsewC cgpPfo sc-iBPRYJ ildvdb sc-hHftDr jpCUGc sc-fHuLdG iLNHZk rendition-form-help"
                         id="root_Name"
                       >
                         <div
-                          class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-hYZPRl gyTNli"
+                          class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-dRPiIx qUHcx"
                         >
                           <div>
                             <p
@@ -3796,7 +3796,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-string rendition-form__field--root_Description"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_Description"
                       >
                         Description
@@ -3816,7 +3816,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-string rendition-form__field--root_Abilities"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_Abilities"
                       >
                         Abilities
@@ -3843,7 +3843,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-number rendition-form__field--root_Height"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_Height"
                       >
                         Height
@@ -3870,7 +3870,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-number rendition-form__field--root_Weight"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_Weight"
                       >
                         Weight
@@ -3897,7 +3897,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-string rendition-form__field--root_Category"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_Category"
                       >
                         Category
@@ -3924,7 +3924,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-number rendition-form__field--root_pokedex_number"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_pokedex_number"
                       >
                         National Pokèdex Number
@@ -3951,17 +3951,17 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-string rendition-form__field--root_first_seen"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_first_seen"
                       >
                         First seen
                       </label>
                       <div
-                        class="sc-gKsewC cgpPfo sc-iBPRYJ ildvdb sc-hHftDr jpCUGc sc-dtTInj bKkgfk rendition-form-description"
+                        class="sc-gKsewC cgpPfo sc-iBPRYJ ildvdb sc-hHftDr jpCUGc sc-fHuLdG dFHllN rendition-form-description"
                         id="root_first_seen__description"
                       >
                         <div
-                          class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-hYZPRl gyTNli"
+                          class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-dRPiIx qUHcx"
                         >
                           <div>
                             <p
@@ -3994,17 +3994,17 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-string rendition-form__field--root_poke_password"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_poke_password"
                       >
                         Poke Password
                       </label>
                       <div
-                        class="sc-gKsewC cgpPfo sc-iBPRYJ ildvdb sc-hHftDr jpCUGc sc-dtTInj bKkgfk rendition-form-description"
+                        class="sc-gKsewC cgpPfo sc-iBPRYJ ildvdb sc-hHftDr jpCUGc sc-fHuLdG dFHllN rendition-form-description"
                         id="root_poke_password__description"
                       >
                         <div
-                          class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-hYZPRl gyTNli"
+                          class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-dRPiIx qUHcx"
                         >
                           <div>
                             <p
@@ -4032,7 +4032,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                           />
                         </div>
                         <button
-                          class="StyledButton-sc-323bzc-0 LKyTv sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk exHnkK sc-biBrSq ZCFfT"
+                          class="StyledButton-sc-323bzc-0 LKyTv sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk exHnkK sc-tYoTV BPTAG"
                           type="button"
                         >
                           <svg
@@ -4061,7 +4061,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-string rendition-form__field--root_environment"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_environment"
                       >
                         environment
@@ -4125,17 +4125,17 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                     >
                       <div>
                         <legend
-                          class="sc-dkIXFM ceKNxn"
+                          class="sc-dtTInj cRySGv"
                           id="root_tags__title"
                         >
                           Tags
                         </legend>
                         <div
-                          class="sc-gKsewC cgpPfo sc-iBPRYJ ildvdb sc-hHftDr jpCUGc sc-dtTInj bKkgfk rendition-form-description"
+                          class="sc-gKsewC cgpPfo sc-iBPRYJ ildvdb sc-hHftDr jpCUGc sc-fHuLdG dFHllN rendition-form-description"
                           id="root_tags__description"
                         >
                           <div
-                            class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-hYZPRl gyTNli"
+                            class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-dRPiIx qUHcx"
                           >
                             <div>
                               <p
@@ -4208,7 +4208,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
 exports[`Storyshots Core/Form With Pattern Properties 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV"
@@ -4217,7 +4217,7 @@ exports[`Storyshots Core/Form With Pattern Properties 1`] = `
         class="sc-gKsewC dWcnb sc-iBPRYJ jsPsJf"
       >
         <div
-          class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-kYrkKh fXKnbV"
+          class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hzMMCg juuWBr"
         >
           <form
             class="rjsf"
@@ -4237,7 +4237,7 @@ exports[`Storyshots Core/Form With Pattern Properties 1`] = `
                     >
                       <section>
                         <legend
-                          class="sc-dkIXFM ceKNxn"
+                          class="sc-dtTInj cRySGv"
                           id="root_dynamicObject__title"
                         >
                           Rules
@@ -4329,7 +4329,7 @@ exports[`Storyshots Core/Form With Pattern Properties 1`] = `
 exports[`Storyshots Core/Form With Titles 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV"
@@ -4338,7 +4338,7 @@ exports[`Storyshots Core/Form With Titles 1`] = `
         class="sc-gKsewC dWcnb sc-iBPRYJ jsPsJf"
       >
         <div
-          class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-kYrkKh fXKnbV"
+          class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hzMMCg juuWBr"
         >
           <form
             class="rjsf"
@@ -4348,7 +4348,7 @@ exports[`Storyshots Core/Form With Titles 1`] = `
             >
               <section>
                 <legend
-                  class="sc-dkIXFM ceKNxn"
+                  class="sc-dtTInj cRySGv"
                   id="root__title"
                 >
                   Networking
@@ -4364,7 +4364,7 @@ exports[`Storyshots Core/Form With Titles 1`] = `
                     >
                       <section>
                         <legend
-                          class="sc-dkIXFM ceKNxn"
+                          class="sc-dtTInj cRySGv"
                           id="root_vpn__title"
                         >
                           Virtual Private Network
@@ -4379,7 +4379,7 @@ exports[`Storyshots Core/Form With Titles 1`] = `
                               class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-string rendition-form__field--root_vpn_endpoint"
                             >
                               <label
-                                class="sc-ikPAkQ fiANsn control-label"
+                                class="sc-XhUPp AMCaj control-label"
                                 for="root_vpn_endpoint"
                               >
                                 Endpoint
@@ -4406,7 +4406,7 @@ exports[`Storyshots Core/Form With Titles 1`] = `
                               class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-string rendition-form__field--root_vpn_certificate"
                             >
                               <label
-                                class="sc-ikPAkQ fiANsn control-label"
+                                class="sc-XhUPp AMCaj control-label"
                                 for="root_vpn_certificate"
                               >
                                 Certificate
@@ -4438,7 +4438,7 @@ exports[`Storyshots Core/Form With Titles 1`] = `
                     >
                       <section>
                         <legend
-                          class="sc-dkIXFM ceKNxn"
+                          class="sc-dtTInj cRySGv"
                           id="root_wifiNetwork__title"
                         >
                           WiFi Network
@@ -4463,7 +4463,7 @@ exports[`Storyshots Core/Form With Titles 1`] = `
                                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-string rendition-form__field--root_wifiNetwork_wifi_ssid"
                                     >
                                       <label
-                                        class="sc-ikPAkQ fiANsn control-label"
+                                        class="sc-XhUPp AMCaj control-label"
                                         for="root_wifiNetwork_wifi_ssid"
                                       >
                                         Network SSID
@@ -4504,7 +4504,7 @@ exports[`Storyshots Core/Form With Titles 1`] = `
                                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-string rendition-form__field--root_wifiNetwork_wifiSecurity_psk"
                                     >
                                       <label
-                                        class="sc-ikPAkQ fiANsn control-label"
+                                        class="sc-XhUPp AMCaj control-label"
                                         for="root_wifiNetwork_wifiSecurity_psk"
                                       >
                                         Network Passphrase
@@ -4569,7 +4569,7 @@ exports[`Storyshots Core/Form With Titles 1`] = `
 exports[`Storyshots Core/Form With Ui Schema 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV"
@@ -4578,7 +4578,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
         class="sc-gKsewC dWcnb sc-iBPRYJ jsPsJf"
       >
         <div
-          class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-kYrkKh fXKnbV"
+          class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hzMMCg juuWBr"
         >
           <form
             class="rjsf"
@@ -4588,7 +4588,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
             >
               <section>
                 <legend
-                  class="sc-dkIXFM ceKNxn"
+                  class="sc-dtTInj cRySGv"
                   id="root__title"
                 >
                   Pokèmon
@@ -4603,7 +4603,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-string rendition-form__field--root_Name"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_Name"
                       >
                         Name
@@ -4656,7 +4656,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-string rendition-form__field--root_Description"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_Description"
                       >
                         Description
@@ -4676,7 +4676,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-string rendition-form__field--root_Abilities"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_Abilities"
                       >
                         Abilities
@@ -4703,7 +4703,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-number rendition-form__field--root_Height"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_Height"
                       >
                         Height
@@ -4730,7 +4730,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-number rendition-form__field--root_Weight"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_Weight"
                       >
                         Weight
@@ -4757,7 +4757,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-string rendition-form__field--root_Category"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_Category"
                       >
                         Category
@@ -4784,7 +4784,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-number rendition-form__field--root_pokedex_number"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_pokedex_number"
                       >
                         National Pokèdex Number
@@ -4811,17 +4811,17 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-string rendition-form__field--root_first_seen"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_first_seen"
                       >
                         First seen
                       </label>
                       <div
-                        class="sc-gKsewC cgpPfo sc-iBPRYJ ildvdb sc-hHftDr jpCUGc sc-dtTInj bKkgfk rendition-form-description"
+                        class="sc-gKsewC cgpPfo sc-iBPRYJ ildvdb sc-hHftDr jpCUGc sc-fHuLdG dFHllN rendition-form-description"
                         id="root_first_seen__description"
                       >
                         <div
-                          class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-hYZPRl gyTNli"
+                          class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-dRPiIx qUHcx"
                         >
                           <div>
                             <p
@@ -4854,17 +4854,17 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-string rendition-form__field--root_poke_password"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_poke_password"
                       >
                         Poke Password
                       </label>
                       <div
-                        class="sc-gKsewC cgpPfo sc-iBPRYJ ildvdb sc-hHftDr jpCUGc sc-dtTInj bKkgfk rendition-form-description"
+                        class="sc-gKsewC cgpPfo sc-iBPRYJ ildvdb sc-hHftDr jpCUGc sc-fHuLdG dFHllN rendition-form-description"
                         id="root_poke_password__description"
                       >
                         <div
-                          class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-hYZPRl gyTNli"
+                          class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-dRPiIx qUHcx"
                         >
                           <div>
                             <p
@@ -4892,7 +4892,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                           />
                         </div>
                         <button
-                          class="StyledButton-sc-323bzc-0 LKyTv sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk exHnkK sc-biBrSq ZCFfT"
+                          class="StyledButton-sc-323bzc-0 LKyTv sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk exHnkK sc-tYoTV BPTAG"
                           type="button"
                         >
                           <svg
@@ -4921,7 +4921,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-string rendition-form__field--root_environment"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_environment"
                       >
                         environment
@@ -4985,17 +4985,17 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                     >
                       <div>
                         <legend
-                          class="sc-dkIXFM ceKNxn"
+                          class="sc-dtTInj cRySGv"
                           id="root_tags__title"
                         >
                           Tags
                         </legend>
                         <div
-                          class="sc-gKsewC cgpPfo sc-iBPRYJ ildvdb sc-hHftDr jpCUGc sc-dtTInj bKkgfk rendition-form-description"
+                          class="sc-gKsewC cgpPfo sc-iBPRYJ ildvdb sc-hHftDr jpCUGc sc-fHuLdG dFHllN rendition-form-description"
                           id="root_tags__description"
                         >
                           <div
-                            class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-hYZPRl gyTNli"
+                            class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-dRPiIx qUHcx"
                           >
                             <div>
                               <p
@@ -5068,7 +5068,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
 exports[`Storyshots Core/Form With Warning 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV"
@@ -5077,7 +5077,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
         class="sc-gKsewC dWcnb sc-iBPRYJ jsPsJf"
       >
         <div
-          class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-kYrkKh fXKnbV"
+          class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hzMMCg juuWBr"
         >
           <form
             class="rjsf"
@@ -5087,7 +5087,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
             >
               <section>
                 <legend
-                  class="sc-dkIXFM ceKNxn"
+                  class="sc-dtTInj cRySGv"
                   id="root__title"
                 >
                   Pokèmon
@@ -5102,7 +5102,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-string rendition-form__field--root_Name"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_Name"
                       >
                         Name
@@ -5133,10 +5133,10 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                           class="sc-fKFyDc jHCVxA sc-iwyYcG dgyEur"
                         >
                           <div
-                            class="sc-gKsewC cgpPfo sc-iBPRYJ ildvdb sc-hHftDr jpCUGc sc-dtTInj iyfbTY"
+                            class="sc-gKsewC cgpPfo sc-iBPRYJ ildvdb sc-hHftDr jpCUGc sc-fHuLdG hgNYmR"
                           >
                             <div
-                              class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-hYZPRl gyTNli"
+                              class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-dRPiIx qUHcx"
                             >
                               <div>
                                 <p
@@ -5201,7 +5201,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-string rendition-form__field--root_Description"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_Description"
                       >
                         Description
@@ -5221,7 +5221,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-string rendition-form__field--root_Abilities"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_Abilities"
                       >
                         Abilities
@@ -5248,7 +5248,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-number rendition-form__field--root_Height"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_Height"
                       >
                         Height
@@ -5275,7 +5275,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-number rendition-form__field--root_Weight"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_Weight"
                       >
                         Weight
@@ -5302,7 +5302,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-string rendition-form__field--root_Category"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_Category"
                       >
                         Category
@@ -5329,7 +5329,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-number rendition-form__field--root_pokedex_number"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_pokedex_number"
                       >
                         National Pokèdex Number
@@ -5356,17 +5356,17 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-string rendition-form__field--root_first_seen"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_first_seen"
                       >
                         First seen
                       </label>
                       <div
-                        class="sc-gKsewC cgpPfo sc-iBPRYJ ildvdb sc-hHftDr jpCUGc sc-dtTInj bKkgfk rendition-form-description"
+                        class="sc-gKsewC cgpPfo sc-iBPRYJ ildvdb sc-hHftDr jpCUGc sc-fHuLdG dFHllN rendition-form-description"
                         id="root_first_seen__description"
                       >
                         <div
-                          class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-hYZPRl gyTNli"
+                          class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-dRPiIx qUHcx"
                         >
                           <div>
                             <p
@@ -5399,17 +5399,17 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-string rendition-form__field--root_poke_password"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_poke_password"
                       >
                         Poke Password
                       </label>
                       <div
-                        class="sc-gKsewC cgpPfo sc-iBPRYJ ildvdb sc-hHftDr jpCUGc sc-dtTInj bKkgfk rendition-form-description"
+                        class="sc-gKsewC cgpPfo sc-iBPRYJ ildvdb sc-hHftDr jpCUGc sc-fHuLdG dFHllN rendition-form-description"
                         id="root_poke_password__description"
                       >
                         <div
-                          class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-hYZPRl gyTNli"
+                          class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-dRPiIx qUHcx"
                         >
                           <div>
                             <p
@@ -5437,7 +5437,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                           />
                         </div>
                         <button
-                          class="StyledButton-sc-323bzc-0 LKyTv sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk exHnkK sc-biBrSq ZCFfT"
+                          class="StyledButton-sc-323bzc-0 LKyTv sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk exHnkK sc-tYoTV BPTAG"
                           type="button"
                         >
                           <svg
@@ -5466,7 +5466,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze form-group field field-string rendition-form__field--root_environment"
                     >
                       <label
-                        class="sc-ikPAkQ fiANsn control-label"
+                        class="sc-XhUPp AMCaj control-label"
                         for="root_environment"
                       >
                         environment
@@ -5530,17 +5530,17 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                     >
                       <div>
                         <legend
-                          class="sc-dkIXFM ceKNxn"
+                          class="sc-dtTInj cRySGv"
                           id="root_tags__title"
                         >
                           Tags
                         </legend>
                         <div
-                          class="sc-gKsewC cgpPfo sc-iBPRYJ ildvdb sc-hHftDr jpCUGc sc-dtTInj bKkgfk rendition-form-description"
+                          class="sc-gKsewC cgpPfo sc-iBPRYJ ildvdb sc-hHftDr jpCUGc sc-fHuLdG dFHllN rendition-form-description"
                           id="root_tags__description"
                         >
                           <div
-                            class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-hYZPRl gyTNli"
+                            class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-dRPiIx qUHcx"
                           >
                             <div>
                               <p

--- a/src/components/Form/__snapshots__/Form.stories.storyshot
+++ b/src/components/Form/__snapshots__/Form.stories.storyshot
@@ -48,7 +48,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                         
                         <input
                           autocomplete="off"
-                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Name"
                           label="Name"
                           list="dummy-datalist"
@@ -79,7 +79,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Height"
                           label="Height"
                           placeholder=""
@@ -106,7 +106,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Weight"
                           label="Weight"
                           placeholder=""
@@ -133,7 +133,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Description"
                           label="Description"
                           placeholder=""
@@ -160,7 +160,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Category"
                           label="Category"
                           placeholder=""
@@ -187,7 +187,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Abilities"
                           label="Abilities"
                           placeholder=""
@@ -214,7 +214,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_pokedex_number"
                           label="National Pokèdex Number"
                           placeholder=""
@@ -278,7 +278,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_first_seen"
                           label="First seen"
                           placeholder=""
@@ -321,7 +321,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_poke_password"
                           label="Poke Password"
                           placeholder=""
@@ -363,7 +363,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                               >
                                 <input
                                   autocomplete="off"
-                                  class="StyledTextInput-sc-1x30a0s-0 AKkVg Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP kMEjWZ"
+                                  class="StyledTextInput-sc-1x30a0s-0 ccRbRh Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP kMEjWZ"
                                   id="root_environment__input"
                                   readonly=""
                                   tabindex="-1"
@@ -530,7 +530,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                         
                         <input
                           autocomplete="off"
-                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Name"
                           label="Name"
                           list="dummy-datalist"
@@ -561,7 +561,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Height"
                           label="Height"
                           placeholder=""
@@ -588,7 +588,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Weight"
                           label="Weight"
                           placeholder=""
@@ -615,7 +615,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Description"
                           label="Description"
                           placeholder=""
@@ -642,7 +642,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Category"
                           label="Category"
                           placeholder=""
@@ -669,7 +669,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Abilities"
                           label="Abilities"
                           placeholder=""
@@ -696,7 +696,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_pokedex_number"
                           label="National Pokèdex Number"
                           placeholder=""
@@ -760,7 +760,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_first_seen"
                           label="First seen"
                           placeholder=""
@@ -803,7 +803,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_poke_password"
                           label="Poke Password"
                           placeholder=""
@@ -845,7 +845,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                               >
                                 <input
                                   autocomplete="off"
-                                  class="StyledTextInput-sc-1x30a0s-0 AKkVg Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP kMEjWZ"
+                                  class="StyledTextInput-sc-1x30a0s-0 ccRbRh Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP kMEjWZ"
                                   id="root_environment__input"
                                   readonly=""
                                   tabindex="-1"
@@ -1012,7 +1012,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                         
                         <input
                           autocomplete="off"
-                          class="StyledTextInput-sc-1x30a0s-0 bTnlqC sc-jgHCyG kmycqX sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 gCxMXz sc-jgHCyG kmycqX sc-gTgzIj eNaHvD"
                           disabled=""
                           id="root_Name"
                           label="Name"
@@ -1044,7 +1044,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 bTnlqC sc-jgHCyG kmycqX sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 gCxMXz sc-jgHCyG kmycqX sc-gTgzIj eNaHvD"
                           disabled=""
                           id="root_Height"
                           label="Height"
@@ -1072,7 +1072,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 bTnlqC sc-jgHCyG kmycqX sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 gCxMXz sc-jgHCyG kmycqX sc-gTgzIj eNaHvD"
                           disabled=""
                           id="root_Weight"
                           label="Weight"
@@ -1100,7 +1100,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 bTnlqC sc-jgHCyG kmycqX sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 gCxMXz sc-jgHCyG kmycqX sc-gTgzIj eNaHvD"
                           disabled=""
                           id="root_Description"
                           label="Description"
@@ -1128,7 +1128,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 bTnlqC sc-jgHCyG kmycqX sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 gCxMXz sc-jgHCyG kmycqX sc-gTgzIj eNaHvD"
                           disabled=""
                           id="root_Category"
                           label="Category"
@@ -1156,7 +1156,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 bTnlqC sc-jgHCyG kmycqX sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 gCxMXz sc-jgHCyG kmycqX sc-gTgzIj eNaHvD"
                           disabled=""
                           id="root_Abilities"
                           label="Abilities"
@@ -1184,7 +1184,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 bTnlqC sc-jgHCyG kmycqX sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 gCxMXz sc-jgHCyG kmycqX sc-gTgzIj eNaHvD"
                           disabled=""
                           id="root_pokedex_number"
                           label="National Pokèdex Number"
@@ -1250,7 +1250,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 bTnlqC sc-jgHCyG kmycqX sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 gCxMXz sc-jgHCyG kmycqX sc-gTgzIj eNaHvD"
                           disabled=""
                           id="root_first_seen"
                           label="First seen"
@@ -1294,7 +1294,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 bTnlqC sc-jgHCyG kmycqX sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 gCxMXz sc-jgHCyG kmycqX sc-gTgzIj eNaHvD"
                           disabled=""
                           id="root_poke_password"
                           label="Poke Password"
@@ -1338,7 +1338,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                               >
                                 <input
                                   autocomplete="off"
-                                  class="StyledTextInput-sc-1x30a0s-0 AKkVg Select__SelectTextInput-sc-17idtfo-0 cANsmG sc-jeGSBP kMEjWZ"
+                                  class="StyledTextInput-sc-1x30a0s-0 ccRbRh Select__SelectTextInput-sc-17idtfo-0 cANsmG sc-jeGSBP kMEjWZ"
                                   id="root_environment__input"
                                   readonly=""
                                   tabindex="-1"
@@ -1505,7 +1505,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                         
                         <input
                           autocomplete="off"
-                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Name"
                           label="Name"
                           list="dummy-datalist"
@@ -1536,7 +1536,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Height"
                           label="Height"
                           placeholder=""
@@ -1563,7 +1563,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Weight"
                           label="Weight"
                           placeholder=""
@@ -1590,7 +1590,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Description"
                           label="Description"
                           placeholder=""
@@ -1617,7 +1617,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Category"
                           label="Category"
                           placeholder=""
@@ -1644,7 +1644,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Abilities"
                           label="Abilities"
                           placeholder=""
@@ -1671,7 +1671,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_pokedex_number"
                           label="National Pokèdex Number"
                           placeholder=""
@@ -1735,7 +1735,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_first_seen"
                           label="First seen"
                           placeholder=""
@@ -1778,7 +1778,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_poke_password"
                           label="Poke Password"
                           placeholder=""
@@ -1820,7 +1820,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                               >
                                 <input
                                   autocomplete="off"
-                                  class="StyledTextInput-sc-1x30a0s-0 AKkVg Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP kMEjWZ"
+                                  class="StyledTextInput-sc-1x30a0s-0 ccRbRh Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP kMEjWZ"
                                   id="root_environment__input"
                                   readonly=""
                                   tabindex="-1"
@@ -1982,7 +1982,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                         
                         <input
                           autocomplete="off"
-                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Name"
                           label="Name"
                           list="dummy-datalist"
@@ -2013,7 +2013,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Height"
                           label="Height"
                           placeholder=""
@@ -2040,7 +2040,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Weight"
                           label="Weight"
                           placeholder=""
@@ -2067,7 +2067,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Description"
                           label="Description"
                           placeholder=""
@@ -2094,7 +2094,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Category"
                           label="Category"
                           placeholder=""
@@ -2121,7 +2121,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Abilities"
                           label="Abilities"
                           placeholder=""
@@ -2148,7 +2148,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_pokedex_number"
                           label="National Pokèdex Number"
                           placeholder=""
@@ -2212,7 +2212,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_first_seen"
                           label="First seen"
                           placeholder=""
@@ -2255,7 +2255,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_poke_password"
                           label="Poke Password"
                           placeholder=""
@@ -2297,7 +2297,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                               >
                                 <input
                                   autocomplete="off"
-                                  class="StyledTextInput-sc-1x30a0s-0 AKkVg Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP kMEjWZ"
+                                  class="StyledTextInput-sc-1x30a0s-0 ccRbRh Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP kMEjWZ"
                                   id="root_environment__input"
                                   readonly=""
                                   tabindex="-1"
@@ -3734,7 +3734,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                         
                         <input
                           autocomplete="off"
-                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Name"
                           label="Name"
                           list="dummy-datalist"
@@ -3826,7 +3826,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Abilities"
                           label="Abilities"
                           placeholder=""
@@ -3853,7 +3853,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG jDTnAL sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG jDTnAL sc-gTgzIj eNaHvD"
                           id="root_Height"
                           label="Height"
                           placeholder=""
@@ -3880,7 +3880,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Weight"
                           label="Weight"
                           placeholder=""
@@ -3907,7 +3907,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Category"
                           label="Category"
                           placeholder=""
@@ -3934,7 +3934,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_pokedex_number"
                           label="National Pokèdex Number"
                           placeholder=""
@@ -3977,7 +3977,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_first_seen"
                           label="First seen"
                           placeholder=""
@@ -4023,7 +4023,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                         >
                           
                           <input
-                            class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj kDmtQx"
+                            class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj kDmtQx"
                             id="root_poke_password"
                             label="Poke Password"
                             placeholder=""
@@ -4086,7 +4086,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                               >
                                 <input
                                   autocomplete="off"
-                                  class="StyledTextInput-sc-1x30a0s-0 AKkVg Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP iqwkEO"
+                                  class="StyledTextInput-sc-1x30a0s-0 ccRbRh Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP iqwkEO"
                                   id="root_environment__input"
                                   readonly=""
                                   tabindex="-1"
@@ -4267,7 +4267,7 @@ exports[`Storyshots Core/Form With Pattern Properties 1`] = `
                                     >
                                       <input
                                         autocomplete="off"
-                                        class="StyledTextInput-sc-1x30a0s-0 bTnlqC sc-jgHCyG kmycqX sc-gTgzIj cjgnvU rendition-form-pattern-properties__key-field"
+                                        class="StyledTextInput-sc-1x30a0s-0 gCxMXz sc-jgHCyG kmycqX sc-gTgzIj cjgnvU rendition-form-pattern-properties__key-field"
                                         disabled=""
                                         pattern="^[0-9]+$"
                                         placeholder="Key"
@@ -4281,7 +4281,7 @@ exports[`Storyshots Core/Form With Pattern Properties 1`] = `
                                     >
                                       <input
                                         autocomplete="off"
-                                        class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj cjgnvU rendition-form-pattern-properties__value-field"
+                                        class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj cjgnvU rendition-form-pattern-properties__value-field"
                                         id="foo"
                                         placeholder="Rule"
                                         value=""
@@ -4389,7 +4389,7 @@ exports[`Storyshots Core/Form With Titles 1`] = `
                               >
                                 
                                 <input
-                                  class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                                  class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                                   id="root_vpn_endpoint"
                                   label="Endpoint"
                                   placeholder=""
@@ -4416,7 +4416,7 @@ exports[`Storyshots Core/Form With Titles 1`] = `
                               >
                                 
                                 <input
-                                  class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                                  class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                                   id="root_vpn_certificate"
                                   label="Certificate"
                                   placeholder=""
@@ -4473,7 +4473,7 @@ exports[`Storyshots Core/Form With Titles 1`] = `
                                       >
                                         
                                         <input
-                                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                                           id="root_wifiNetwork_wifi_ssid"
                                           label="Network SSID"
                                           placeholder=""
@@ -4514,7 +4514,7 @@ exports[`Storyshots Core/Form With Titles 1`] = `
                                       >
                                         
                                         <input
-                                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                                           id="root_wifiNetwork_wifiSecurity_psk"
                                           label="Network Passphrase"
                                           placeholder=""
@@ -4614,7 +4614,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                         
                         <input
                           autocomplete="off"
-                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Name"
                           label="Name"
                           list="dummy-datalist"
@@ -4686,7 +4686,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Abilities"
                           label="Abilities"
                           placeholder=""
@@ -4713,7 +4713,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG jDTnAL sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG jDTnAL sc-gTgzIj eNaHvD"
                           id="root_Height"
                           label="Height"
                           placeholder=""
@@ -4740,7 +4740,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Weight"
                           label="Weight"
                           placeholder=""
@@ -4767,7 +4767,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Category"
                           label="Category"
                           placeholder=""
@@ -4794,7 +4794,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_pokedex_number"
                           label="National Pokèdex Number"
                           placeholder=""
@@ -4837,7 +4837,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_first_seen"
                           label="First seen"
                           placeholder=""
@@ -4883,7 +4883,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                         >
                           
                           <input
-                            class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj kDmtQx"
+                            class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj kDmtQx"
                             id="root_poke_password"
                             label="Poke Password"
                             placeholder=""
@@ -4946,7 +4946,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                               >
                                 <input
                                   autocomplete="off"
-                                  class="StyledTextInput-sc-1x30a0s-0 AKkVg Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP iqwkEO"
+                                  class="StyledTextInput-sc-1x30a0s-0 ccRbRh Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP iqwkEO"
                                   id="root_environment__input"
                                   readonly=""
                                   tabindex="-1"
@@ -5159,7 +5159,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                         
                         <input
                           autocomplete="off"
-                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Name"
                           label="Name"
                           list="dummy-datalist"
@@ -5231,7 +5231,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Abilities"
                           label="Abilities"
                           placeholder=""
@@ -5258,7 +5258,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG jDTnAL sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG jDTnAL sc-gTgzIj eNaHvD"
                           id="root_Height"
                           label="Height"
                           placeholder=""
@@ -5285,7 +5285,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Weight"
                           label="Weight"
                           placeholder=""
@@ -5312,7 +5312,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Category"
                           label="Category"
                           placeholder=""
@@ -5339,7 +5339,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_pokedex_number"
                           label="National Pokèdex Number"
                           placeholder=""
@@ -5382,7 +5382,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_first_seen"
                           label="First seen"
                           placeholder=""
@@ -5428,7 +5428,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                         >
                           
                           <input
-                            class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj kDmtQx"
+                            class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj kDmtQx"
                             id="root_poke_password"
                             label="Poke Password"
                             placeholder=""
@@ -5491,7 +5491,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                               >
                                 <input
                                   autocomplete="off"
-                                  class="StyledTextInput-sc-1x30a0s-0 AKkVg Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP iqwkEO"
+                                  class="StyledTextInput-sc-1x30a0s-0 ccRbRh Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP iqwkEO"
                                   id="root_environment__input"
                                   readonly=""
                                   tabindex="-1"

--- a/src/components/Form/__snapshots__/spec.tsx.snap
+++ b/src/components/Form/__snapshots__/spec.tsx.snap
@@ -1,5 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Form component description keyword should support markdown 1`] = `"<div id=\\"root_foo__description\\" class=\\"sc-gKsewC cgpPfo sc-iBPRYJ ildvdb sc-hHftDr jpCUGc sc-dtTInj bKkgfk rendition-form-description\\"><div class=\\"sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI\\">Lorem ipsum *dolor* sit amet</div></div>"`;
+exports[`Form component description keyword should support markdown 1`] = `"<div id=\\"root_foo__description\\" class=\\"sc-gKsewC cgpPfo sc-iBPRYJ ildvdb sc-hHftDr jpCUGc sc-fHuLdG dFHllN rendition-form-description\\"><div class=\\"sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI\\">Lorem ipsum *dolor* sit amet</div></div>"`;
 
-exports[`Form component ui:help keyword should support markdown 1`] = `"<div id=\\"root_foo\\" class=\\"sc-gKsewC cgpPfo sc-iBPRYJ ildvdb sc-hHftDr jpCUGc sc-dtTInj goZdpp rendition-form-help\\"><div class=\\"sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI\\">Lorem ipsum *dolor* sit amet</div></div>"`;
+exports[`Form component ui:help keyword should support markdown 1`] = `"<div id=\\"root_foo\\" class=\\"sc-gKsewC cgpPfo sc-iBPRYJ ildvdb sc-hHftDr jpCUGc sc-fHuLdG iLNHZk rendition-form-help\\"><div class=\\"sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI\\">Lorem ipsum *dolor* sit amet</div></div>"`;

--- a/src/components/Heading/__snapshots__/Heading.stories.storyshot
+++ b/src/components/Heading/__snapshots__/Heading.stories.storyshot
@@ -6,7 +6,7 @@ exports[`Storyshots Core/Heading Default 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
   >
     <h3
-      class="sc-gWHgXt eCVPSB sc-cBNfnY hJuLdz"
+      class="sc-iktFzd ePMNkU sc-jJEJSO kYibbK"
     >
       Heading h3
     </h3>
@@ -20,7 +20,7 @@ exports[`Storyshots Core/Heading H 1 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
   >
     <h1
-      class="sc-gWHgXt eCVPSB sc-citwmv gCCLOD"
+      class="sc-iktFzd ePMNkU sc-hiSbYr hwRkKu"
     >
       Heading h1
     </h1>
@@ -34,7 +34,7 @@ exports[`Storyshots Core/Heading H 2 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
   >
     <h2
-      class="sc-gWHgXt eCVPSB sc-jcVebW fcdKNU"
+      class="sc-iktFzd ePMNkU sc-gWHgXt goapnY"
     >
       Heading h2
     </h2>
@@ -48,7 +48,7 @@ exports[`Storyshots Core/Heading H 3 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
   >
     <h3
-      class="sc-gWHgXt eCVPSB sc-bZSQDF QBWsK"
+      class="sc-iktFzd ePMNkU sc-cBNfnY hcRIY"
     >
       Heading h3
     </h3>
@@ -62,7 +62,7 @@ exports[`Storyshots Core/Heading H 4 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
   >
     <h4
-      class="sc-gWHgXt vKAIQ sc-iUuytg hGhxwq"
+      class="sc-iktFzd bZzDXR sc-citwmv hsEgEr"
     >
       Heading h4
     </h4>
@@ -76,7 +76,7 @@ exports[`Storyshots Core/Heading H 5 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
   >
     <h5
-      class="sc-gWHgXt vKAIQ sc-iBaPrD eWrQCP"
+      class="sc-iktFzd bZzDXR sc-jcVebW huUMIs"
     >
       Heading h5
     </h5>

--- a/src/components/Heading/__snapshots__/Heading.stories.storyshot
+++ b/src/components/Heading/__snapshots__/Heading.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/Heading Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <h3
       class="sc-iktFzd ePMNkU sc-jJEJSO kYibbK"
@@ -17,7 +17,7 @@ exports[`Storyshots Core/Heading Default 1`] = `
 exports[`Storyshots Core/Heading H 1 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <h1
       class="sc-iktFzd ePMNkU sc-hiSbYr hwRkKu"
@@ -31,7 +31,7 @@ exports[`Storyshots Core/Heading H 1 1`] = `
 exports[`Storyshots Core/Heading H 2 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <h2
       class="sc-iktFzd ePMNkU sc-gWHgXt goapnY"
@@ -45,7 +45,7 @@ exports[`Storyshots Core/Heading H 2 1`] = `
 exports[`Storyshots Core/Heading H 3 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <h3
       class="sc-iktFzd ePMNkU sc-cBNfnY hcRIY"
@@ -59,7 +59,7 @@ exports[`Storyshots Core/Heading H 3 1`] = `
 exports[`Storyshots Core/Heading H 4 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <h4
       class="sc-iktFzd bZzDXR sc-citwmv hsEgEr"
@@ -73,7 +73,7 @@ exports[`Storyshots Core/Heading H 4 1`] = `
 exports[`Storyshots Core/Heading H 5 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <h5
       class="sc-iktFzd bZzDXR sc-jcVebW huUMIs"

--- a/src/components/HighlightedName/__snapshots__/HighlightedName.stories.storyshot
+++ b/src/components/HighlightedName/__snapshots__/HighlightedName.stories.storyshot
@@ -3,10 +3,10 @@
 exports[`Storyshots Core/HighlightedName Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <span
-      class="sc-fKFyDc jHCVxA sc-iwyYcG gAkelF sc-GTWni eVmJHO sc-gsxnyZ dHyYZs"
+      class="sc-fKFyDc jHCVxA sc-iwyYcG gAkelF sc-fbNXWD xnzqE sc-GTWni VLWRW"
     >
       Frontend Service
     </span>
@@ -17,10 +17,10 @@ exports[`Storyshots Core/HighlightedName Default 1`] = `
 exports[`Storyshots Core/HighlightedName With Custom Colors 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <span
-      class="sc-fKFyDc jHCVxA sc-iwyYcG brBCdy sc-GTWni eVmJHO sc-gsxnyZ gQsiKP"
+      class="sc-fKFyDc jHCVxA sc-iwyYcG brBCdy sc-fbNXWD xnzqE sc-GTWni dbLoyB"
     >
       Frontend Service
     </span>

--- a/src/components/Img/__snapshots__/Img.stories.storyshot
+++ b/src/components/Img/__snapshots__/Img.stories.storyshot
@@ -3,10 +3,10 @@
 exports[`Storyshots Core/Img Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <img
-      class="sc-bXDlPE YPfIL"
+      class="sc-gsxnyZ dsPZMt"
       src=""
     />
   </div>
@@ -16,10 +16,10 @@ exports[`Storyshots Core/Img Default 1`] = `
 exports[`Storyshots Core/Img With Fallback 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <img
-      class="sc-bXDlPE YPfIL"
+      class="sc-gsxnyZ dsPZMt"
       src="imgthatfails"
     />
   </div>

--- a/src/components/Input/__snapshots__/Input.stories.storyshot
+++ b/src/components/Input/__snapshots__/Input.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/Input Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 dpaJQp"
@@ -21,7 +21,7 @@ exports[`Storyshots Core/Input Default 1`] = `
 exports[`Storyshots Core/Input Emphasized 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 dpaJQp"
@@ -39,7 +39,7 @@ exports[`Storyshots Core/Input Emphasized 1`] = `
 exports[`Storyshots Core/Input Monospace 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 dpaJQp"
@@ -57,7 +57,7 @@ exports[`Storyshots Core/Input Monospace 1`] = `
 exports[`Storyshots Core/Input With Placeholder 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 dpaJQp"

--- a/src/components/Input/__snapshots__/Input.stories.storyshot
+++ b/src/components/Input/__snapshots__/Input.stories.storyshot
@@ -10,7 +10,7 @@ exports[`Storyshots Core/Input Default 1`] = `
     >
       <input
         autocomplete="off"
-        class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj cjgnvU"
+        class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj cjgnvU"
         value=""
       />
     </div>
@@ -28,7 +28,7 @@ exports[`Storyshots Core/Input Emphasized 1`] = `
     >
       <input
         autocomplete="off"
-        class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG jDTnAL sc-gTgzIj cjgnvU"
+        class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG jDTnAL sc-gTgzIj cjgnvU"
         value=""
       />
     </div>
@@ -46,7 +46,7 @@ exports[`Storyshots Core/Input Monospace 1`] = `
     >
       <input
         autocomplete="off"
-        class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG fbrLsF sc-gTgzIj cjgnvU"
+        class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG fbrLsF sc-gTgzIj cjgnvU"
         value=""
       />
     </div>
@@ -64,7 +64,7 @@ exports[`Storyshots Core/Input With Placeholder 1`] = `
     >
       <input
         autocomplete="off"
-        class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj cjgnvU"
+        class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj cjgnvU"
         placeholder="This is a placeholder"
         value=""
       />

--- a/src/components/Link/__snapshots__/Link.stories.storyshot
+++ b/src/components/Link/__snapshots__/Link.stories.storyshot
@@ -3,10 +3,10 @@
 exports[`Storyshots Core/Link Blank Target 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <a
-      class="sc-eGCarw kBARfK sc-ctaXAZ bvFpzE"
+      class="sc-bXDlPE lhITcI sc-eGCarw CequI"
       color="primary.main"
       href="https://balena.io"
       rel="noopener"
@@ -21,10 +21,10 @@ exports[`Storyshots Core/Link Blank Target 1`] = `
 exports[`Storyshots Core/Link Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <a
-      class="sc-eGCarw kBARfK sc-ctaXAZ bvFpzE"
+      class="sc-bXDlPE lhITcI sc-eGCarw CequI"
       color="primary.main"
       href="#"
     >
@@ -37,10 +37,10 @@ exports[`Storyshots Core/Link Default 1`] = `
 exports[`Storyshots Core/Link Disabled 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <a
-      class="sc-eGCarw xmywi sc-ctaXAZ bvFpzE"
+      class="sc-bXDlPE cfdlbE sc-eGCarw CequI"
       color="primary.main"
       disabled=""
     />

--- a/src/components/List/__snapshots__/List.stories.storyshot
+++ b/src/components/List/__snapshots__/List.stories.storyshot
@@ -3,10 +3,10 @@
 exports[`Storyshots Core/List Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <ul
-      class="sc-dFJsGO sc-gInsOo eOUArm kNgqAg sc-euMpXR gIBRgG"
+      class="sc-ctaXAZ sc-bsipQr joBwOg ljFyiw sc-gInsOo hnacvy"
     >
       <li>
         <div
@@ -14,7 +14,7 @@ exports[`Storyshots Core/List Default 1`] = `
         >
           You can put 
           <a
-            class="sc-eGCarw kBARfK sc-ctaXAZ bvFpzE"
+            class="sc-bXDlPE lhITcI sc-eGCarw CequI"
             color="primary.main"
             href="#"
           >
@@ -52,10 +52,10 @@ exports[`Storyshots Core/List Default 1`] = `
 exports[`Storyshots Core/List Ordered 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <ol
-      class="sc-dFJsGO sc-bsipQr eOUArm cFuukQ sc-euMpXR gIBRgG"
+      class="sc-ctaXAZ sc-dFJsGO joBwOg ktgAws sc-gInsOo hnacvy"
     >
       <li>
         <div
@@ -63,7 +63,7 @@ exports[`Storyshots Core/List Ordered 1`] = `
         >
           You can put 
           <a
-            class="sc-eGCarw kBARfK sc-ctaXAZ bvFpzE"
+            class="sc-bXDlPE lhITcI sc-eGCarw CequI"
             color="primary.main"
             href="#"
           >

--- a/src/components/Map/__snapshots__/Map.stories.storyshot
+++ b/src/components/Map/__snapshots__/Map.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/Map Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       style="height: 600px;"

--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -17,33 +17,61 @@ const NestedModalDemo = (props: Partial<ModalProps>) => {
 			</Button>
 			{show1 && (
 				<Modal
-					title="First Modal"
+					header="First Modal"
 					{...props}
-					cancel={() => {
-						setShow1(false);
-						props.cancel?.();
-					}}
-					done={() => {
-						setShow2(true);
-						props.done?.();
-					}}
-					action="Open another modal"
+					actions={[
+						{
+							title: 'Close',
+							onTriggerAction: () => setShow1(false),
+						},
+						{
+							title: 'Open another modal',
+							type: 'primary',
+							onTriggerAction: () => setShow2(true),
+						},
+					]}
 				>
 					{show2 && (
 						<Modal
-							title="Second Modal"
+							header="Second Modal"
 							{...props}
-							cancel={() => {
-								setShow2(false);
-								props.cancel?.();
-							}}
-							done={() => {
-								setShow2(false);
-								props.done?.();
-							}}
+							actions={[
+								{
+									title: 'Close',
+									onTriggerAction: () => setShow2(false),
+								},
+							]}
 						/>
 					)}
 				</Modal>
+			)}
+		</Box>
+	);
+};
+
+const ModalDemo = ({ actions, ...otherProps }: Partial<ModalProps>) => {
+	const [show1, setShow1] = React.useState(false);
+
+	return (
+		<Box>
+			<Button primary onClick={() => setShow1(true)}>
+				Open Modal
+			</Button>
+			{show1 && (
+				<Modal
+					header="First Modal"
+					{...otherProps}
+					actions={
+						!!actions
+							? actions
+							: [
+									{
+										title: 'Close',
+										onTriggerAction: () => setShow1(false),
+									},
+							  ]
+					}
+				></Modal>
 			)}
 		</Box>
 	);
@@ -54,40 +82,11 @@ export default {
 	component: Modal,
 } as Meta;
 
-const Template = createTemplate<ModalProps>(NestedModalDemo);
+const NestedTemplate = createTemplate<ModalProps>(NestedModalDemo);
+const Template = createTemplate<ModalProps>(ModalDemo);
 
 export const Default = createStory<ModalProps>(Template, {
-	title: 'Modal title',
-	children: (
-		<>
-			<p>Lorem ipsum dolor sit amet</p>
-		</>
-	),
-});
-
-export const CustomAction = createStory<ModalProps>(Template, {
-	title: 'Modal title',
-	children: (
-		<>
-			<p>Lorem ipsum dolor sit amet</p>
-		</>
-	),
-	action: 'Go!',
-});
-
-export const NoCancel = createStory<ModalProps>(Template, {
-	title: 'Modal title',
-	children: (
-		<>
-			<p>Lorem ipsum dolor sit amet</p>
-		</>
-	),
-	// cancel: null,
-});
-
-export const WithTitleDetails = createStory<ModalProps>(Template, {
-	title: 'Modal title',
-	titleDetails: 'Optional details',
+	header: 'Modal title',
 	children: (
 		<>
 			<p>Lorem ipsum dolor sit amet</p>
@@ -96,8 +95,7 @@ export const WithTitleDetails = createStory<ModalProps>(Template, {
 });
 
 export const WithCustomWidth = createStory<ModalProps>(Template, {
-	title: 'Modal title',
-	titleDetails: 'Optional details',
+	header: 'Modal title',
 	width: ['auto', 500, 1000],
 	children: (
 		<>
@@ -107,7 +105,7 @@ export const WithCustomWidth = createStory<ModalProps>(Template, {
 });
 
 export const WithMultielementTitle = createStory<ModalProps>(Template, {
-	titleElement: (
+	header: (
 		<React.Fragment>
 			<Heading.h3>Heading</Heading.h3>
 			<Button mt={3} primary>
@@ -122,25 +120,38 @@ export const WithMultielementTitle = createStory<ModalProps>(Template, {
 	),
 });
 
-export const WithCustomizedButtons = createStory<ModalProps>(Template, {
+export const WithoutActions = createStory<ModalProps>(Template, {
 	title: 'Modal title',
-	secondaryButtonProps: {
-		children: 'Refresh',
-		onClick: () => null,
-	},
-	cancelButtonProps: {
-		children: 'Abort',
-		width: 150,
-		style: {
-			marginRight: 30,
+	actions: [],
+	children: (
+		<>
+			<p>Lorem ipsum dolor sit amet</p>
+		</>
+	),
+});
+
+export const WithActionButtons = createStory<ModalProps>(Template, {
+	title: 'Modal title',
+	actions: [
+		{
+			title: 'Cancel',
+			type: 'none',
+			disabled: true,
 		},
-	},
-	primaryButtonProps: {
-		width: 150,
-		danger: true,
-		primary: false,
-		disabled: true,
-	},
+		{
+			title: 'OK',
+			type: 'primary',
+			disabled: true,
+		},
+		{
+			type: 'danger',
+			title: 'Abort',
+		},
+		{
+			type: 'warning',
+			title: 'Refresh',
+		},
+	],
 	children: (
 		<>
 			<p>Lorem ipsum dolor sit amet</p>
@@ -170,7 +181,7 @@ export const WithTooltip = createStory<ModalProps>(Template, {
 	),
 });
 
-export const Nested = createStory<ModalProps>(Template, {
+export const Nested = createStory<ModalProps>(NestedTemplate, {
 	title: 'Modal title',
 	children: (
 		<>

--- a/src/components/Modal/__snapshots__/Modal.stories.storyshot
+++ b/src/components/Modal/__snapshots__/Modal.stories.storyshot
@@ -1,28 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Storyshots Core/Modal Custom Action 1`] = `
-<div>
-  <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
-  >
-    <div
-      class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP"
-    >
-      <button
-        class="StyledButton-sc-323bzc-0 fGJlAh sc-bqyKva sc-kstrdz gjQfnS FUwNf sc-dIUggk YDvpG"
-        type="button"
-      >
-        Open Modal
-      </button>
-    </div>
-  </div>
-</div>
-`;
-
 exports[`Storyshots Core/Modal Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP"
@@ -41,7 +22,7 @@ exports[`Storyshots Core/Modal Default 1`] = `
 exports[`Storyshots Core/Modal Nested 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP"
@@ -57,10 +38,10 @@ exports[`Storyshots Core/Modal Nested 1`] = `
 </div>
 `;
 
-exports[`Storyshots Core/Modal No Cancel 1`] = `
+exports[`Storyshots Core/Modal With Action Buttons 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP"
@@ -79,26 +60,7 @@ exports[`Storyshots Core/Modal No Cancel 1`] = `
 exports[`Storyshots Core/Modal With Custom Width 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
-  >
-    <div
-      class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP"
-    >
-      <button
-        class="StyledButton-sc-323bzc-0 fGJlAh sc-bqyKva sc-kstrdz gjQfnS FUwNf sc-dIUggk YDvpG"
-        type="button"
-      >
-        Open Modal
-      </button>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Storyshots Core/Modal With Customized Buttons 1`] = `
-<div>
-  <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP"
@@ -117,7 +79,7 @@ exports[`Storyshots Core/Modal With Customized Buttons 1`] = `
 exports[`Storyshots Core/Modal With Multielement Title 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP"
@@ -136,26 +98,7 @@ exports[`Storyshots Core/Modal With Multielement Title 1`] = `
 exports[`Storyshots Core/Modal With Overflowing Content 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
-  >
-    <div
-      class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP"
-    >
-      <button
-        class="StyledButton-sc-323bzc-0 fGJlAh sc-bqyKva sc-kstrdz gjQfnS FUwNf sc-dIUggk YDvpG"
-        type="button"
-      >
-        Open Modal
-      </button>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Storyshots Core/Modal With Title Details 1`] = `
-<div>
-  <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP"
@@ -174,7 +117,26 @@ exports[`Storyshots Core/Modal With Title Details 1`] = `
 exports[`Storyshots Core/Modal With Tooltip 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
+  >
+    <div
+      class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP"
+    >
+      <button
+        class="StyledButton-sc-323bzc-0 fGJlAh sc-bqyKva sc-kstrdz gjQfnS FUwNf sc-dIUggk YDvpG"
+        type="button"
+      >
+        Open Modal
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Core/Modal Without Actions 1`] = `
+<div>
+  <div
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP"

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -1,14 +1,16 @@
 import { Layer } from 'grommet';
-import merge from 'lodash/merge';
 import * as React from 'react';
 import styled, { createGlobalStyle, withTheme } from 'styled-components';
-import { ResponsiveStyle, Theme } from '../../common-types';
+import { ActionButtonGroup } from '../../internal/ActionButtonGroup';
+import {
+	ResponsiveStyle,
+	Theme,
+	ActionButtonDefinition,
+} from '../../common-types';
 import { px } from '../../utils';
 import { Box } from '../Box';
-import { Button, ButtonProps } from '../Button';
 import { Flex } from '../Flex';
 import { Heading } from '../Heading';
-import { Txt } from '../Txt';
 
 const bodyNoOverflowClass = `rendition-modal-open`;
 
@@ -24,18 +26,6 @@ const DEFAULT_MODAL_WIDTH = 700;
 const ModalSizer = styled(Box)`
 	overflow-y: auto;
 `;
-
-const HeadingDescription = styled(Txt)`
-	font-weight: normal;
-`;
-
-const ModalButton = (props: ButtonProps) => {
-	return 'href' in props && props.href ? (
-		<Button as="a" {...props} />
-	) : (
-		<Button {...props} />
-	);
-};
 
 class BaseModal extends React.Component<ThemedModalProps, any> {
 	public static mountedCount = 0;
@@ -61,8 +51,6 @@ class BaseModal extends React.Component<ThemedModalProps, any> {
 		if (!BaseModal.mountedCount) {
 			document.body.classList.remove(bodyNoOverflowClass);
 		}
-
-		window.removeEventListener('keydown', this.handleKeyDown);
 	}
 
 	public handleKeyDown = (e: KeyboardEvent) => {
@@ -74,14 +62,15 @@ class BaseModal extends React.Component<ThemedModalProps, any> {
 		if (!e.defaultPrevented && e.which === 13) {
 			e.preventDefault();
 			e.stopPropagation();
-
-			if (this.props.primaryButtonProps?.disabled) {
+			const firstPrimaryAction = this.props.actions?.find(
+				(action) => action.type === 'primary',
+			);
+			if (firstPrimaryAction?.disabled) {
 				return;
 			}
-
 			// Enter key
 			if (e.which === 13) {
-				this.props.done();
+				firstPrimaryAction?.onTriggerAction();
 			}
 		}
 	};
@@ -93,38 +82,17 @@ class BaseModal extends React.Component<ThemedModalProps, any> {
 		if (BaseModal.mountedCount !== this.ownIndex) {
 			return;
 		}
-
-		(this.props.cancel || this.props.done)();
+		const firstPrimaryAction = this.props.actions?.find(
+			(action) => action.type === 'none' || !action.type,
+		);
+		if (firstPrimaryAction?.disabled) {
+			return;
+		}
+		firstPrimaryAction?.onTriggerAction();
 	};
 
 	public render() {
 		const { width, theme, ...props } = this.props;
-
-		const cancelButtonProps = Object.assign({ ml: 3 }, props.cancelButtonProps);
-
-		const secondaryButtonProps = Object.assign(
-			{
-				primary: true,
-				outline: true,
-				ml: 3,
-			},
-			props.secondaryButtonProps,
-		);
-
-		const shouldChangePrimaryButtonOrder =
-			(props.primaryButtonProps?.danger ??
-				props.primaryButtonProps?.warning) === true;
-
-		const primaryButtonProps = merge(
-			{
-				primary: true,
-				ml: 3,
-				...(shouldChangePrimaryButtonOrder && {
-					style: { order: -1 },
-				}),
-			},
-			props.primaryButtonProps,
-		);
 
 		return (
 			<Layer
@@ -148,34 +116,14 @@ class BaseModal extends React.Component<ThemedModalProps, any> {
 					className={props.className}
 				>
 					<Box p={[px(theme.space[3]), '40px 50px 30px']}>
-						{props.titleElement ? (
-							<Heading.h3 mb={4}>{props.titleElement}</Heading.h3>
+						{props.header && typeof props.header === 'string' ? (
+							<Heading.h3 mb={4}>{props.header}</Heading.h3>
 						) : (
-							!!props.title && (
-								<Heading.h3 mb={4}>
-									{props.title}
-									{!!props.titleDetails && (
-										<HeadingDescription color="text.light" fontSize={2}>
-											{props.titleDetails}
-										</HeadingDescription>
-									)}
-								</Heading.h3>
-							)
+							props.header
 						)}
 						{props.children}
 						<Flex mt={5} alignItems="center" justifyContent="flex-end">
-							{props.cancel && (
-								<ModalButton {...cancelButtonProps} onClick={props.cancel}>
-									{(cancelButtonProps && cancelButtonProps.children) ||
-										'Cancel'}
-								</ModalButton>
-							)}
-							{props.secondaryButtonProps && (
-								<ModalButton {...secondaryButtonProps} />
-							)}
-							<ModalButton {...primaryButtonProps} onClick={props.done}>
-								{props.action || 'OK'}
-							</ModalButton>
+							<ActionButtonGroup actions={this.props.actions} />
 						</Flex>
 					</Box>
 				</ModalSizer>
@@ -185,27 +133,15 @@ class BaseModal extends React.Component<ThemedModalProps, any> {
 }
 
 export interface ModalProps extends React.HTMLAttributes<HTMLElement> {
-	/** A title to display at the top of the Modal, only displayed if the `titleElement` property is not used */
-	title?: string;
+	/** A string or JSX element to display at the top of the modal */
+	header?: string | JSX.Element;
 	width?: ResponsiveStyle;
 	/** Start the modal from the center (default) or top */
 	position?: 'center' | 'top';
-	/** A string or JSX element to display at the top of the modal */
-	titleElement?: string | JSX.Element;
 	/** A string or JSX element to display underneath the modal's `title`, only displayed if the `titleElement` property is not used and a `title` property is provided */
 	titleDetails?: string | JSX.Element;
 	/** A string or JSX element to display in the primary modal button, defaults to 'OK' */
-	action?: string | JSX.Element;
-	/** A function that is called if the modal is dismissed */
-	cancel?: () => any;
-	/** A function that is called if the primary modal button is clicked */
-	done: () => any;
-	/** Properties that are passed to the primary button, these are the same props used for the [`Button`](#button) component */
-	primaryButtonProps?: ButtonProps;
-	/** If provided, will cause a secondary button to appear on the modal. These properties that are passed to that button, these are the same props used for the [`Button`](#button) component */
-	secondaryButtonProps?: ButtonProps;
-	/** Properties that are passed to the cancel button, these are the same props used for the [`Button`](#button) component */
-	cancelButtonProps?: ButtonProps;
+	actions?: ActionButtonDefinition[];
 }
 
 export interface ThemedModalProps extends ModalProps {

--- a/src/components/Modal/spec.tsx
+++ b/src/components/Modal/spec.tsx
@@ -10,11 +10,17 @@ describe('Keyboard closing modals', () => {
 	it('should call the callback of the top-most nested modal on Escape key press', () => {
 		const firstModalSpy = sinon.spy();
 		const secondModalSpy = sinon.spy();
+		const firstModalActions = [
+			{ title: 'first Modal Action', onTriggerAction: firstModalSpy },
+		];
+		const secondModalActions = [
+			{ title: 'second Modal Action', onTriggerAction: secondModalSpy },
+		];
 
 		const component = mount(
 			<Provider>
-				<Modal done={firstModalSpy}>
-					<Modal done={secondModalSpy}>Test</Modal>
+				<Modal actions={firstModalActions}>
+					<Modal actions={secondModalActions}>Test</Modal>
 				</Modal>
 			</Provider>,
 		);
@@ -29,10 +35,13 @@ describe('Keyboard closing modals', () => {
 
 	it('should call the callback of the only modal on Escape key press', () => {
 		const modalSpy = sinon.spy();
+		const modalActions = [
+			{ title: 'first Modal Action', onTriggerAction: modalSpy },
+		];
 
 		const component = mount(
 			<Provider>
-				<Modal done={modalSpy}>Test</Modal>
+				<Modal actions={modalActions}>Test</Modal>
 			</Provider>,
 		);
 
@@ -66,11 +75,25 @@ describe('Keyboard submitting nested modals', () => {
 	it('should call the callback of the top-most modal with done on Enter key press', () => {
 		const firstModalSpy = sinon.spy();
 		const secondModalSpy = sinon.spy();
+		const firstModalActions = [
+			{
+				title: 'first Modal Action',
+				type: 'primary',
+				onTriggerAction: firstModalSpy,
+			},
+		];
+		const secondModalActions = [
+			{
+				title: 'second Modal Action',
+				type: 'primary',
+				onTriggerAction: secondModalSpy,
+			},
+		];
 
 		mount(
 			<Provider>
-				<Modal done={firstModalSpy}>
-					<Modal done={secondModalSpy}>Test</Modal>
+				<Modal actions={firstModalActions}>
+					<Modal actions={secondModalActions}>Test</Modal>
 				</Modal>
 			</Provider>,
 		);
@@ -90,13 +113,21 @@ describe('Keyboard submitting nested modals', () => {
 	it('should not call any callback of either modal on Enter key press when the primary button is disabled', () => {
 		const firstModalSpy = sinon.spy();
 		const secondModalSpy = sinon.spy();
+		const firstModalActions = [
+			{ title: 'first Modal Action', onTriggerAction: firstModalSpy },
+		];
+		const secondModalActions = [
+			{
+				title: 'second Modal Action',
+				disabled: true,
+				onTriggerAction: secondModalSpy,
+			},
+		];
 
 		mount(
 			<Provider>
-				<Modal done={firstModalSpy}>
-					<Modal primaryButtonProps={{ disabled: true }} done={secondModalSpy}>
-						Test
-					</Modal>
+				<Modal actions={firstModalActions}>
+					<Modal actions={secondModalActions}>Test</Modal>
 				</Modal>
 			</Provider>,
 		);

--- a/src/components/Navbar/__snapshots__/Navbar.stories.storyshot
+++ b/src/components/Navbar/__snapshots__/Navbar.stories.storyshot
@@ -3,13 +3,13 @@
 exports[`Storyshots Core/Navbar Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="sc-gKsewC cgpPfo sc-iBPRYJ csJJEL"
     >
       <div
-        class="sc-gKsewC cgpPfo sc-iBPRYJ QCGZt sc-aKZfe TjqdR sc-kmASHI kBhFNE"
+        class="sc-gKsewC cgpPfo sc-iBPRYJ QCGZt sc-gsBrbv fHHEeu sc-aKZfe dnXERG"
       >
         <div
           class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr hgkEZm"
@@ -18,22 +18,22 @@ exports[`Storyshots Core/Navbar Default 1`] = `
             class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV"
           >
             <div
-              class="sc-gKsewC cgpPfo sc-iBPRYJ jjhpBS sc-cvJHqN fkYJk"
+              class="sc-gKsewC cgpPfo sc-iBPRYJ jjhpBS sc-kmASHI eKqCMJ"
             >
               <a
-                class="sc-eGCarw fNeKsH sc-ctaXAZ juDWEP"
+                class="sc-bXDlPE iGtnxp sc-eGCarw cqZnMj"
                 color="white"
                 href="/"
               >
                 <img
-                  class="sc-bXDlPE YPfIL"
+                  class="sc-gsxnyZ dsPZMt"
                   src=""
                   style="height: 20px;"
                 />
               </a>
             </div>
             <div
-              class="sc-gKsewC cgpPfo sc-iBPRYJ kYPycb sc-dkmKpi lknZhg"
+              class="sc-gKsewC cgpPfo sc-iBPRYJ kYPycb sc-cvJHqN ktukHg"
             >
               <svg
                 aria-hidden="true"
@@ -53,7 +53,7 @@ exports[`Storyshots Core/Navbar Default 1`] = `
             </div>
           </div>
           <div
-            class="sc-gKsewC cgpPfo sc-iBPRYJ iHZzfI sc-hHftDr sc-gIRixj cLDXoV coxAll"
+            class="sc-gKsewC cgpPfo sc-iBPRYJ iHZzfI sc-hHftDr sc-dkmKpi cLDXoV kmoagy"
           >
             <div
               class="sc-gKsewC cgpPfo sc-iBPRYJ VwhUL sc-hHftDr hgkEZm"
@@ -62,7 +62,7 @@ exports[`Storyshots Core/Navbar Default 1`] = `
                 class="sc-gKsewC cgpPfo sc-iBPRYJ doqgsf"
               >
                 <a
-                  class="sc-eGCarw fNeKsH sc-ctaXAZ juDWEP"
+                  class="sc-bXDlPE iGtnxp sc-eGCarw cqZnMj"
                   color="white"
                   href="/docs/"
                 >
@@ -73,7 +73,7 @@ exports[`Storyshots Core/Navbar Default 1`] = `
                 class="sc-gKsewC cgpPfo sc-iBPRYJ doqgsf"
               >
                 <a
-                  class="sc-eGCarw fNeKsH sc-ctaXAZ juDWEP"
+                  class="sc-bXDlPE iGtnxp sc-eGCarw cqZnMj"
                   color="white"
                   href="/changelog/"
                 >
@@ -84,7 +84,7 @@ exports[`Storyshots Core/Navbar Default 1`] = `
                 class="sc-gKsewC cgpPfo sc-iBPRYJ doqgsf"
               >
                 <a
-                  class="sc-eGCarw fNeKsH sc-ctaXAZ juDWEP"
+                  class="sc-bXDlPE iGtnxp sc-eGCarw cqZnMj"
                   color="white"
                   href="/gitter/"
                 >

--- a/src/components/Notifications/__snapshots__/Notifications.stories.storyshot
+++ b/src/components/Notifications/__snapshots__/Notifications.stories.storyshot
@@ -3,13 +3,13 @@
 exports[`Storyshots Core/Notifications Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="sc-gKsewC cgpPfo sc-iBPRYJ htdDiA sc-hHftDr jpCUGc"
     >
       <div
-        class="react-notification-root sc-gsBrbv dXUKmO"
+        class="react-notification-root sc-iIEYCM kTPMVU"
       >
         <div
           class="notification-container-top-left"
@@ -25,7 +25,7 @@ exports[`Storyshots Core/Notifications Default 1`] = `
               class="notification-item n-child"
             >
               <div
-                class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-dmlrTW cLDXoV jCybnR sc-lmoMRL cGXAYQ sc-iIEYCM ktfDZQ"
+                class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-dmlrTW cLDXoV jCybnR sc-lmoMRL cGXAYQ sc-cKZHah jdzSPJ"
               >
                 
                 <div
@@ -71,7 +71,7 @@ exports[`Storyshots Core/Notifications Default 1`] = `
               class="notification-item n-child"
             >
               <div
-                class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-dmlrTW cLDXoV jCybnR sc-lmoMRL cGXAYQ sc-iIEYCM ktfDZQ"
+                class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-dmlrTW cLDXoV jCybnR sc-lmoMRL cGXAYQ sc-cKZHah jdzSPJ"
               >
                 
                 <div
@@ -164,10 +164,10 @@ exports[`Storyshots Core/Notifications Default 1`] = `
 exports[`Storyshots Core/Notifications Positioning 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
-      class="react-notification-root sc-gsBrbv dXUKmO"
+      class="react-notification-root sc-iIEYCM kTPMVU"
     >
       <div
         class="notification-container-top-left"
@@ -180,7 +180,7 @@ exports[`Storyshots Core/Notifications Positioning 1`] = `
             class="notification-item n-child"
           >
             <div
-              class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-dmlrTW cLDXoV jCybnR sc-lmoMRL cGXAYQ sc-iIEYCM ktfDZQ"
+              class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-dmlrTW cLDXoV jCybnR sc-lmoMRL cGXAYQ sc-cKZHah jdzSPJ"
             >
               
               <div
@@ -230,7 +230,7 @@ exports[`Storyshots Core/Notifications Positioning 1`] = `
             class="notification-item n-child"
           >
             <div
-              class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-dmlrTW cLDXoV jCybnR sc-lmoMRL cGXAYQ sc-iIEYCM ktfDZQ"
+              class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-dmlrTW cLDXoV jCybnR sc-lmoMRL cGXAYQ sc-cKZHah jdzSPJ"
             >
               
               <div
@@ -280,7 +280,7 @@ exports[`Storyshots Core/Notifications Positioning 1`] = `
             class="notification-item n-child"
           >
             <div
-              class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-dmlrTW cLDXoV jCybnR sc-lmoMRL cGXAYQ sc-iIEYCM ktfDZQ"
+              class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-dmlrTW cLDXoV jCybnR sc-lmoMRL cGXAYQ sc-cKZHah jdzSPJ"
             >
               
               <div
@@ -330,7 +330,7 @@ exports[`Storyshots Core/Notifications Positioning 1`] = `
             class="notification-item n-child"
           >
             <div
-              class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-dmlrTW cLDXoV jCybnR sc-lmoMRL cGXAYQ sc-iIEYCM ktfDZQ"
+              class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-dmlrTW cLDXoV jCybnR sc-lmoMRL cGXAYQ sc-cKZHah jdzSPJ"
             >
               
               <div
@@ -380,7 +380,7 @@ exports[`Storyshots Core/Notifications Positioning 1`] = `
             class="notification-item n-child"
           >
             <div
-              class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-dmlrTW cLDXoV jCybnR sc-lmoMRL cGXAYQ sc-iIEYCM ktfDZQ"
+              class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-dmlrTW cLDXoV jCybnR sc-lmoMRL cGXAYQ sc-cKZHah jdzSPJ"
             >
               
               <div
@@ -433,7 +433,7 @@ exports[`Storyshots Core/Notifications Positioning 1`] = `
               class="notification-item n-child"
             >
               <div
-                class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-dmlrTW cLDXoV jCybnR sc-lmoMRL cGXAYQ sc-iIEYCM ktfDZQ"
+                class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-dmlrTW cLDXoV jCybnR sc-lmoMRL cGXAYQ sc-cKZHah jdzSPJ"
               >
                 
                 <div
@@ -484,7 +484,7 @@ exports[`Storyshots Core/Notifications Positioning 1`] = `
             class="notification-item n-child"
           >
             <div
-              class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-dmlrTW cLDXoV jCybnR sc-lmoMRL cGXAYQ sc-iIEYCM ktfDZQ"
+              class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-dmlrTW cLDXoV jCybnR sc-lmoMRL cGXAYQ sc-cKZHah jdzSPJ"
             >
               
               <div
@@ -585,13 +585,13 @@ exports[`Storyshots Core/Notifications Positioning 1`] = `
 exports[`Storyshots Core/Notifications Types 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="sc-gKsewC cgpPfo sc-iBPRYJ htdDiA sc-hHftDr jpCUGc"
     >
       <div
-        class="react-notification-root sc-gsBrbv dXUKmO"
+        class="react-notification-root sc-iIEYCM kTPMVU"
       >
         <div
           class="notification-container-top-left"
@@ -607,7 +607,7 @@ exports[`Storyshots Core/Notifications Types 1`] = `
               class="notification-item n-child"
             >
               <div
-                class="sc-gKsewC cgpPfo sc-iBPRYJ dQsSLq sc-hHftDr sc-dmlrTW cLDXoV RAjJT sc-lmoMRL cGXAYQ sc-iIEYCM ktfDZQ"
+                class="sc-gKsewC cgpPfo sc-iBPRYJ dQsSLq sc-hHftDr sc-dmlrTW cLDXoV RAjJT sc-lmoMRL cGXAYQ sc-cKZHah jdzSPJ"
               >
                 <div
                   class="sc-fKFyDc jHCVxA sc-bBXqnf XVwEh"
@@ -675,7 +675,7 @@ exports[`Storyshots Core/Notifications Types 1`] = `
               class="notification-item n-child"
             >
               <div
-                class="sc-gKsewC cgpPfo sc-iBPRYJ fiWzOU sc-hHftDr sc-dmlrTW cLDXoV dcrGdQ sc-lmoMRL cGXAYQ sc-iIEYCM ktfDZQ"
+                class="sc-gKsewC cgpPfo sc-iBPRYJ fiWzOU sc-hHftDr sc-dmlrTW cLDXoV dcrGdQ sc-lmoMRL cGXAYQ sc-cKZHah jdzSPJ"
               >
                 <div
                   class="sc-fKFyDc jHCVxA sc-bBXqnf hsApDH"
@@ -743,7 +743,7 @@ exports[`Storyshots Core/Notifications Types 1`] = `
               class="notification-item n-child"
             >
               <div
-                class="sc-gKsewC cgpPfo sc-iBPRYJ ipiHMM sc-hHftDr sc-dmlrTW cLDXoV fNGbub sc-lmoMRL cGXAYQ sc-iIEYCM ktfDZQ"
+                class="sc-gKsewC cgpPfo sc-iBPRYJ ipiHMM sc-hHftDr sc-dmlrTW cLDXoV fNGbub sc-lmoMRL cGXAYQ sc-cKZHah jdzSPJ"
               >
                 <div
                   class="sc-fKFyDc jHCVxA sc-bBXqnf ebpqPX"
@@ -811,7 +811,7 @@ exports[`Storyshots Core/Notifications Types 1`] = `
               class="notification-item n-child"
             >
               <div
-                class="sc-gKsewC cgpPfo sc-iBPRYJ cEHZTN sc-hHftDr sc-dmlrTW cLDXoV jwBGWI sc-lmoMRL cGXAYQ sc-iIEYCM ktfDZQ"
+                class="sc-gKsewC cgpPfo sc-iBPRYJ cEHZTN sc-hHftDr sc-dmlrTW cLDXoV jwBGWI sc-lmoMRL cGXAYQ sc-cKZHah jdzSPJ"
               >
                 <div
                   class="sc-fKFyDc jHCVxA sc-bBXqnf ifPkvS"

--- a/src/components/Pager/__snapshots__/Pager.stories.storyshot
+++ b/src/components/Pager/__snapshots__/Pager.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/Pager Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr ZlJMD"

--- a/src/components/Popover/__snapshots__/Popover.stories.storyshot
+++ b/src/components/Popover/__snapshots__/Popover.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/Popover Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="sc-gKsewC cgpPfo sc-iBPRYJ frgkGL"

--- a/src/components/ProgressBar/__snapshots__/ProgressBar.stories.storyshot
+++ b/src/components/ProgressBar/__snapshots__/ProgressBar.stories.storyshot
@@ -3,24 +3,24 @@
 exports[`Storyshots Core/ProgressBar Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
-      class="sc-Fyfyc cDUnxV sc-jXktwP eTEXdq"
+      class="sc-fXoxut fVeoGG sc-Fyfyc hNOTjr"
       color="#fff"
     >
       <div
-        class="sc-bQdQlF MhrIg"
+        class="sc-jGVbCA jWbjBD"
       >
         10
         %
       </div>
       <div
-        class="sc-jGVbCA clexNs"
+        class="sc-dWdcrH eJmBql"
         style="width: 10%;"
       >
         <div
-          class="sc-fXoxut bFuxBo"
+          class="sc-bQdQlF kUjWPQ"
           style="width: 1000%;"
         >
           10
@@ -35,25 +35,25 @@ exports[`Storyshots Core/ProgressBar Default 1`] = `
 exports[`Storyshots Core/ProgressBar Different Color 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
-      class="sc-Fyfyc cDUnxV sc-jXktwP eTEXdq"
+      class="sc-fXoxut fVeoGG sc-Fyfyc hNOTjr"
       color="#fff"
       type="danger"
     >
       <div
-        class="sc-bQdQlF MhrIg"
+        class="sc-jGVbCA jWbjBD"
       >
         10
         %
       </div>
       <div
-        class="sc-jGVbCA eGrcvu"
+        class="sc-dWdcrH kShCtr"
         style="width: 10%;"
       >
         <div
-          class="sc-fXoxut bFuxBo"
+          class="sc-bQdQlF kUjWPQ"
           style="width: 1000%;"
         >
           10
@@ -68,24 +68,24 @@ exports[`Storyshots Core/ProgressBar Different Color 1`] = `
 exports[`Storyshots Core/ProgressBar Emphasized 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
-      class="sc-Fyfyc ggnkhg sc-jXktwP eTEXdq"
+      class="sc-fXoxut hsTJaj sc-Fyfyc hNOTjr"
       color="#fff"
     >
       <div
-        class="sc-bQdQlF MhrIg"
+        class="sc-jGVbCA jWbjBD"
       >
         10
         %
       </div>
       <div
-        class="sc-jGVbCA clexNs"
+        class="sc-dWdcrH eJmBql"
         style="width: 10%;"
       >
         <div
-          class="sc-fXoxut bFuxBo"
+          class="sc-bQdQlF kUjWPQ"
           style="width: 1000%;"
         >
           10

--- a/src/components/RadioButton/__snapshots__/RadioButton.stories.storyshot
+++ b/src/components/RadioButton/__snapshots__/RadioButton.stories.storyshot
@@ -3,10 +3,10 @@
 exports[`Storyshots Core/RadioButton Checked 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
-      class="sc-gyUeRy byZlja sc-gkdzZj dDFlzP"
+      class="sc-fHYxKZ bFFPlt sc-gyUeRy gnloAc"
     >
       <label
         class="StyledRadioButton__StyledRadioButtonContainer-g1f6ld-0 kpowLU"
@@ -50,10 +50,10 @@ exports[`Storyshots Core/RadioButton Checked 1`] = `
 exports[`Storyshots Core/RadioButton Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
-      class="sc-gyUeRy cAFpBO sc-gkdzZj dDFlzP"
+      class="sc-fHYxKZ cwnXrR sc-gyUeRy gnloAc"
     >
       <label
         class="StyledRadioButton__StyledRadioButtonContainer-g1f6ld-0 kpowLU"
@@ -84,10 +84,10 @@ exports[`Storyshots Core/RadioButton Default 1`] = `
 exports[`Storyshots Core/RadioButton Disabled 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
-      class="sc-gyUeRy cAFpBO sc-gkdzZj dDFlzP"
+      class="sc-fHYxKZ cwnXrR sc-gyUeRy gnloAc"
     >
       <label
         class="StyledRadioButton__StyledRadioButtonContainer-g1f6ld-0 gmkESR"

--- a/src/components/RadioButtonGroup/__snapshots__/RadioButtonGroup.stories.storyshot
+++ b/src/components/RadioButtonGroup/__snapshots__/RadioButtonGroup.stories.storyshot
@@ -3,10 +3,10 @@
 exports[`Storyshots Core/RadioButtonGroup Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 dYebPD sc-flMoUE ernOHs sc-eWVKcp eikgVN"
+      class="StyledBox-sc-13pk1d4-0 dYebPD sc-gkdzZj etxjjy sc-flMoUE iKTkeN"
     >
       <label
         class="StyledRadioButton__StyledRadioButtonContainer-g1f6ld-0 kpowLU"
@@ -80,10 +80,10 @@ exports[`Storyshots Core/RadioButtonGroup Default 1`] = `
 exports[`Storyshots Core/RadioButtonGroup With Expanded Options 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 dYebPD sc-flMoUE iXKTKg sc-eWVKcp eikgVN"
+      class="StyledBox-sc-13pk1d4-0 dYebPD sc-gkdzZj iMZGGC sc-flMoUE iKTkeN"
     >
       <label
         class="StyledRadioButton__StyledRadioButtonContainer-g1f6ld-0 gmkESR"

--- a/src/components/Rating/__snapshots__/Rating.stories.storyshot
+++ b/src/components/Rating/__snapshots__/Rating.stories.storyshot
@@ -3,10 +3,10 @@
 exports[`Storyshots Core/Rating Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
-      class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV sc-fmlJLJ kHFkEm"
+      class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV sc-eFubAy fNAVWt"
     >
       <svg
         aria-hidden="true"

--- a/src/components/Renderer/RendererPlayground/index.tsx
+++ b/src/components/Renderer/RendererPlayground/index.tsx
@@ -216,13 +216,20 @@ const RendererPlaygroundBase = ({
 				<ResultCard
 					flex={1}
 					{...commonCardProps}
-					title="Result"
-					cta={
-						<Checkbox
-							checked={validate}
-							label="Validate"
-							onChange={(e) => setValidate(e.target.checked)}
-						/>
+					header={
+						<Flex
+							flex="0 0 auto"
+							justifyContent="space-between"
+							alignItems="center"
+						>
+							<Heading.h3>Result</Heading.h3>
+							<Checkbox
+								ml={2}
+								checked={validate}
+								label="Validate"
+								onChange={(e) => setValidate(e.target.checked)}
+							/>
+						</Flex>
 					}
 				>
 					<Renderer

--- a/src/components/Search/__snapshots__/Search.stories.storyshot
+++ b/src/components/Search/__snapshots__/Search.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/Search Dark 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="sc-khAkjo iYewy sc-hTZhsR eZHrxK"
@@ -36,7 +36,7 @@ exports[`Storyshots Core/Search Dark 1`] = `
 exports[`Storyshots Core/Search Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="sc-khAkjo iYewy sc-hTZhsR eZHrxK"
@@ -68,7 +68,7 @@ exports[`Storyshots Core/Search Default 1`] = `
 exports[`Storyshots Core/Search Disabled 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="sc-khAkjo iYewy sc-hTZhsR eZHrxK"
@@ -101,7 +101,7 @@ exports[`Storyshots Core/Search Disabled 1`] = `
 exports[`Storyshots Core/Search With Placeholder 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="sc-khAkjo iYewy sc-hTZhsR eZHrxK"

--- a/src/components/Select/__snapshots__/Select.stories.storyshot
+++ b/src/components/Select/__snapshots__/Select.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/Select Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="sc-eJMQSu icifty sc-nFpLZ jNUxxL"
@@ -59,7 +59,7 @@ exports[`Storyshots Core/Select Default 1`] = `
 exports[`Storyshots Core/Select Emphasized 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="sc-eJMQSu icifty sc-nFpLZ jNUxxL"
@@ -115,7 +115,7 @@ exports[`Storyshots Core/Select Emphasized 1`] = `
 exports[`Storyshots Core/Select Invalid 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="sc-eJMQSu ekgIso sc-nFpLZ jNUxxL"
@@ -171,7 +171,7 @@ exports[`Storyshots Core/Select Invalid 1`] = `
 exports[`Storyshots Core/Select Object Options 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="sc-eJMQSu icifty sc-nFpLZ jNUxxL"
@@ -227,7 +227,7 @@ exports[`Storyshots Core/Select Object Options 1`] = `
 exports[`Storyshots Core/Select With Custom Option 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="sc-eJMQSu icifty sc-nFpLZ jNUxxL"
@@ -283,7 +283,7 @@ exports[`Storyshots Core/Select With Custom Option 1`] = `
 exports[`Storyshots Core/Select With Placeholder 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="sc-eJMQSu icifty sc-nFpLZ jNUxxL"

--- a/src/components/Select/__snapshots__/Select.stories.storyshot
+++ b/src/components/Select/__snapshots__/Select.stories.storyshot
@@ -24,7 +24,7 @@ exports[`Storyshots Core/Select Default 1`] = `
             >
               <input
                 autocomplete="off"
-                class="StyledTextInput-sc-1x30a0s-0 AKkVg Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP kMEjWZ"
+                class="StyledTextInput-sc-1x30a0s-0 ccRbRh Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP kMEjWZ"
                 readonly=""
                 tabindex="-1"
                 type="text"
@@ -80,7 +80,7 @@ exports[`Storyshots Core/Select Emphasized 1`] = `
             >
               <input
                 autocomplete="off"
-                class="StyledTextInput-sc-1x30a0s-0 AKkVg Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP iqwkEO"
+                class="StyledTextInput-sc-1x30a0s-0 ccRbRh Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP iqwkEO"
                 readonly=""
                 tabindex="-1"
                 type="text"
@@ -136,7 +136,7 @@ exports[`Storyshots Core/Select Invalid 1`] = `
             >
               <input
                 autocomplete="off"
-                class="StyledTextInput-sc-1x30a0s-0 AKkVg Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP kMEjWZ"
+                class="StyledTextInput-sc-1x30a0s-0 ccRbRh Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP kMEjWZ"
                 readonly=""
                 tabindex="-1"
                 type="text"
@@ -192,7 +192,7 @@ exports[`Storyshots Core/Select Object Options 1`] = `
             >
               <input
                 autocomplete="off"
-                class="StyledTextInput-sc-1x30a0s-0 AKkVg Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP kMEjWZ"
+                class="StyledTextInput-sc-1x30a0s-0 ccRbRh Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP kMEjWZ"
                 readonly=""
                 tabindex="-1"
                 type="text"
@@ -248,7 +248,7 @@ exports[`Storyshots Core/Select With Custom Option 1`] = `
             >
               <input
                 autocomplete="off"
-                class="StyledTextInput-sc-1x30a0s-0 AKkVg Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP kMEjWZ"
+                class="StyledTextInput-sc-1x30a0s-0 ccRbRh Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP kMEjWZ"
                 readonly=""
                 tabindex="-1"
                 type="text"
@@ -304,7 +304,7 @@ exports[`Storyshots Core/Select With Placeholder 1`] = `
             >
               <input
                 autocomplete="off"
-                class="StyledTextInput-sc-1x30a0s-0 AKkVg Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP kMEjWZ"
+                class="StyledTextInput-sc-1x30a0s-0 ccRbRh Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP kMEjWZ"
                 placeholder="Select one..."
                 readonly=""
                 tabindex="-1"

--- a/src/components/Spinner/__snapshots__/Spinner.stories.storyshot
+++ b/src/components/Spinner/__snapshots__/Spinner.stories.storyshot
@@ -3,13 +3,13 @@
 exports[`Storyshots Core/Spinner Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
-      class="sc-gKsewC cgpPfo sc-iBPRYJ ewcxWD sc-hHftDr fYuNSV sc-cbDGPM jfOLHm"
+      class="sc-gKsewC cgpPfo sc-iBPRYJ ewcxWD sc-hHftDr fYuNSV sc-httYMd dZetDd"
     >
       <div
-        class="sc-ljRboo dKVzgf"
+        class="sc-fmlJLJ kLqknm"
       />
     </div>
   </div>
@@ -19,13 +19,13 @@ exports[`Storyshots Core/Spinner Default 1`] = `
 exports[`Storyshots Core/Spinner Emphasized 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
-      class="sc-gKsewC cgpPfo sc-iBPRYJ ewcxWD sc-hHftDr cMsQud sc-cbDGPM jfOLHm"
+      class="sc-gKsewC cgpPfo sc-iBPRYJ ewcxWD sc-hHftDr cMsQud sc-httYMd dZetDd"
     >
       <div
-        class="sc-ljRboo FpWZZ"
+        class="sc-fmlJLJ kIvwIk"
       />
     </div>
   </div>
@@ -35,19 +35,19 @@ exports[`Storyshots Core/Spinner Emphasized 1`] = `
 exports[`Storyshots Core/Spinner With Children 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
-      class="sc-jmhFOf Irpdp sc-cbDGPM jfOLHm"
+      class="sc-ljRboo goKbbP sc-httYMd dZetDd"
     >
       <div
-        class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-dUrnRO kFVJVF iKHNoa"
+        class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-jmhFOf kFVJVF cUeQFS"
       >
         <div
           class="sc-gKsewC cgpPfo sc-iBPRYJ ewcxWD sc-hHftDr fYuNSV"
         >
           <div
-            class="sc-ljRboo dKVzgf"
+            class="sc-fmlJLJ kLqknm"
           />
           <div
             class="sc-fKFyDc jHCVxA sc-bBXqnf kCTWx"
@@ -57,7 +57,7 @@ exports[`Storyshots Core/Spinner With Children 1`] = `
         </div>
       </div>
       <div
-        class="sc-httYMd fxrWNV"
+        class="sc-dUrnRO ihhtHV"
       >
         <div
           class="sc-gKsewC cgpPfo sc-iBPRYJ bgxczn"
@@ -74,13 +74,13 @@ exports[`Storyshots Core/Spinner With Children 1`] = `
 exports[`Storyshots Core/Spinner With Component Label 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
-      class="sc-gKsewC cgpPfo sc-iBPRYJ ewcxWD sc-hHftDr fYuNSV sc-cbDGPM jfOLHm"
+      class="sc-gKsewC cgpPfo sc-iBPRYJ ewcxWD sc-hHftDr fYuNSV sc-httYMd dZetDd"
     >
       <div
-        class="sc-ljRboo dKVzgf"
+        class="sc-fmlJLJ kLqknm"
       />
       <div
         class="sc-fKFyDc jHCVxA sc-bBXqnf kCTWx"
@@ -106,13 +106,13 @@ exports[`Storyshots Core/Spinner With Component Label 1`] = `
 exports[`Storyshots Core/Spinner With Label 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
-      class="sc-gKsewC cgpPfo sc-iBPRYJ ewcxWD sc-hHftDr fYuNSV sc-cbDGPM jfOLHm"
+      class="sc-gKsewC cgpPfo sc-iBPRYJ ewcxWD sc-hHftDr fYuNSV sc-httYMd dZetDd"
     >
       <div
-        class="sc-ljRboo dKVzgf"
+        class="sc-fmlJLJ kLqknm"
       />
       <div
         class="sc-fKFyDc jHCVxA sc-bBXqnf kCTWx"

--- a/src/components/StatsBar/__snapshots__/StatsBar.stories.storyshot
+++ b/src/components/StatsBar/__snapshots__/StatsBar.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/StatsBar Cpu Temp 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="sc-gKsewC dWcnb sc-iBPRYJ gaVbIt sc-hHftDr iIBJBt"
@@ -66,19 +66,19 @@ exports[`Storyshots Core/StatsBar Cpu Temp 1`] = `
           class="sc-gKsewC dWcnb sc-iBPRYJ fzmzON"
         >
           <div
-            class="sc-Fyfyc cDUnxV sc-jXktwP eTEXdq"
+            class="sc-fXoxut fVeoGG sc-Fyfyc hNOTjr"
             color="#fff"
             type="success"
           >
             <div
-              class="sc-bQdQlF MhrIg"
+              class="sc-jGVbCA jWbjBD"
             />
             <div
-              class="sc-jGVbCA gKQmYf"
+              class="sc-dWdcrH gKRYHK"
               style="width: 34%;"
             >
               <div
-                class="sc-fXoxut bFuxBo"
+                class="sc-bQdQlF kUjWPQ"
                 style="width: 294.11764705882354%;"
               />
             </div>
@@ -93,7 +93,7 @@ exports[`Storyshots Core/StatsBar Cpu Temp 1`] = `
 exports[`Storyshots Core/StatsBar Cpu Usage 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="sc-gKsewC dWcnb sc-iBPRYJ gaVbIt sc-hHftDr iIBJBt"
@@ -156,19 +156,19 @@ exports[`Storyshots Core/StatsBar Cpu Usage 1`] = `
           class="sc-gKsewC dWcnb sc-iBPRYJ dlUrgp"
         >
           <div
-            class="sc-Fyfyc cDUnxV sc-jXktwP eTEXdq"
+            class="sc-fXoxut fVeoGG sc-Fyfyc hNOTjr"
             color="#fff"
             type="success"
           >
             <div
-              class="sc-bQdQlF MhrIg"
+              class="sc-jGVbCA jWbjBD"
             />
             <div
-              class="sc-jGVbCA gKQmYf"
+              class="sc-dWdcrH gKRYHK"
               style="width: 100%;"
             >
               <div
-                class="sc-fXoxut bFuxBo"
+                class="sc-bQdQlF kUjWPQ"
                 style="width: 100%;"
               />
             </div>
@@ -178,19 +178,19 @@ exports[`Storyshots Core/StatsBar Cpu Usage 1`] = `
           class="sc-gKsewC dWcnb sc-iBPRYJ dlUrgp"
         >
           <div
-            class="sc-Fyfyc cDUnxV sc-jXktwP eTEXdq"
+            class="sc-fXoxut fVeoGG sc-Fyfyc hNOTjr"
             color="#fff"
             type="success"
           >
             <div
-              class="sc-bQdQlF MhrIg"
+              class="sc-jGVbCA jWbjBD"
             />
             <div
-              class="sc-jGVbCA gKQmYf"
+              class="sc-dWdcrH gKRYHK"
               style="width: 100%;"
             >
               <div
-                class="sc-fXoxut bFuxBo"
+                class="sc-bQdQlF kUjWPQ"
                 style="width: 100%;"
               />
             </div>
@@ -200,19 +200,19 @@ exports[`Storyshots Core/StatsBar Cpu Usage 1`] = `
           class="sc-gKsewC dWcnb sc-iBPRYJ dlUrgp"
         >
           <div
-            class="sc-Fyfyc cDUnxV sc-jXktwP eTEXdq"
+            class="sc-fXoxut fVeoGG sc-Fyfyc hNOTjr"
             color="#fff"
             type="success"
           >
             <div
-              class="sc-bQdQlF MhrIg"
+              class="sc-jGVbCA jWbjBD"
             />
             <div
-              class="sc-jGVbCA gKQmYf"
+              class="sc-dWdcrH gKRYHK"
               style="width: 0%;"
             >
               <div
-                class="sc-fXoxut bFuxBo"
+                class="sc-bQdQlF kUjWPQ"
                 style="width: 0%;"
               />
             </div>
@@ -222,19 +222,19 @@ exports[`Storyshots Core/StatsBar Cpu Usage 1`] = `
           class="sc-gKsewC dWcnb sc-iBPRYJ dlUrgp"
         >
           <div
-            class="sc-Fyfyc cDUnxV sc-jXktwP eTEXdq"
+            class="sc-fXoxut fVeoGG sc-Fyfyc hNOTjr"
             color="#fff"
             type="success"
           >
             <div
-              class="sc-bQdQlF MhrIg"
+              class="sc-jGVbCA jWbjBD"
             />
             <div
-              class="sc-jGVbCA gKQmYf"
+              class="sc-dWdcrH gKRYHK"
               style="width: 0%;"
             >
               <div
-                class="sc-fXoxut bFuxBo"
+                class="sc-bQdQlF kUjWPQ"
                 style="width: 0%;"
               />
             </div>
@@ -244,19 +244,19 @@ exports[`Storyshots Core/StatsBar Cpu Usage 1`] = `
           class="sc-gKsewC dWcnb sc-iBPRYJ fzmzON"
         >
           <div
-            class="sc-Fyfyc cDUnxV sc-jXktwP eTEXdq"
+            class="sc-fXoxut fVeoGG sc-Fyfyc hNOTjr"
             color="#fff"
             type="success"
           >
             <div
-              class="sc-bQdQlF MhrIg"
+              class="sc-jGVbCA jWbjBD"
             />
             <div
-              class="sc-jGVbCA gKQmYf"
+              class="sc-dWdcrH gKRYHK"
               style="width: 0%;"
             >
               <div
-                class="sc-fXoxut bFuxBo"
+                class="sc-bQdQlF kUjWPQ"
                 style="width: 0%;"
               />
             </div>
@@ -271,7 +271,7 @@ exports[`Storyshots Core/StatsBar Cpu Usage 1`] = `
 exports[`Storyshots Core/StatsBar Memory 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="sc-gKsewC dWcnb sc-iBPRYJ gaVbIt sc-hHftDr iIBJBt"
@@ -344,19 +344,19 @@ exports[`Storyshots Core/StatsBar Memory 1`] = `
           class="sc-gKsewC dWcnb sc-iBPRYJ fzmzON"
         >
           <div
-            class="sc-Fyfyc cDUnxV sc-jXktwP eTEXdq"
+            class="sc-fXoxut fVeoGG sc-Fyfyc hNOTjr"
             color="#fff"
             type="success"
           >
             <div
-              class="sc-bQdQlF MhrIg"
+              class="sc-jGVbCA jWbjBD"
             />
             <div
-              class="sc-jGVbCA gKQmYf"
+              class="sc-dWdcrH gKRYHK"
               style="width: 45.300000000000004%;"
             >
               <div
-                class="sc-fXoxut bFuxBo"
+                class="sc-bQdQlF kUjWPQ"
                 style="width: 220.75055187637966%;"
               />
             </div>
@@ -371,7 +371,7 @@ exports[`Storyshots Core/StatsBar Memory 1`] = `
 exports[`Storyshots Core/StatsBar Storage 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="sc-gKsewC dWcnb sc-iBPRYJ gaVbIt sc-hHftDr iIBJBt"
@@ -444,19 +444,19 @@ exports[`Storyshots Core/StatsBar Storage 1`] = `
           class="sc-gKsewC dWcnb sc-iBPRYJ fzmzON"
         >
           <div
-            class="sc-Fyfyc cDUnxV sc-jXktwP eTEXdq"
+            class="sc-fXoxut fVeoGG sc-Fyfyc hNOTjr"
             color="#fff"
             type="warning"
           >
             <div
-              class="sc-bQdQlF MhrIg"
+              class="sc-jGVbCA jWbjBD"
             />
             <div
-              class="sc-jGVbCA eMdXan"
+              class="sc-dWdcrH cpHzTu"
               style="width: 62.3%;"
             >
               <div
-                class="sc-fXoxut bFuxBo"
+                class="sc-bQdQlF kUjWPQ"
                 style="width: 160.51364365971108%;"
               />
             </div>

--- a/src/components/Steps/__snapshots__/Steps.stories.storyshot
+++ b/src/components/Steps/__snapshots__/Steps.stories.storyshot
@@ -359,7 +359,7 @@ exports[`Storyshots Core/Steps With Custom Title 1`] = `
           </svg>
         </div>
         <h6
-          class="sc-gWHgXt vKAIQ sc-eggNIi bmOwTH"
+          class="sc-iktFzd bZzDXR sc-bZSQDF GiOZA"
         >
           Beginners Guide
         </h6>

--- a/src/components/Steps/__snapshots__/Steps.stories.storyshot
+++ b/src/components/Steps/__snapshots__/Steps.stories.storyshot
@@ -3,10 +3,10 @@
 exports[`Storyshots Core/Steps Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
-      class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-dmlrTW fLUTfi gKJALV sc-fHYxKZ fcysqr"
+      class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-dmlrTW fLUTfi gKJALV sc-fWPcDo cA-dlpk"
     >
       <div
         class="sc-gKsewC cgpPfo sc-iBPRYJ cILJJc sc-hHftDr bRrPDa"
@@ -18,7 +18,7 @@ exports[`Storyshots Core/Steps Default 1`] = `
             class="sc-gKsewC cgpPfo sc-iBPRYJ iTdmGI sc-hHftDr fYuNSV"
           >
             <div
-              class="sc-gKsewC cgpPfo sc-iBPRYJ dzgPqC sc-hHftDr sc-hjWSAi cLDXoV GWHGs"
+              class="sc-gKsewC cgpPfo sc-iBPRYJ dzgPqC sc-hHftDr sc-cbDGPM cLDXoV jfcZuZ"
             >
               <svg
                 aria-hidden="true"
@@ -76,7 +76,7 @@ exports[`Storyshots Core/Steps Default 1`] = `
             class="sc-gKsewC cgpPfo sc-iBPRYJ iTdmGI sc-hHftDr fYuNSV"
           >
             <div
-              class="sc-gKsewC cgpPfo sc-iBPRYJ dzgPqC sc-hHftDr sc-hjWSAi cLDXoV GWHGs"
+              class="sc-gKsewC cgpPfo sc-iBPRYJ dzgPqC sc-hHftDr sc-cbDGPM cLDXoV jfcZuZ"
             >
               <svg
                 aria-hidden="true"
@@ -134,7 +134,7 @@ exports[`Storyshots Core/Steps Default 1`] = `
             class="sc-gKsewC cgpPfo sc-iBPRYJ iTdmGI sc-hHftDr fYuNSV"
           >
             <div
-              class="sc-gKsewC cgpPfo sc-iBPRYJ dzgPqC sc-hHftDr sc-hjWSAi cLDXoV GWHGs"
+              class="sc-gKsewC cgpPfo sc-iBPRYJ dzgPqC sc-hHftDr sc-cbDGPM cLDXoV jfcZuZ"
             >
               <svg
                 aria-hidden="true"
@@ -168,10 +168,10 @@ exports[`Storyshots Core/Steps Default 1`] = `
 exports[`Storyshots Core/Steps Ordered 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
-      class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-dmlrTW fLUTfi gKJALV sc-fHYxKZ fcysqr"
+      class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-dmlrTW fLUTfi gKJALV sc-fWPcDo cA-dlpk"
     >
       <div
         class="sc-gKsewC cgpPfo sc-iBPRYJ cILJJc sc-hHftDr bRrPDa"
@@ -183,7 +183,7 @@ exports[`Storyshots Core/Steps Ordered 1`] = `
             class="sc-gKsewC cgpPfo sc-iBPRYJ iTdmGI sc-hHftDr fYuNSV"
           >
             <div
-              class="sc-gKsewC cgpPfo sc-iBPRYJ dzgPqC sc-hHftDr sc-hjWSAi cLDXoV GWHGs"
+              class="sc-gKsewC cgpPfo sc-iBPRYJ dzgPqC sc-hHftDr sc-cbDGPM cLDXoV jfcZuZ"
             >
               <svg
                 aria-hidden="true"
@@ -241,7 +241,7 @@ exports[`Storyshots Core/Steps Ordered 1`] = `
             class="sc-gKsewC cgpPfo sc-iBPRYJ iTdmGI sc-hHftDr fYuNSV"
           >
             <div
-              class="sc-gKsewC cgpPfo sc-iBPRYJ gCUzdd sc-hHftDr sc-hjWSAi cLDXoV GWHGs fa-layers"
+              class="sc-gKsewC cgpPfo sc-iBPRYJ gCUzdd sc-hHftDr sc-cbDGPM cLDXoV jfcZuZ fa-layers"
             >
               <svg
                 aria-hidden="true"
@@ -259,7 +259,7 @@ exports[`Storyshots Core/Steps Ordered 1`] = `
                 />
               </svg>
               <div
-                class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-gVgnHT bSNzSd fa-layers-text fa-inverse"
+                class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-hjWSAi dIEIaP fa-layers-text fa-inverse"
               >
                 2
               </div>
@@ -304,13 +304,13 @@ exports[`Storyshots Core/Steps Ordered 1`] = `
             class="sc-gKsewC cgpPfo sc-iBPRYJ iTdmGI sc-hHftDr fYuNSV"
           >
             <div
-              class="sc-gKsewC cgpPfo sc-iBPRYJ dStBGr sc-hHftDr sc-hjWSAi cLDXoV GWHGs fa-layers"
+              class="sc-gKsewC cgpPfo sc-iBPRYJ dStBGr sc-hHftDr sc-cbDGPM cLDXoV jfcZuZ fa-layers"
             >
               <div
-                class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-fWPcDo jrPWli"
+                class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-gVgnHT wNzeP"
               />
               <div
-                class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-gVgnHT bSNzSd fa-layers-text"
+                class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-hjWSAi dIEIaP fa-layers-text"
               >
                 3
               </div>
@@ -331,10 +331,10 @@ exports[`Storyshots Core/Steps Ordered 1`] = `
 exports[`Storyshots Core/Steps With Custom Title 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
-      class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-dmlrTW fLUTfi gKJALV sc-fHYxKZ fcysqr"
+      class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-dmlrTW fLUTfi gKJALV sc-fWPcDo cA-dlpk"
     >
       <div
         class="sc-gKsewC cgpPfo sc-iBPRYJ jDRXQs sc-hHftDr kFVJVF"
@@ -374,7 +374,7 @@ exports[`Storyshots Core/Steps With Custom Title 1`] = `
             class="sc-gKsewC cgpPfo sc-iBPRYJ iTdmGI sc-hHftDr fYuNSV"
           >
             <div
-              class="sc-gKsewC cgpPfo sc-iBPRYJ dzgPqC sc-hHftDr sc-hjWSAi cLDXoV GWHGs"
+              class="sc-gKsewC cgpPfo sc-iBPRYJ dzgPqC sc-hHftDr sc-cbDGPM cLDXoV jfcZuZ"
             >
               <svg
                 aria-hidden="true"
@@ -432,7 +432,7 @@ exports[`Storyshots Core/Steps With Custom Title 1`] = `
             class="sc-gKsewC cgpPfo sc-iBPRYJ iTdmGI sc-hHftDr fYuNSV"
           >
             <div
-              class="sc-gKsewC cgpPfo sc-iBPRYJ dzgPqC sc-hHftDr sc-hjWSAi cLDXoV GWHGs"
+              class="sc-gKsewC cgpPfo sc-iBPRYJ dzgPqC sc-hHftDr sc-cbDGPM cLDXoV jfcZuZ"
             >
               <svg
                 aria-hidden="true"
@@ -490,7 +490,7 @@ exports[`Storyshots Core/Steps With Custom Title 1`] = `
             class="sc-gKsewC cgpPfo sc-iBPRYJ iTdmGI sc-hHftDr fYuNSV"
           >
             <div
-              class="sc-gKsewC cgpPfo sc-iBPRYJ dzgPqC sc-hHftDr sc-hjWSAi cLDXoV GWHGs"
+              class="sc-gKsewC cgpPfo sc-iBPRYJ dzgPqC sc-hHftDr sc-cbDGPM cLDXoV jfcZuZ"
             >
               <svg
                 aria-hidden="true"
@@ -524,10 +524,10 @@ exports[`Storyshots Core/Steps With Custom Title 1`] = `
 exports[`Storyshots Core/Steps Without Borders 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
-      class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-dmlrTW fLUTfi jifnFy sc-fHYxKZ fcysqr"
+      class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-dmlrTW fLUTfi jifnFy sc-fWPcDo cA-dlpk"
     >
       <div
         class="sc-gKsewC cgpPfo sc-iBPRYJ cILJJc sc-hHftDr bRrPDa"
@@ -539,7 +539,7 @@ exports[`Storyshots Core/Steps Without Borders 1`] = `
             class="sc-gKsewC cgpPfo sc-iBPRYJ iTdmGI sc-hHftDr fYuNSV"
           >
             <div
-              class="sc-gKsewC cgpPfo sc-iBPRYJ dzgPqC sc-hHftDr sc-hjWSAi cLDXoV GWHGs"
+              class="sc-gKsewC cgpPfo sc-iBPRYJ dzgPqC sc-hHftDr sc-cbDGPM cLDXoV jfcZuZ"
             >
               <svg
                 aria-hidden="true"
@@ -558,7 +558,7 @@ exports[`Storyshots Core/Steps Without Borders 1`] = `
               </svg>
             </div>
             <a
-              class="sc-eGCarw kBARfK sc-ctaXAZ bvFpzE"
+              class="sc-bXDlPE lhITcI sc-eGCarw CequI"
               color="primary.main"
             >
               Doesn't have
@@ -598,7 +598,7 @@ exports[`Storyshots Core/Steps Without Borders 1`] = `
             class="sc-gKsewC cgpPfo sc-iBPRYJ iTdmGI sc-hHftDr fYuNSV"
           >
             <div
-              class="sc-gKsewC cgpPfo sc-iBPRYJ dStBGr sc-hHftDr sc-hjWSAi cLDXoV GWHGs"
+              class="sc-gKsewC cgpPfo sc-iBPRYJ dStBGr sc-hHftDr sc-cbDGPM cLDXoV jfcZuZ"
             >
               <svg
                 aria-hidden="true"
@@ -617,7 +617,7 @@ exports[`Storyshots Core/Steps Without Borders 1`] = `
               </svg>
             </div>
             <a
-              class="sc-eGCarw kBARfK sc-ctaXAZ bvFpzE"
+              class="sc-bXDlPE lhITcI sc-eGCarw CequI"
               color="primary.main"
             >
               Title or dismiss button
@@ -657,7 +657,7 @@ exports[`Storyshots Core/Steps Without Borders 1`] = `
             class="sc-gKsewC cgpPfo sc-iBPRYJ iTdmGI sc-hHftDr fYuNSV"
           >
             <a
-              class="sc-eGCarw kBARfK sc-ctaXAZ bvFpzE"
+              class="sc-bXDlPE lhITcI sc-eGCarw CequI"
               color="primary.main"
             >
               That's it (no icon)

--- a/src/components/Table/__snapshots__/Table.stories.storyshot
+++ b/src/components/Table/__snapshots__/Table.stories.storyshot
@@ -3,13 +3,13 @@
 exports[`Storyshots Core/Table Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
-      class="sc-irlOZD IlvTR"
+      class="sc-iGctRS fBeMOH"
     >
       <div
-        class="sc-eWvPJL fbVfNP"
+        class="sc-irlOZD iSubxv"
       >
         <div
           data-display="table-head"
@@ -21,7 +21,7 @@ exports[`Storyshots Core/Table Default 1`] = `
               data-display="table-cell"
             >
               <button
-                class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG sc-kUbhmq MktDz"
+                class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG sc-eWvPJL foozHZ"
                 data-field="Name"
                 type="button"
               >
@@ -49,7 +49,7 @@ exports[`Storyshots Core/Table Default 1`] = `
               data-display="table-cell"
             >
               <button
-                class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG sc-kUbhmq MktDz"
+                class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG sc-eWvPJL foozHZ"
                 data-field="pokedex_number"
                 type="button"
               >
@@ -77,7 +77,7 @@ exports[`Storyshots Core/Table Default 1`] = `
               data-display="table-cell"
             >
               <button
-                class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG sc-kUbhmq MktDz"
+                class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG sc-eWvPJL foozHZ"
                 data-field="Category"
                 type="button"
               >
@@ -105,7 +105,7 @@ exports[`Storyshots Core/Table Default 1`] = `
               data-display="table-cell"
             >
               <button
-                class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG sc-kUbhmq MktDz"
+                class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG sc-eWvPJL foozHZ"
                 data-field="first_seen"
                 type="button"
               >
@@ -498,13 +498,13 @@ exports[`Storyshots Core/Table Default 1`] = `
 exports[`Storyshots Core/Table Sorted 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
-      class="sc-irlOZD IlvTR"
+      class="sc-iGctRS fBeMOH"
     >
       <div
-        class="sc-eWvPJL fbVfNP"
+        class="sc-irlOZD iSubxv"
       >
         <div
           data-display="table-head"
@@ -516,7 +516,7 @@ exports[`Storyshots Core/Table Sorted 1`] = `
               data-display="table-cell"
             >
               <button
-                class="StyledButton-sc-323bzc-0 fVClA-D sc-bqyKva sc-bkzZxe gjQfnS dvvpJt sc-dIUggk YDvpG sc-kUbhmq MktDz"
+                class="StyledButton-sc-323bzc-0 fVClA-D sc-bqyKva sc-bkzZxe gjQfnS dvvpJt sc-dIUggk YDvpG sc-eWvPJL foozHZ"
                 data-field="Name"
                 type="button"
               >
@@ -544,7 +544,7 @@ exports[`Storyshots Core/Table Sorted 1`] = `
               data-display="table-cell"
             >
               <button
-                class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG sc-kUbhmq MktDz"
+                class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG sc-eWvPJL foozHZ"
                 data-field="pokedex_number"
                 type="button"
               >
@@ -572,7 +572,7 @@ exports[`Storyshots Core/Table Sorted 1`] = `
               data-display="table-cell"
             >
               <button
-                class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG sc-kUbhmq MktDz"
+                class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG sc-eWvPJL foozHZ"
                 data-field="Category"
                 type="button"
               >
@@ -600,7 +600,7 @@ exports[`Storyshots Core/Table Sorted 1`] = `
               data-display="table-cell"
             >
               <button
-                class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG sc-kUbhmq MktDz"
+                class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG sc-eWvPJL foozHZ"
                 data-field="first_seen"
                 type="button"
               >
@@ -993,13 +993,13 @@ exports[`Storyshots Core/Table Sorted 1`] = `
 exports[`Storyshots Core/Table With Anchor Rows 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
-      class="sc-irlOZD IlvTR"
+      class="sc-iGctRS fBeMOH"
     >
       <div
-        class="sc-eWvPJL bZuYRt"
+        class="sc-irlOZD kHGdBV"
       >
         <div
           data-display="table-head"
@@ -1011,7 +1011,7 @@ exports[`Storyshots Core/Table With Anchor Rows 1`] = `
               data-display="table-cell"
             >
               <button
-                class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG sc-kUbhmq MktDz"
+                class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG sc-eWvPJL foozHZ"
                 data-field="Name"
                 type="button"
               >
@@ -1039,7 +1039,7 @@ exports[`Storyshots Core/Table With Anchor Rows 1`] = `
               data-display="table-cell"
             >
               <button
-                class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG sc-kUbhmq MktDz"
+                class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG sc-eWvPJL foozHZ"
                 data-field="pokedex_number"
                 type="button"
               >
@@ -1067,7 +1067,7 @@ exports[`Storyshots Core/Table With Anchor Rows 1`] = `
               data-display="table-cell"
             >
               <button
-                class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG sc-kUbhmq MktDz"
+                class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG sc-eWvPJL foozHZ"
                 data-field="Category"
                 type="button"
               >
@@ -1095,7 +1095,7 @@ exports[`Storyshots Core/Table With Anchor Rows 1`] = `
               data-display="table-cell"
             >
               <button
-                class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG sc-kUbhmq MktDz"
+                class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG sc-eWvPJL foozHZ"
                 data-field="first_seen"
                 type="button"
               >
@@ -1576,13 +1576,13 @@ exports[`Storyshots Core/Table With Anchor Rows 1`] = `
 exports[`Storyshots Core/Table With Checkboxes 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
-      class="sc-irlOZD IlvTR"
+      class="sc-iGctRS fBeMOH"
     >
       <div
-        class="sc-eWvPJL btEmpV"
+        class="sc-irlOZD nXcGV"
       >
         <div
           data-display="table-head"
@@ -1591,7 +1591,7 @@ exports[`Storyshots Core/Table With Checkboxes 1`] = `
             data-display="table-row"
           >
             <div
-              class="sc-iGctRS gWuzpO"
+              class="sc-eWVKcp iBUOTC"
               data-display="table-cell"
             >
               <div
@@ -1618,7 +1618,7 @@ exports[`Storyshots Core/Table With Checkboxes 1`] = `
               data-display="table-cell"
             >
               <button
-                class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG sc-kUbhmq MktDz"
+                class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG sc-eWvPJL foozHZ"
                 data-field="Name"
                 type="button"
               >
@@ -1646,7 +1646,7 @@ exports[`Storyshots Core/Table With Checkboxes 1`] = `
               data-display="table-cell"
             >
               <button
-                class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG sc-kUbhmq MktDz"
+                class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG sc-eWvPJL foozHZ"
                 data-field="pokedex_number"
                 type="button"
               >
@@ -1674,7 +1674,7 @@ exports[`Storyshots Core/Table With Checkboxes 1`] = `
               data-display="table-cell"
             >
               <button
-                class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG sc-kUbhmq MktDz"
+                class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG sc-eWvPJL foozHZ"
                 data-field="Category"
                 type="button"
               >
@@ -1702,7 +1702,7 @@ exports[`Storyshots Core/Table With Checkboxes 1`] = `
               data-display="table-cell"
             >
               <button
-                class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG sc-kUbhmq MktDz"
+                class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG sc-eWvPJL foozHZ"
                 data-field="first_seen"
                 type="button"
               >
@@ -1737,7 +1737,7 @@ exports[`Storyshots Core/Table With Checkboxes 1`] = `
             data-highlight="true"
           >
             <div
-              class="sc-iGctRS gWuzpO"
+              class="sc-eWVKcp iBUOTC"
               data-display="table-cell"
             >
               <div
@@ -1804,7 +1804,7 @@ exports[`Storyshots Core/Table With Checkboxes 1`] = `
             data-highlight="true"
           >
             <div
-              class="sc-iGctRS gWuzpO"
+              class="sc-eWVKcp iBUOTC"
               data-display="table-cell"
             >
               <div
@@ -1871,7 +1871,7 @@ exports[`Storyshots Core/Table With Checkboxes 1`] = `
             data-highlight="true"
           >
             <div
-              class="sc-iGctRS gWuzpO"
+              class="sc-eWVKcp iBUOTC"
               data-display="table-cell"
             >
               <div
@@ -1938,7 +1938,7 @@ exports[`Storyshots Core/Table With Checkboxes 1`] = `
             data-highlight="false"
           >
             <div
-              class="sc-iGctRS gWuzpO"
+              class="sc-eWVKcp iBUOTC"
               data-display="table-cell"
             >
               <div
@@ -1993,7 +1993,7 @@ exports[`Storyshots Core/Table With Checkboxes 1`] = `
             data-highlight="false"
           >
             <div
-              class="sc-iGctRS gWuzpO"
+              class="sc-eWVKcp iBUOTC"
               data-display="table-cell"
             >
               <div
@@ -2056,7 +2056,7 @@ exports[`Storyshots Core/Table With Checkboxes 1`] = `
             data-highlight="false"
           >
             <div
-              class="sc-iGctRS gWuzpO"
+              class="sc-eWVKcp iBUOTC"
               data-display="table-cell"
             >
               <div
@@ -2119,7 +2119,7 @@ exports[`Storyshots Core/Table With Checkboxes 1`] = `
             data-highlight="false"
           >
             <div
-              class="sc-iGctRS gWuzpO"
+              class="sc-eWVKcp iBUOTC"
               data-display="table-cell"
             >
               <div
@@ -2182,7 +2182,7 @@ exports[`Storyshots Core/Table With Checkboxes 1`] = `
             data-highlight="false"
           >
             <div
-              class="sc-iGctRS gWuzpO"
+              class="sc-eWVKcp iBUOTC"
               data-display="table-cell"
             >
               <div
@@ -2237,7 +2237,7 @@ exports[`Storyshots Core/Table With Checkboxes 1`] = `
             data-highlight="false"
           >
             <div
-              class="sc-iGctRS gWuzpO"
+              class="sc-eWVKcp iBUOTC"
               data-display="table-cell"
             >
               <div
@@ -2292,7 +2292,7 @@ exports[`Storyshots Core/Table With Checkboxes 1`] = `
             data-highlight="false"
           >
             <div
-              class="sc-iGctRS gWuzpO"
+              class="sc-eWVKcp iBUOTC"
               data-display="table-cell"
             >
               <div
@@ -2347,7 +2347,7 @@ exports[`Storyshots Core/Table With Checkboxes 1`] = `
             data-highlight="false"
           >
             <div
-              class="sc-iGctRS gWuzpO"
+              class="sc-eWVKcp iBUOTC"
               data-display="table-cell"
             >
               <div
@@ -2406,13 +2406,13 @@ exports[`Storyshots Core/Table With Checkboxes 1`] = `
 exports[`Storyshots Core/Table With Conditional Row Classes 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
-      class="sc-irlOZD IlvTR"
+      class="sc-iGctRS fBeMOH"
     >
       <div
-        class="sc-eWvPJL fbVfNP"
+        class="sc-irlOZD iSubxv"
       >
         <div
           data-display="table-head"
@@ -2424,7 +2424,7 @@ exports[`Storyshots Core/Table With Conditional Row Classes 1`] = `
               data-display="table-cell"
             >
               <button
-                class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG sc-kUbhmq MktDz"
+                class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG sc-eWvPJL foozHZ"
                 data-field="Name"
                 type="button"
               >
@@ -2452,7 +2452,7 @@ exports[`Storyshots Core/Table With Conditional Row Classes 1`] = `
               data-display="table-cell"
             >
               <button
-                class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG sc-kUbhmq MktDz"
+                class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG sc-eWvPJL foozHZ"
                 data-field="pokedex_number"
                 type="button"
               >
@@ -2480,7 +2480,7 @@ exports[`Storyshots Core/Table With Conditional Row Classes 1`] = `
               data-display="table-cell"
             >
               <button
-                class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG sc-kUbhmq MktDz"
+                class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG sc-eWvPJL foozHZ"
                 data-field="Category"
                 type="button"
               >
@@ -2508,7 +2508,7 @@ exports[`Storyshots Core/Table With Conditional Row Classes 1`] = `
               data-display="table-cell"
             >
               <button
-                class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG sc-kUbhmq MktDz"
+                class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG sc-eWvPJL foozHZ"
                 data-field="first_seen"
                 type="button"
               >
@@ -2901,13 +2901,13 @@ exports[`Storyshots Core/Table With Conditional Row Classes 1`] = `
 exports[`Storyshots Core/Table With Highlighted Rows 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
-      class="sc-irlOZD IlvTR"
+      class="sc-iGctRS fBeMOH"
     >
       <div
-        class="sc-eWvPJL fbVfNP"
+        class="sc-irlOZD iSubxv"
       >
         <div
           data-display="table-head"
@@ -2919,7 +2919,7 @@ exports[`Storyshots Core/Table With Highlighted Rows 1`] = `
               data-display="table-cell"
             >
               <button
-                class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG sc-kUbhmq MktDz"
+                class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG sc-eWvPJL foozHZ"
                 data-field="Name"
                 type="button"
               >
@@ -2947,7 +2947,7 @@ exports[`Storyshots Core/Table With Highlighted Rows 1`] = `
               data-display="table-cell"
             >
               <button
-                class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG sc-kUbhmq MktDz"
+                class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG sc-eWvPJL foozHZ"
                 data-field="pokedex_number"
                 type="button"
               >
@@ -2975,7 +2975,7 @@ exports[`Storyshots Core/Table With Highlighted Rows 1`] = `
               data-display="table-cell"
             >
               <button
-                class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG sc-kUbhmq MktDz"
+                class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG sc-eWvPJL foozHZ"
                 data-field="Category"
                 type="button"
               >
@@ -3003,7 +3003,7 @@ exports[`Storyshots Core/Table With Highlighted Rows 1`] = `
               data-display="table-cell"
             >
               <button
-                class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG sc-kUbhmq MktDz"
+                class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG sc-eWvPJL foozHZ"
                 data-field="first_seen"
                 type="button"
               >
@@ -3396,7 +3396,7 @@ exports[`Storyshots Core/Table With Highlighted Rows 1`] = `
 exports[`Storyshots Core/Table With Pager 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="sc-gKsewC cgpPfo sc-iBPRYJ bBwSze sc-hHftDr ZlJMD"
@@ -3466,10 +3466,10 @@ exports[`Storyshots Core/Table With Pager 1`] = `
       </div>
     </div>
     <div
-      class="sc-irlOZD IlvTR"
+      class="sc-iGctRS fBeMOH"
     >
       <div
-        class="sc-eWvPJL fbVfNP"
+        class="sc-irlOZD iSubxv"
       >
         <div
           data-display="table-head"
@@ -3481,7 +3481,7 @@ exports[`Storyshots Core/Table With Pager 1`] = `
               data-display="table-cell"
             >
               <button
-                class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG sc-kUbhmq MktDz"
+                class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG sc-eWvPJL foozHZ"
                 data-field="Name"
                 type="button"
               >
@@ -3509,7 +3509,7 @@ exports[`Storyshots Core/Table With Pager 1`] = `
               data-display="table-cell"
             >
               <button
-                class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG sc-kUbhmq MktDz"
+                class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG sc-eWvPJL foozHZ"
                 data-field="pokedex_number"
                 type="button"
               >
@@ -3537,7 +3537,7 @@ exports[`Storyshots Core/Table With Pager 1`] = `
               data-display="table-cell"
             >
               <button
-                class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG sc-kUbhmq MktDz"
+                class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG sc-eWvPJL foozHZ"
                 data-field="Category"
                 type="button"
               >
@@ -3565,7 +3565,7 @@ exports[`Storyshots Core/Table With Pager 1`] = `
               data-display="table-cell"
             >
               <button
-                class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG sc-kUbhmq MktDz"
+                class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG sc-eWvPJL foozHZ"
                 data-field="first_seen"
                 type="button"
               >
@@ -3761,13 +3761,13 @@ exports[`Storyshots Core/Table With Pager 1`] = `
 exports[`Storyshots Core/Table With Prefix 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
-      class="sc-irlOZD IlvTR"
+      class="sc-iGctRS fBeMOH"
     >
       <div
-        class="sc-eWvPJL fbVfNP"
+        class="sc-irlOZD iSubxv"
       >
         <div
           data-display="table-head"
@@ -3779,7 +3779,7 @@ exports[`Storyshots Core/Table With Prefix 1`] = `
               data-display="table-cell"
             >
               <button
-                class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG sc-kUbhmq MktDz"
+                class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG sc-eWvPJL foozHZ"
                 data-field="Name"
                 type="button"
               >
@@ -3807,7 +3807,7 @@ exports[`Storyshots Core/Table With Prefix 1`] = `
               data-display="table-cell"
             >
               <button
-                class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG sc-kUbhmq MktDz"
+                class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG sc-eWvPJL foozHZ"
                 data-field="pokedex_number"
                 type="button"
               >
@@ -3835,7 +3835,7 @@ exports[`Storyshots Core/Table With Prefix 1`] = `
               data-display="table-cell"
             >
               <button
-                class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG sc-kUbhmq MktDz"
+                class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG sc-eWvPJL foozHZ"
                 data-field="Category"
                 type="button"
               >
@@ -3863,7 +3863,7 @@ exports[`Storyshots Core/Table With Prefix 1`] = `
               data-display="table-cell"
             >
               <button
-                class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG sc-kUbhmq MktDz"
+                class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG sc-eWvPJL foozHZ"
                 data-field="first_seen"
                 type="button"
               >
@@ -4278,13 +4278,13 @@ exports[`Storyshots Core/Table With Prefix 1`] = `
 exports[`Storyshots Core/Table With Row Click 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
-      class="sc-irlOZD IlvTR"
+      class="sc-iGctRS fBeMOH"
     >
       <div
-        class="sc-eWvPJL bZuYRt"
+        class="sc-irlOZD kHGdBV"
       >
         <div
           data-display="table-head"
@@ -4296,7 +4296,7 @@ exports[`Storyshots Core/Table With Row Click 1`] = `
               data-display="table-cell"
             >
               <button
-                class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG sc-kUbhmq MktDz"
+                class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG sc-eWvPJL foozHZ"
                 data-field="Name"
                 type="button"
               >
@@ -4324,7 +4324,7 @@ exports[`Storyshots Core/Table With Row Click 1`] = `
               data-display="table-cell"
             >
               <button
-                class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG sc-kUbhmq MktDz"
+                class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG sc-eWvPJL foozHZ"
                 data-field="pokedex_number"
                 type="button"
               >
@@ -4352,7 +4352,7 @@ exports[`Storyshots Core/Table With Row Click 1`] = `
               data-display="table-cell"
             >
               <button
-                class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG sc-kUbhmq MktDz"
+                class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG sc-eWvPJL foozHZ"
                 data-field="Category"
                 type="button"
               >
@@ -4380,7 +4380,7 @@ exports[`Storyshots Core/Table With Row Click 1`] = `
               data-display="table-cell"
             >
               <button
-                class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG sc-kUbhmq MktDz"
+                class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG sc-eWvPJL foozHZ"
                 data-field="first_seen"
                 type="button"
               >

--- a/src/components/Tabs/__snapshots__/Tabs.stories.storyshot
+++ b/src/components/Tabs/__snapshots__/Tabs.stories.storyshot
@@ -3,10 +3,10 @@
 exports[`Storyshots Core/Tabs Compact 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 dYebPD StyledTabs-a4fwxl-2 jQLYpX sc-fybufo hTkUKI sc-iWFSnp dyTeJE"
+      class="StyledBox-sc-13pk1d4-0 dYebPD StyledTabs-a4fwxl-2 jQLYpX sc-gIRixj cPFWEC sc-fybufo evTA-dY"
       role="tablist"
     >
       <div
@@ -134,10 +134,10 @@ exports[`Storyshots Core/Tabs Compact 1`] = `
 exports[`Storyshots Core/Tabs Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 dYebPD StyledTabs-a4fwxl-2 jQLYpX sc-fybufo bihSlZ sc-iWFSnp dyTeJE"
+      class="StyledBox-sc-13pk1d4-0 dYebPD StyledTabs-a4fwxl-2 jQLYpX sc-gIRixj npfmj sc-fybufo evTA-dY"
       role="tablist"
     >
       <div
@@ -214,10 +214,10 @@ exports[`Storyshots Core/Tabs Default 1`] = `
 exports[`Storyshots Core/Tabs With Long Titles 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 dYebPD StyledTabs-a4fwxl-2 jQLYpX sc-fybufo bihSlZ sc-iWFSnp dyTeJE"
+      class="StyledBox-sc-13pk1d4-0 dYebPD StyledTabs-a4fwxl-2 jQLYpX sc-gIRixj npfmj sc-fybufo evTA-dY"
       role="tablist"
     >
       <div

--- a/src/components/Tag/__snapshots__/Tag.stories.storyshot
+++ b/src/components/Tag/__snapshots__/Tag.stories.storyshot
@@ -3,17 +3,17 @@
 exports[`Storyshots Core/Tag Clickable 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
-      class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV sc-GqfZa cHWpcm"
+      class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV sc-fbkhIv gnNozJ"
     >
       <button
         class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk YDvpG"
         type="button"
       >
         <div
-          class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-clsHhM cLDXoV bjaVYF"
+          class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-gGmIRh cLDXoV dgHkOy"
         >
           <div
             class="sc-fKFyDc dTkenA sc-bBXqnf iHGIIw"
@@ -35,13 +35,13 @@ exports[`Storyshots Core/Tag Clickable 1`] = `
 exports[`Storyshots Core/Tag Closable 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
-      class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV sc-GqfZa cHWpcm"
+      class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV sc-fbkhIv gnNozJ"
     >
       <div
-        class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-clsHhM cLDXoV bjaVYF"
+        class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-gGmIRh cLDXoV dgHkOy"
       >
         <div
           class="sc-fKFyDc dTkenA sc-bBXqnf iHGIIw"
@@ -55,7 +55,7 @@ exports[`Storyshots Core/Tag Closable 1`] = `
         </div>
       </div>
       <button
-        class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk fBWcUT sc-fbkhIv hQBnSA"
+        class="StyledButton-sc-323bzc-0 jajFOe sc-bqyKva sc-bkzZxe gjQfnS hgJIgM sc-dIUggk fBWcUT sc-clsHhM hUEyIR"
         type="button"
       >
         <svg
@@ -82,13 +82,13 @@ exports[`Storyshots Core/Tag Closable 1`] = `
 exports[`Storyshots Core/Tag Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
-      class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV sc-GqfZa cHWpcm"
+      class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV sc-fbkhIv gnNozJ"
     >
       <div
-        class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-clsHhM cLDXoV bjaVYF"
+        class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-gGmIRh cLDXoV dgHkOy"
       >
         <div
           class="sc-fKFyDc dTkenA sc-bBXqnf iHGIIw"
@@ -109,13 +109,13 @@ exports[`Storyshots Core/Tag Default 1`] = `
 exports[`Storyshots Core/Tag Empty 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
-      class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV sc-GqfZa cHWpcm"
+      class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV sc-fbkhIv gnNozJ"
     >
       <div
-        class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-clsHhM cLDXoV bjaVYF"
+        class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-gGmIRh cLDXoV dgHkOy"
       >
         <div
           class="sc-fKFyDc kZwXGu sc-bBXqnf iHGIIw"
@@ -131,13 +131,13 @@ exports[`Storyshots Core/Tag Empty 1`] = `
 exports[`Storyshots Core/Tag Multiple Values 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
-      class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV sc-GqfZa cHWpcm"
+      class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV sc-fbkhIv gnNozJ"
     >
       <div
-        class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-clsHhM cLDXoV bjaVYF"
+        class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-gGmIRh cLDXoV dgHkOy"
       >
         <div
           class="sc-fKFyDc dTkenA sc-bBXqnf iHGIIw"
@@ -173,13 +173,13 @@ exports[`Storyshots Core/Tag Multiple Values 1`] = `
 exports[`Storyshots Core/Tag Only Name 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
-      class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV sc-GqfZa cHWpcm"
+      class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV sc-fbkhIv gnNozJ"
     >
       <div
-        class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-clsHhM cLDXoV bjaVYF"
+        class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-gGmIRh cLDXoV dgHkOy"
       >
         <div
           class="sc-fKFyDc euqOvB sc-bBXqnf iHGIIw"
@@ -195,13 +195,13 @@ exports[`Storyshots Core/Tag Only Name 1`] = `
 exports[`Storyshots Core/Tag Only Value 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
-      class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV sc-GqfZa cHWpcm"
+      class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV sc-fbkhIv gnNozJ"
     >
       <div
-        class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-clsHhM cLDXoV bjaVYF"
+        class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-gGmIRh cLDXoV dgHkOy"
       >
         <div
           class="sc-fKFyDc euqOvB sc-bBXqnf iHGIIw"

--- a/src/components/Terminal/__snapshots__/Terminal.stories.storyshot
+++ b/src/components/Terminal/__snapshots__/Terminal.stories.storyshot
@@ -3,16 +3,16 @@
 exports[`Storyshots Core/Terminal Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       style="height: 500px;"
     >
       <div
-        class="sc-gKsewC dWcnb sc-iBPRYJ eRfhOV sc-hHftDr sc-jtHMlw cLDXoV eBbwFj"
+        class="sc-gKsewC dWcnb sc-iBPRYJ eRfhOV sc-hHftDr sc-dwcuIR cLDXoV gjTlgd"
       >
         <div
-          class="sc-gKsewC dWcnb sc-iBPRYJ dWRxlP sc-hHftDr sc-eltcbb iIBJBt gTjPbv"
+          class="sc-gKsewC dWcnb sc-iBPRYJ dWRxlP sc-hHftDr sc-jtHMlw iIBJBt bcLjAp"
         />
       </div>
     </div>
@@ -23,16 +23,16 @@ exports[`Storyshots Core/Terminal Default 1`] = `
 exports[`Storyshots Core/Terminal Noninteractive Terminal 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       style="height: 500px;"
     >
       <div
-        class="sc-gKsewC dWcnb sc-iBPRYJ eRfhOV sc-hHftDr sc-jtHMlw cLDXoV eBbwFj"
+        class="sc-gKsewC dWcnb sc-iBPRYJ eRfhOV sc-hHftDr sc-dwcuIR cLDXoV gjTlgd"
       >
         <div
-          class="sc-gKsewC dWcnb sc-iBPRYJ dWRxlP sc-hHftDr sc-eltcbb iIBJBt gTjPbv"
+          class="sc-gKsewC dWcnb sc-iBPRYJ dWRxlP sc-hHftDr sc-jtHMlw iIBJBt bcLjAp"
         />
       </div>
     </div>

--- a/src/components/TextWithCopy/__snapshots__/TextWithCopy.stories.storyshot
+++ b/src/components/TextWithCopy/__snapshots__/TextWithCopy.stories.storyshot
@@ -3,10 +3,10 @@
 exports[`Storyshots Core/TextWithCopy Always Show 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <span
-      class="sc-fKFyDc jHCVxA sc-iwyYcG bsaCCL sc-kiYtDG htJzkp text-with-copy"
+      class="sc-fKFyDc jHCVxA sc-iwyYcG bsaCCL sc-eltcbb fXLZGf text-with-copy"
     >
       <span
         class="text-with-copy__content"
@@ -44,10 +44,10 @@ exports[`Storyshots Core/TextWithCopy Always Show 1`] = `
 exports[`Storyshots Core/TextWithCopy Code 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <span
-      class="sc-fKFyDc jHCVxA sc-iwyYcG bsaCCL sc-kiYtDG cohYER text-with-copy"
+      class="sc-fKFyDc jHCVxA sc-iwyYcG bsaCCL sc-eltcbb leyuTn text-with-copy"
       title="This value has been copied to your clipboard!"
     >
       <code
@@ -86,10 +86,10 @@ exports[`Storyshots Core/TextWithCopy Code 1`] = `
 exports[`Storyshots Core/TextWithCopy Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <span
-      class="sc-fKFyDc jHCVxA sc-iwyYcG bsaCCL sc-kiYtDG cohYER text-with-copy"
+      class="sc-fKFyDc jHCVxA sc-iwyYcG bsaCCL sc-eltcbb leyuTn text-with-copy"
       title="This value has been copied to your clipboard!"
     >
       <span

--- a/src/components/Textarea/__snapshots__/Textarea.stories.storyshot
+++ b/src/components/Textarea/__snapshots__/Textarea.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/Textarea Auto Rows 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <textarea
       class="StyledTextArea-sc-17i3mwp-0 gFImaJ sc-laRPJI bNMKOQ sc-iNqMTl fXSmiS"
@@ -15,7 +15,7 @@ exports[`Storyshots Core/Textarea Auto Rows 1`] = `
 exports[`Storyshots Core/Textarea Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <textarea
       class="StyledTextArea-sc-17i3mwp-0 gFImaJ sc-laRPJI bNMKOQ sc-iNqMTl fXSmiS"
@@ -27,7 +27,7 @@ exports[`Storyshots Core/Textarea Default 1`] = `
 exports[`Storyshots Core/Textarea Disabled 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <textarea
       class="StyledTextArea-sc-17i3mwp-0 fQPlXT sc-laRPJI cfHALb sc-iNqMTl fXSmiS"
@@ -40,7 +40,7 @@ exports[`Storyshots Core/Textarea Disabled 1`] = `
 exports[`Storyshots Core/Textarea Min Max Rows 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <textarea
       class="StyledTextArea-sc-17i3mwp-0 gFImaJ sc-laRPJI bNMKOQ sc-iNqMTl fXSmiS"
@@ -53,7 +53,7 @@ exports[`Storyshots Core/Textarea Min Max Rows 1`] = `
 exports[`Storyshots Core/Textarea Monospace 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <textarea
       class="StyledTextArea-sc-17i3mwp-0 gFImaJ sc-laRPJI fYiIrp sc-iNqMTl fXSmiS"
@@ -66,7 +66,7 @@ exports[`Storyshots Core/Textarea Monospace 1`] = `
 exports[`Storyshots Core/Textarea Read Only 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <textarea
       class="StyledTextArea-sc-17i3mwp-0 gFImaJ sc-laRPJI bNMKOQ sc-iNqMTl fXSmiS"
@@ -79,7 +79,7 @@ exports[`Storyshots Core/Textarea Read Only 1`] = `
 exports[`Storyshots Core/Textarea With Placeholder 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <textarea
       class="StyledTextArea-sc-17i3mwp-0 gFImaJ sc-laRPJI bNMKOQ sc-iNqMTl fXSmiS"

--- a/src/components/Txt/__snapshots__/Txt.stories.storyshot
+++ b/src/components/Txt/__snapshots__/Txt.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/Txt Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI"
@@ -17,7 +17,7 @@ exports[`Storyshots Core/Txt Default 1`] = `
 exports[`Storyshots Core/Txt In Color 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="sc-fKFyDc jHCVxA sc-bBXqnf kRESjy"
@@ -31,7 +31,7 @@ exports[`Storyshots Core/Txt In Color 1`] = `
 exports[`Storyshots Core/Txt Span Component 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <span
       class="sc-fKFyDc dTkenA sc-iwyYcG bsaCCL"
@@ -45,7 +45,7 @@ exports[`Storyshots Core/Txt Span Component 1`] = `
 exports[`Storyshots Core/Txt Styled 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="sc-fKFyDc gWdjUC sc-bBXqnf kYwmpI"

--- a/src/extra/Markdown/Markdown.stories.tsx
+++ b/src/extra/Markdown/Markdown.stories.tsx
@@ -21,12 +21,12 @@ const generateTableData = () => {
 				<pre>{JSON.stringify(sanitizerOptions, null, 2)}</pre>
 			),
 			Original: (
-				<Card small>
+				<Card>
 					<Markdown>{markdown}</Markdown>
 				</Card>
 			),
 			Customized: (
-				<Card small>
+				<Card>
 					<Markdown sanitizerOptions={customSanitizerOptions}>
 						{markdown}
 					</Markdown>

--- a/src/extra/Markdown/__snapshots__/Markdown.stories.storyshot
+++ b/src/extra/Markdown/__snapshots__/Markdown.stories.storyshot
@@ -64,10 +64,10 @@ exports[`Storyshots Extra/Markdown Customized 1`] = `
                 class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-dmlrTW cLDXoV gKJALV sc-cTkwdZ kyJVgU sc-jNMdTA eIbWGx"
               >
                 <div
-                  class="sc-gKsewC cgpPfo sc-iBPRYJ kCgyvI"
+                  class="sc-gKsewC dWcnb sc-iBPRYJ dWRxlP sc-hHftDr iIBJBt"
                 >
                   <div
-                    class="sc-gKsewC cgpPfo sc-iBPRYJ kKemJS"
+                    class="sc-gKsewC dWcnb sc-iBPRYJ iTdmGI sc-hHftDr iIBJBt"
                   >
                     <div
                       class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-hYZPRl gyTNli"
@@ -101,10 +101,10 @@ exports[`Storyshots Extra/Markdown Customized 1`] = `
                 class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-dmlrTW cLDXoV gKJALV sc-cTkwdZ kyJVgU sc-jNMdTA eIbWGx"
               >
                 <div
-                  class="sc-gKsewC cgpPfo sc-iBPRYJ kCgyvI"
+                  class="sc-gKsewC dWcnb sc-iBPRYJ dWRxlP sc-hHftDr iIBJBt"
                 >
                   <div
-                    class="sc-gKsewC cgpPfo sc-iBPRYJ kKemJS"
+                    class="sc-gKsewC dWcnb sc-iBPRYJ iTdmGI sc-hHftDr iIBJBt"
                   >
                     <div
                       class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-hYZPRl gyTNli"
@@ -155,10 +155,10 @@ exports[`Storyshots Extra/Markdown Customized 1`] = `
                 class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-dmlrTW cLDXoV gKJALV sc-cTkwdZ kyJVgU sc-jNMdTA eIbWGx"
               >
                 <div
-                  class="sc-gKsewC cgpPfo sc-iBPRYJ kCgyvI"
+                  class="sc-gKsewC dWcnb sc-iBPRYJ dWRxlP sc-hHftDr iIBJBt"
                 >
                   <div
-                    class="sc-gKsewC cgpPfo sc-iBPRYJ kKemJS"
+                    class="sc-gKsewC dWcnb sc-iBPRYJ iTdmGI sc-hHftDr iIBJBt"
                   >
                     <div
                       class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-hYZPRl gyTNli"
@@ -192,10 +192,10 @@ exports[`Storyshots Extra/Markdown Customized 1`] = `
                 class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-dmlrTW cLDXoV gKJALV sc-cTkwdZ kyJVgU sc-jNMdTA eIbWGx"
               >
                 <div
-                  class="sc-gKsewC cgpPfo sc-iBPRYJ kCgyvI"
+                  class="sc-gKsewC dWcnb sc-iBPRYJ dWRxlP sc-hHftDr iIBJBt"
                 >
                   <div
-                    class="sc-gKsewC cgpPfo sc-iBPRYJ kKemJS"
+                    class="sc-gKsewC dWcnb sc-iBPRYJ iTdmGI sc-hHftDr iIBJBt"
                   >
                     <div
                       class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-hYZPRl gyTNli"
@@ -240,10 +240,10 @@ exports[`Storyshots Extra/Markdown Customized 1`] = `
                 class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-dmlrTW cLDXoV gKJALV sc-cTkwdZ kyJVgU sc-jNMdTA eIbWGx"
               >
                 <div
-                  class="sc-gKsewC cgpPfo sc-iBPRYJ kCgyvI"
+                  class="sc-gKsewC dWcnb sc-iBPRYJ dWRxlP sc-hHftDr iIBJBt"
                 >
                   <div
-                    class="sc-gKsewC cgpPfo sc-iBPRYJ kKemJS"
+                    class="sc-gKsewC dWcnb sc-iBPRYJ iTdmGI sc-hHftDr iIBJBt"
                   >
                     <div
                       class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-hYZPRl gyTNli"
@@ -277,10 +277,10 @@ exports[`Storyshots Extra/Markdown Customized 1`] = `
                 class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr sc-dmlrTW cLDXoV gKJALV sc-cTkwdZ kyJVgU sc-jNMdTA eIbWGx"
               >
                 <div
-                  class="sc-gKsewC cgpPfo sc-iBPRYJ kCgyvI"
+                  class="sc-gKsewC dWcnb sc-iBPRYJ dWRxlP sc-hHftDr iIBJBt"
                 >
                   <div
-                    class="sc-gKsewC cgpPfo sc-iBPRYJ kKemJS"
+                    class="sc-gKsewC dWcnb sc-iBPRYJ iTdmGI sc-hHftDr iIBJBt"
                   >
                     <div
                       class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-hYZPRl gyTNli"

--- a/src/extra/Markdown/__snapshots__/Markdown.stories.storyshot
+++ b/src/extra/Markdown/__snapshots__/Markdown.stories.storyshot
@@ -74,7 +74,7 @@ exports[`Storyshots Extra/Markdown Customized 1`] = `
                     >
                       <div>
                         <h1
-                          class="sc-gWHgXt eCVPSB sc-citwmv gCCLOD"
+                          class="sc-iktFzd ePMNkU sc-hiSbYr hwRkKu"
                         >
                           A title
                         </h1>
@@ -165,7 +165,7 @@ exports[`Storyshots Extra/Markdown Customized 1`] = `
                     >
                       <div>
                         <h1
-                          class="sc-gWHgXt eCVPSB sc-citwmv gCCLOD"
+                          class="sc-iktFzd ePMNkU sc-hiSbYr hwRkKu"
                         >
                           A title
                         </h1>
@@ -250,7 +250,7 @@ exports[`Storyshots Extra/Markdown Customized 1`] = `
                     >
                       <div>
                         <h1
-                          class="sc-gWHgXt eCVPSB sc-citwmv gCCLOD"
+                          class="sc-iktFzd ePMNkU sc-hiSbYr hwRkKu"
                         >
                           A title
                         </h1>
@@ -287,7 +287,7 @@ exports[`Storyshots Extra/Markdown Customized 1`] = `
                     >
                       <div>
                         <h1
-                          class="sc-gWHgXt eCVPSB sc-citwmv gCCLOD"
+                          class="sc-iktFzd ePMNkU sc-hiSbYr hwRkKu"
                         >
                           A title
                         </h1>
@@ -316,7 +316,7 @@ exports[`Storyshots Extra/Markdown Default 1`] = `
     >
       <div>
         <h1
-          class="sc-gWHgXt eCVPSB sc-citwmv gCCLOD"
+          class="sc-iktFzd ePMNkU sc-hiSbYr hwRkKu"
         >
           Markdown
         </h1>
@@ -334,14 +334,14 @@ exports[`Storyshots Extra/Markdown Default 1`] = `
         
 
         <h2
-          class="sc-gWHgXt eCVPSB sc-jcVebW fcdKNU"
+          class="sc-iktFzd ePMNkU sc-gWHgXt goapnY"
         >
           Headers
         </h2>
         
 
         <h1
-          class="sc-gWHgXt eCVPSB sc-citwmv gCCLOD"
+          class="sc-iktFzd ePMNkU sc-hiSbYr hwRkKu"
         >
           This is an 
           <code>
@@ -352,7 +352,7 @@ exports[`Storyshots Extra/Markdown Default 1`] = `
         
 
         <h2
-          class="sc-gWHgXt eCVPSB sc-jcVebW fcdKNU"
+          class="sc-iktFzd ePMNkU sc-gWHgXt goapnY"
         >
           This is an 
           <code>
@@ -363,7 +363,7 @@ exports[`Storyshots Extra/Markdown Default 1`] = `
         
 
         <h6
-          class="sc-gWHgXt vKAIQ sc-eggNIi iUGsQu"
+          class="sc-iktFzd bZzDXR sc-bZSQDF fvMmhJ"
         >
           This is an 
           <code>
@@ -374,7 +374,7 @@ exports[`Storyshots Extra/Markdown Default 1`] = `
         
 
         <h2
-          class="sc-gWHgXt eCVPSB sc-jcVebW fcdKNU"
+          class="sc-iktFzd ePMNkU sc-gWHgXt goapnY"
         >
           Emphasis
         </h2>
@@ -424,14 +424,14 @@ exports[`Storyshots Extra/Markdown Default 1`] = `
         
 
         <h2
-          class="sc-gWHgXt eCVPSB sc-jcVebW fcdKNU"
+          class="sc-iktFzd ePMNkU sc-gWHgXt goapnY"
         >
           Lists
         </h2>
         
 
         <h3
-          class="sc-gWHgXt eCVPSB sc-bZSQDF QBWsK"
+          class="sc-iktFzd ePMNkU sc-cBNfnY hcRIY"
         >
           Unordered
         </h3>
@@ -471,7 +471,7 @@ exports[`Storyshots Extra/Markdown Default 1`] = `
         
 
         <h3
-          class="sc-gWHgXt eCVPSB sc-bZSQDF QBWsK"
+          class="sc-iktFzd ePMNkU sc-cBNfnY hcRIY"
         >
           Ordered
         </h3>
@@ -516,7 +516,7 @@ exports[`Storyshots Extra/Markdown Default 1`] = `
         
 
         <h2
-          class="sc-gWHgXt eCVPSB sc-jcVebW fcdKNU"
+          class="sc-iktFzd ePMNkU sc-gWHgXt goapnY"
         >
           Images
         </h2>
@@ -533,7 +533,7 @@ exports[`Storyshots Extra/Markdown Default 1`] = `
         
 
         <h2
-          class="sc-gWHgXt eCVPSB sc-jcVebW fcdKNU"
+          class="sc-iktFzd ePMNkU sc-gWHgXt goapnY"
         >
           Links
         </h2>
@@ -567,7 +567,7 @@ exports[`Storyshots Extra/Markdown Default 1`] = `
         
 
         <h2
-          class="sc-gWHgXt eCVPSB sc-jcVebW fcdKNU"
+          class="sc-iktFzd ePMNkU sc-gWHgXt goapnY"
         >
           Blockquotes
         </h2>
@@ -594,7 +594,7 @@ exports[`Storyshots Extra/Markdown Default 1`] = `
         
 
         <h2
-          class="sc-gWHgXt eCVPSB sc-jcVebW fcdKNU"
+          class="sc-iktFzd ePMNkU sc-gWHgXt goapnY"
         >
           Inline code
         </h2>
@@ -615,7 +615,7 @@ exports[`Storyshots Extra/Markdown Default 1`] = `
         
 
         <h2
-          class="sc-gWHgXt eCVPSB sc-jcVebW fcdKNU"
+          class="sc-iktFzd ePMNkU sc-gWHgXt goapnY"
         >
           Code blocks
         </h2>
@@ -712,7 +712,7 @@ const foo = () =&gt; {
         
 
         <h2
-          class="sc-gWHgXt eCVPSB sc-jcVebW fcdKNU"
+          class="sc-iktFzd ePMNkU sc-gWHgXt goapnY"
         >
           Task Lists
         </h2>
@@ -762,7 +762,7 @@ const foo = () =&gt; {
         
 
         <h2
-          class="sc-gWHgXt eCVPSB sc-jcVebW fcdKNU"
+          class="sc-iktFzd ePMNkU sc-gWHgXt goapnY"
         >
           Tables
         </h2>
@@ -818,7 +818,7 @@ const foo = () =&gt; {
         
 
         <h2
-          class="sc-gWHgXt eCVPSB sc-jcVebW fcdKNU"
+          class="sc-iktFzd ePMNkU sc-gWHgXt goapnY"
         >
           Strikethrough
         </h2>
@@ -845,7 +845,7 @@ const foo = () =&gt; {
         
 
         <h2
-          class="sc-gWHgXt eCVPSB sc-jcVebW fcdKNU"
+          class="sc-iktFzd ePMNkU sc-gWHgXt goapnY"
         >
           Inline HTML
         </h2>
@@ -891,7 +891,7 @@ const foo = () =&gt; {
         
 
         <h2
-          class="sc-gWHgXt eCVPSB sc-jcVebW fcdKNU"
+          class="sc-iktFzd ePMNkU sc-gWHgXt goapnY"
         >
           Keyboard keys
         </h2>

--- a/src/extra/Markdown/__snapshots__/Markdown.stories.storyshot
+++ b/src/extra/Markdown/__snapshots__/Markdown.stories.storyshot
@@ -3,13 +3,13 @@
 exports[`Storyshots Extra/Markdown Customized 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
-      class="sc-irlOZD IlvTR"
+      class="sc-iGctRS fBeMOH"
     >
       <div
-        class="sc-eWvPJL fbVfNP"
+        class="sc-irlOZD iSubxv"
       >
         <div
           data-display="table-head"
@@ -70,7 +70,7 @@ exports[`Storyshots Extra/Markdown Customized 1`] = `
                     class="sc-gKsewC dWcnb sc-iBPRYJ iTdmGI sc-hHftDr iIBJBt"
                   >
                     <div
-                      class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-hYZPRl gyTNli"
+                      class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-dRPiIx qUHcx"
                     >
                       <div>
                         <h1
@@ -107,7 +107,7 @@ exports[`Storyshots Extra/Markdown Customized 1`] = `
                     class="sc-gKsewC dWcnb sc-iBPRYJ iTdmGI sc-hHftDr iIBJBt"
                   >
                     <div
-                      class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-hYZPRl gyTNli"
+                      class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-dRPiIx qUHcx"
                     >
                       <div>
                         A title
@@ -161,7 +161,7 @@ exports[`Storyshots Extra/Markdown Customized 1`] = `
                     class="sc-gKsewC dWcnb sc-iBPRYJ iTdmGI sc-hHftDr iIBJBt"
                   >
                     <div
-                      class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-hYZPRl gyTNli"
+                      class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-dRPiIx qUHcx"
                     >
                       <div>
                         <h1
@@ -198,7 +198,7 @@ exports[`Storyshots Extra/Markdown Customized 1`] = `
                     class="sc-gKsewC dWcnb sc-iBPRYJ iTdmGI sc-hHftDr iIBJBt"
                   >
                     <div
-                      class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-hYZPRl gyTNli"
+                      class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-dRPiIx qUHcx"
                     >
                       <div>
                         A title
@@ -246,7 +246,7 @@ exports[`Storyshots Extra/Markdown Customized 1`] = `
                     class="sc-gKsewC dWcnb sc-iBPRYJ iTdmGI sc-hHftDr iIBJBt"
                   >
                     <div
-                      class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-hYZPRl gyTNli"
+                      class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-dRPiIx qUHcx"
                     >
                       <div>
                         <h1
@@ -283,7 +283,7 @@ exports[`Storyshots Extra/Markdown Customized 1`] = `
                     class="sc-gKsewC dWcnb sc-iBPRYJ iTdmGI sc-hHftDr iIBJBt"
                   >
                     <div
-                      class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-hYZPRl gyTNli"
+                      class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-dRPiIx qUHcx"
                     >
                       <div>
                         <h1
@@ -309,10 +309,10 @@ exports[`Storyshots Extra/Markdown Customized 1`] = `
 exports[`Storyshots Extra/Markdown Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
-      class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-hYZPRl gyTNli"
+      class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-dRPiIx qUHcx"
     >
       <div>
         <h1
@@ -543,7 +543,7 @@ exports[`Storyshots Extra/Markdown Default 1`] = `
           class="sc-fKFyDc jHCVxA sc-cxFLnm kkkmRH"
         >
           <a
-            class="sc-eGCarw kBARfK sc-ctaXAZ bvFpzE"
+            class="sc-bXDlPE lhITcI sc-eGCarw CequI"
             color="primary.main"
             href="http://github.com"
           >
@@ -557,7 +557,7 @@ exports[`Storyshots Extra/Markdown Default 1`] = `
           class="sc-fKFyDc jHCVxA sc-cxFLnm kkkmRH"
         >
           <a
-            class="sc-eGCarw kBARfK sc-ctaXAZ bvFpzE"
+            class="sc-bXDlPE lhITcI sc-eGCarw CequI"
             color="primary.main"
             href="http://github.com"
           >
@@ -881,7 +881,7 @@ const foo = () =&gt; {
           
 
           <a
-            class="sc-eGCarw kBARfK sc-ctaXAZ bvFpzE"
+            class="sc-bXDlPE lhITcI sc-eGCarw CequI"
             color="primary.main"
             href="http://github.com/"
           >
@@ -925,10 +925,10 @@ const foo = () =&gt; {
 exports[`Storyshots Extra/Markdown With Decorators 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
-      class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-hYZPRl gyTNli"
+      class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI sc-dRPiIx qUHcx"
     >
       <div>
         <p
@@ -944,7 +944,7 @@ exports[`Storyshots Extra/Markdown With Decorators 1`] = `
              foo @bad@bad 
           </span>
           <a
-            class="sc-eGCarw kBARfK sc-ctaXAZ bvFpzE"
+            class="sc-bXDlPE lhITcI sc-eGCarw CequI"
             color="primary.main"
             href="https://github.com"
           >

--- a/src/extra/MarkdownEditor/__snapshots__/MarkdownEditor.stories.storyshot
+++ b/src/extra/MarkdownEditor/__snapshots__/MarkdownEditor.stories.storyshot
@@ -3,10 +3,10 @@
 exports[`Storyshots Extra/MarkdownEditor Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
-      class="sc-tkKAw ddBawh"
+      class="sc-bUrJUP bSArhB"
       id="simplemde-editor-2-wrapper"
     >
       <textarea

--- a/src/extra/Mermaid/__snapshots__/Mermaid.stories.storyshot
+++ b/src/extra/Mermaid/__snapshots__/Mermaid.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Extra/Mermaid Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-jXktwP kNOktQ"
   >
     <div
       class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP"

--- a/src/internal/ActionButtonGroup.tsx
+++ b/src/internal/ActionButtonGroup.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react';
+import { Button } from '../components/Button';
+import { ActionButtonDefinition, orderedActionTypes } from '../common-types';
+import { sortedGroupBy } from '../utils';
+
+export interface ActionButtonGroupProps {
+	actions: ActionButtonDefinition[] | undefined;
+}
+
+export const ActionButtonGroup = ({ actions }: ActionButtonGroupProps) => {
+	const groupedActionEntries = React.useMemo(() => {
+		const groupedActions = sortedGroupBy(
+			actions,
+			(action) => action.type ?? orderedActionTypes[0],
+			orderedActionTypes,
+		);
+		return Object.entries(groupedActions);
+	}, [actions]);
+
+	const actionEntries = groupedActionEntries
+		.map(([group, actionsGroup], index) => [
+			actionsGroup.map(
+				({ title, type, onTriggerAction, disabled, hidden }) =>
+					!hidden && (
+						<Button
+							key={group + index}
+							{...(!!type &&
+								type !== orderedActionTypes[0] && { [type]: true })}
+							disabled={!!disabled}
+							tooltip={typeof disabled === 'string' ? disabled : undefined}
+							onClick={onTriggerAction}
+							ml={2}
+							mt={1}
+						>
+							{title}
+						</Button>
+					),
+			),
+		])
+		.filter((action) => !!action);
+
+	if (!actionEntries.length) {
+		return null;
+	}
+
+	return <>{actionEntries}</>;
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
+import { Dictionary, groupBy, ValueIteratee } from 'lodash';
 import * as React from 'react';
 export * from './colorUtils';
 export * from './schemaUtils';
@@ -41,4 +42,20 @@ export const withConditional = <TProps extends {}>(
 			return React.createElement(Component, { ...props, ref });
 		});
 	};
+};
+
+export const sortedGroupBy = <T>(
+	collection: T[] | null | undefined,
+	iteratee: ValueIteratee<T>,
+	orderedKeys: string[],
+): Dictionary<T[]> => {
+	const groupedItems = groupBy(collection, iteratee);
+
+	const sortedGroupedItems: typeof groupedItems = Object.create(null);
+	for (const key of orderedKeys) {
+		if (groupedItems[key]) {
+			sortedGroupedItems[key] = groupedItems[key];
+		}
+	}
+	return sortedGroupedItems;
 };


### PR DESCRIPTION
Add card actions and divider props, and refactor style

Change-type: minor
Signed-off-by: Andrea Rosci <andrear@balena.io>

In this PR we want to add a footer with actions inside the card component and remove the divider if not required. We also fix the body height to not be bigger than the containter.

<img width="423" alt="Screenshot 2021-01-05 at 12 03 11" src="https://user-images.githubusercontent.com/7238159/103639138-33cc4300-4f4e-11eb-9e4d-3b24c29d92de.png">


---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
