### PR TITLE
Form: Allow using the rjsf transformErrors property

### DIFF
--- a/src/components/Form/index.tsx
+++ b/src/components/Form/index.tsx
@@ -118,7 +118,11 @@ export interface FormProps
 	extends BoxProps,
 		Pick<
 			JsonSchemaFormProps<any>,
-			'validate' | 'noValidate' | 'liveValidate' | 'disabled'
+			| 'validate'
+			| 'noValidate'
+			| 'liveValidate'
+			| 'transformErrors'
+			| 'disabled'
 		> {
 	/** A string or JSX element to replace the text in the form submit button */
 	submitButtonText?: string | JSX.Element;
@@ -159,6 +163,7 @@ const BaseForm = React.forwardRef<RsjfForm<any>, FormProps>(
 			validate,
 			liveValidate,
 			noValidate,
+			transformErrors,
 			...props
 		}: FormProps,
 		ref,
@@ -229,6 +234,7 @@ const BaseForm = React.forwardRef<RsjfForm<any>, FormProps>(
 					liveValidate={liveValidate}
 					noValidate={noValidate}
 					validate={validate}
+					transformErrors={transformErrors}
 					showErrorList={false}
 					schema={calculatedSchema}
 					formData={formState}


### PR DESCRIPTION
Required so that we can give a more sensible error
for cases like maxLength errors on file uploads.

Change-type: minor
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
