### PR TITLE
Renderer: add support for `ui:explicit`

### DIFF
--- a/src/components/Form/__snapshots__/Form.stories.storyshot
+++ b/src/components/Form/__snapshots__/Form.stories.storyshot
@@ -48,7 +48,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                         
                         <input
                           autocomplete="off"
-                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Name"
                           label="Name"
                           list="dummy-datalist"
@@ -79,7 +79,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Height"
                           label="Height"
                           placeholder=""
@@ -106,7 +106,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Weight"
                           label="Weight"
                           placeholder=""
@@ -133,7 +133,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Description"
                           label="Description"
                           placeholder=""
@@ -160,7 +160,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Category"
                           label="Category"
                           placeholder=""
@@ -187,7 +187,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Abilities"
                           label="Abilities"
                           placeholder=""
@@ -214,7 +214,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_pokedex_number"
                           label="National Pokèdex Number"
                           placeholder=""
@@ -278,7 +278,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_first_seen"
                           label="First seen"
                           placeholder=""
@@ -321,7 +321,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_poke_password"
                           label="Poke Password"
                           placeholder=""
@@ -363,7 +363,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                               >
                                 <input
                                   autocomplete="off"
-                                  class="StyledTextInput-sc-1x30a0s-0 ccRbRh Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP kMEjWZ"
+                                  class="StyledTextInput-sc-1x30a0s-0 AKkVg Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP kMEjWZ"
                                   id="root_environment__input"
                                   readonly=""
                                   tabindex="-1"
@@ -530,7 +530,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                         
                         <input
                           autocomplete="off"
-                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Name"
                           label="Name"
                           list="dummy-datalist"
@@ -561,7 +561,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Height"
                           label="Height"
                           placeholder=""
@@ -588,7 +588,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Weight"
                           label="Weight"
                           placeholder=""
@@ -615,7 +615,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Description"
                           label="Description"
                           placeholder=""
@@ -642,7 +642,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Category"
                           label="Category"
                           placeholder=""
@@ -669,7 +669,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Abilities"
                           label="Abilities"
                           placeholder=""
@@ -696,7 +696,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_pokedex_number"
                           label="National Pokèdex Number"
                           placeholder=""
@@ -760,7 +760,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_first_seen"
                           label="First seen"
                           placeholder=""
@@ -803,7 +803,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_poke_password"
                           label="Poke Password"
                           placeholder=""
@@ -845,7 +845,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                               >
                                 <input
                                   autocomplete="off"
-                                  class="StyledTextInput-sc-1x30a0s-0 ccRbRh Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP kMEjWZ"
+                                  class="StyledTextInput-sc-1x30a0s-0 AKkVg Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP kMEjWZ"
                                   id="root_environment__input"
                                   readonly=""
                                   tabindex="-1"
@@ -1012,7 +1012,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                         
                         <input
                           autocomplete="off"
-                          class="StyledTextInput-sc-1x30a0s-0 gCxMXz sc-jgHCyG kmycqX sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 bTnlqC sc-jgHCyG kmycqX sc-gTgzIj eNaHvD"
                           disabled=""
                           id="root_Name"
                           label="Name"
@@ -1044,7 +1044,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 gCxMXz sc-jgHCyG kmycqX sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 bTnlqC sc-jgHCyG kmycqX sc-gTgzIj eNaHvD"
                           disabled=""
                           id="root_Height"
                           label="Height"
@@ -1072,7 +1072,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 gCxMXz sc-jgHCyG kmycqX sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 bTnlqC sc-jgHCyG kmycqX sc-gTgzIj eNaHvD"
                           disabled=""
                           id="root_Weight"
                           label="Weight"
@@ -1100,7 +1100,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 gCxMXz sc-jgHCyG kmycqX sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 bTnlqC sc-jgHCyG kmycqX sc-gTgzIj eNaHvD"
                           disabled=""
                           id="root_Description"
                           label="Description"
@@ -1128,7 +1128,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 gCxMXz sc-jgHCyG kmycqX sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 bTnlqC sc-jgHCyG kmycqX sc-gTgzIj eNaHvD"
                           disabled=""
                           id="root_Category"
                           label="Category"
@@ -1156,7 +1156,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 gCxMXz sc-jgHCyG kmycqX sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 bTnlqC sc-jgHCyG kmycqX sc-gTgzIj eNaHvD"
                           disabled=""
                           id="root_Abilities"
                           label="Abilities"
@@ -1184,7 +1184,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 gCxMXz sc-jgHCyG kmycqX sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 bTnlqC sc-jgHCyG kmycqX sc-gTgzIj eNaHvD"
                           disabled=""
                           id="root_pokedex_number"
                           label="National Pokèdex Number"
@@ -1250,7 +1250,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 gCxMXz sc-jgHCyG kmycqX sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 bTnlqC sc-jgHCyG kmycqX sc-gTgzIj eNaHvD"
                           disabled=""
                           id="root_first_seen"
                           label="First seen"
@@ -1294,7 +1294,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 gCxMXz sc-jgHCyG kmycqX sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 bTnlqC sc-jgHCyG kmycqX sc-gTgzIj eNaHvD"
                           disabled=""
                           id="root_poke_password"
                           label="Poke Password"
@@ -1338,7 +1338,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                               >
                                 <input
                                   autocomplete="off"
-                                  class="StyledTextInput-sc-1x30a0s-0 ccRbRh Select__SelectTextInput-sc-17idtfo-0 cANsmG sc-jeGSBP kMEjWZ"
+                                  class="StyledTextInput-sc-1x30a0s-0 AKkVg Select__SelectTextInput-sc-17idtfo-0 cANsmG sc-jeGSBP kMEjWZ"
                                   id="root_environment__input"
                                   readonly=""
                                   tabindex="-1"
@@ -1505,7 +1505,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                         
                         <input
                           autocomplete="off"
-                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Name"
                           label="Name"
                           list="dummy-datalist"
@@ -1536,7 +1536,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Height"
                           label="Height"
                           placeholder=""
@@ -1563,7 +1563,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Weight"
                           label="Weight"
                           placeholder=""
@@ -1590,7 +1590,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Description"
                           label="Description"
                           placeholder=""
@@ -1617,7 +1617,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Category"
                           label="Category"
                           placeholder=""
@@ -1644,7 +1644,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Abilities"
                           label="Abilities"
                           placeholder=""
@@ -1671,7 +1671,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_pokedex_number"
                           label="National Pokèdex Number"
                           placeholder=""
@@ -1735,7 +1735,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_first_seen"
                           label="First seen"
                           placeholder=""
@@ -1778,7 +1778,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_poke_password"
                           label="Poke Password"
                           placeholder=""
@@ -1820,7 +1820,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                               >
                                 <input
                                   autocomplete="off"
-                                  class="StyledTextInput-sc-1x30a0s-0 ccRbRh Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP kMEjWZ"
+                                  class="StyledTextInput-sc-1x30a0s-0 AKkVg Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP kMEjWZ"
                                   id="root_environment__input"
                                   readonly=""
                                   tabindex="-1"
@@ -1982,7 +1982,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                         
                         <input
                           autocomplete="off"
-                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Name"
                           label="Name"
                           list="dummy-datalist"
@@ -2013,7 +2013,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Height"
                           label="Height"
                           placeholder=""
@@ -2040,7 +2040,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Weight"
                           label="Weight"
                           placeholder=""
@@ -2067,7 +2067,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Description"
                           label="Description"
                           placeholder=""
@@ -2094,7 +2094,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Category"
                           label="Category"
                           placeholder=""
@@ -2121,7 +2121,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Abilities"
                           label="Abilities"
                           placeholder=""
@@ -2148,7 +2148,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_pokedex_number"
                           label="National Pokèdex Number"
                           placeholder=""
@@ -2212,7 +2212,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_first_seen"
                           label="First seen"
                           placeholder=""
@@ -2255,7 +2255,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_poke_password"
                           label="Poke Password"
                           placeholder=""
@@ -2297,7 +2297,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                               >
                                 <input
                                   autocomplete="off"
-                                  class="StyledTextInput-sc-1x30a0s-0 ccRbRh Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP kMEjWZ"
+                                  class="StyledTextInput-sc-1x30a0s-0 AKkVg Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP kMEjWZ"
                                   id="root_environment__input"
                                   readonly=""
                                   tabindex="-1"
@@ -3734,7 +3734,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                         
                         <input
                           autocomplete="off"
-                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Name"
                           label="Name"
                           list="dummy-datalist"
@@ -3826,7 +3826,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Abilities"
                           label="Abilities"
                           placeholder=""
@@ -3853,7 +3853,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG jDTnAL sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG jDTnAL sc-gTgzIj eNaHvD"
                           id="root_Height"
                           label="Height"
                           placeholder=""
@@ -3880,7 +3880,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Weight"
                           label="Weight"
                           placeholder=""
@@ -3907,7 +3907,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Category"
                           label="Category"
                           placeholder=""
@@ -3934,7 +3934,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_pokedex_number"
                           label="National Pokèdex Number"
                           placeholder=""
@@ -3977,7 +3977,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_first_seen"
                           label="First seen"
                           placeholder=""
@@ -4023,7 +4023,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                         >
                           
                           <input
-                            class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj kDmtQx"
+                            class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj kDmtQx"
                             id="root_poke_password"
                             label="Poke Password"
                             placeholder=""
@@ -4086,7 +4086,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                               >
                                 <input
                                   autocomplete="off"
-                                  class="StyledTextInput-sc-1x30a0s-0 ccRbRh Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP iqwkEO"
+                                  class="StyledTextInput-sc-1x30a0s-0 AKkVg Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP iqwkEO"
                                   id="root_environment__input"
                                   readonly=""
                                   tabindex="-1"
@@ -4267,7 +4267,7 @@ exports[`Storyshots Core/Form With Pattern Properties 1`] = `
                                     >
                                       <input
                                         autocomplete="off"
-                                        class="StyledTextInput-sc-1x30a0s-0 gCxMXz sc-jgHCyG kmycqX sc-gTgzIj cjgnvU rendition-form-pattern-properties__key-field"
+                                        class="StyledTextInput-sc-1x30a0s-0 bTnlqC sc-jgHCyG kmycqX sc-gTgzIj cjgnvU rendition-form-pattern-properties__key-field"
                                         disabled=""
                                         pattern="^[0-9]+$"
                                         placeholder="Key"
@@ -4281,7 +4281,7 @@ exports[`Storyshots Core/Form With Pattern Properties 1`] = `
                                     >
                                       <input
                                         autocomplete="off"
-                                        class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj cjgnvU rendition-form-pattern-properties__value-field"
+                                        class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj cjgnvU rendition-form-pattern-properties__value-field"
                                         id="foo"
                                         placeholder="Rule"
                                         value=""
@@ -4389,7 +4389,7 @@ exports[`Storyshots Core/Form With Titles 1`] = `
                               >
                                 
                                 <input
-                                  class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                                  class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                                   id="root_vpn_endpoint"
                                   label="Endpoint"
                                   placeholder=""
@@ -4416,7 +4416,7 @@ exports[`Storyshots Core/Form With Titles 1`] = `
                               >
                                 
                                 <input
-                                  class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                                  class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                                   id="root_vpn_certificate"
                                   label="Certificate"
                                   placeholder=""
@@ -4473,7 +4473,7 @@ exports[`Storyshots Core/Form With Titles 1`] = `
                                       >
                                         
                                         <input
-                                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                                           id="root_wifiNetwork_wifi_ssid"
                                           label="Network SSID"
                                           placeholder=""
@@ -4514,7 +4514,7 @@ exports[`Storyshots Core/Form With Titles 1`] = `
                                       >
                                         
                                         <input
-                                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                                           id="root_wifiNetwork_wifiSecurity_psk"
                                           label="Network Passphrase"
                                           placeholder=""
@@ -4614,7 +4614,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                         
                         <input
                           autocomplete="off"
-                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Name"
                           label="Name"
                           list="dummy-datalist"
@@ -4686,7 +4686,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Abilities"
                           label="Abilities"
                           placeholder=""
@@ -4713,7 +4713,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG jDTnAL sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG jDTnAL sc-gTgzIj eNaHvD"
                           id="root_Height"
                           label="Height"
                           placeholder=""
@@ -4740,7 +4740,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Weight"
                           label="Weight"
                           placeholder=""
@@ -4767,7 +4767,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Category"
                           label="Category"
                           placeholder=""
@@ -4794,7 +4794,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_pokedex_number"
                           label="National Pokèdex Number"
                           placeholder=""
@@ -4837,7 +4837,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_first_seen"
                           label="First seen"
                           placeholder=""
@@ -4883,7 +4883,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                         >
                           
                           <input
-                            class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj kDmtQx"
+                            class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj kDmtQx"
                             id="root_poke_password"
                             label="Poke Password"
                             placeholder=""
@@ -4946,7 +4946,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                               >
                                 <input
                                   autocomplete="off"
-                                  class="StyledTextInput-sc-1x30a0s-0 ccRbRh Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP iqwkEO"
+                                  class="StyledTextInput-sc-1x30a0s-0 AKkVg Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP iqwkEO"
                                   id="root_environment__input"
                                   readonly=""
                                   tabindex="-1"
@@ -5159,7 +5159,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                         
                         <input
                           autocomplete="off"
-                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Name"
                           label="Name"
                           list="dummy-datalist"
@@ -5231,7 +5231,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Abilities"
                           label="Abilities"
                           placeholder=""
@@ -5258,7 +5258,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG jDTnAL sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG jDTnAL sc-gTgzIj eNaHvD"
                           id="root_Height"
                           label="Height"
                           placeholder=""
@@ -5285,7 +5285,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Weight"
                           label="Weight"
                           placeholder=""
@@ -5312,7 +5312,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_Category"
                           label="Category"
                           placeholder=""
@@ -5339,7 +5339,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_pokedex_number"
                           label="National Pokèdex Number"
                           placeholder=""
@@ -5382,7 +5382,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
+                          class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj eNaHvD"
                           id="root_first_seen"
                           label="First seen"
                           placeholder=""
@@ -5428,7 +5428,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                         >
                           
                           <input
-                            class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj kDmtQx"
+                            class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj kDmtQx"
                             id="root_poke_password"
                             label="Poke Password"
                             placeholder=""
@@ -5491,7 +5491,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                               >
                                 <input
                                   autocomplete="off"
-                                  class="StyledTextInput-sc-1x30a0s-0 ccRbRh Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP iqwkEO"
+                                  class="StyledTextInput-sc-1x30a0s-0 AKkVg Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP iqwkEO"
                                   id="root_environment__input"
                                   readonly=""
                                   tabindex="-1"

--- a/src/components/Input/__snapshots__/Input.stories.storyshot
+++ b/src/components/Input/__snapshots__/Input.stories.storyshot
@@ -10,7 +10,7 @@ exports[`Storyshots Core/Input Default 1`] = `
     >
       <input
         autocomplete="off"
-        class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj cjgnvU"
+        class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj cjgnvU"
         value=""
       />
     </div>
@@ -28,7 +28,7 @@ exports[`Storyshots Core/Input Emphasized 1`] = `
     >
       <input
         autocomplete="off"
-        class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG jDTnAL sc-gTgzIj cjgnvU"
+        class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG jDTnAL sc-gTgzIj cjgnvU"
         value=""
       />
     </div>
@@ -46,7 +46,7 @@ exports[`Storyshots Core/Input Monospace 1`] = `
     >
       <input
         autocomplete="off"
-        class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG fbrLsF sc-gTgzIj cjgnvU"
+        class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG fbrLsF sc-gTgzIj cjgnvU"
         value=""
       />
     </div>
@@ -64,7 +64,7 @@ exports[`Storyshots Core/Input With Placeholder 1`] = `
     >
       <input
         autocomplete="off"
-        class="StyledTextInput-sc-1x30a0s-0 cxIKgN sc-jgHCyG cnloRI sc-gTgzIj cjgnvU"
+        class="StyledTextInput-sc-1x30a0s-0 hJjFGo sc-jgHCyG cnloRI sc-gTgzIj cjgnvU"
         placeholder="This is a placeholder"
         value=""
       />

--- a/src/components/Renderer/RendererPlayground/util.ts
+++ b/src/components/Renderer/RendererPlayground/util.ts
@@ -36,6 +36,9 @@ const getBaseMetaSchema = (): UiSchemaMetaSchema => ({
 		'ui:options': {
 			type: 'object',
 		},
+		'ui:explicit': {
+			type: 'boolean',
+		},
 	},
 });
 

--- a/src/components/Renderer/__snapshots__/spec.tsx.snap
+++ b/src/components/Renderer/__snapshots__/spec.tsx.snap
@@ -3514,6 +3514,123 @@ exports[`Renderer component An object with various properties 1`] = `
 </div>
 `;
 
+exports[`Renderer component Explicitly specifying which fields to render 1`] = `
+.c0 {
+  font-family: 'Source Sans Pro',Helvetica,sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c2 {
+  box-sizing: border-box;
+}
+
+.c3 {
+  margin-bottom: 4px;
+  min-width: 0;
+  min-height: 0;
+}
+
+.c5 {
+  margin-right: 8px;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c6 {
+  font-weight: 600;
+}
+
+.c7 {
+  font-size: 85%;
+  color: #527699;
+}
+
+.c1 {
+  font-family: 'Source Sans Pro',Helvetica,sans-serif;
+  font-size: 14px;
+  color: #2A506F;
+}
+
+<div>
+  <div
+    class="c0 c1"
+  >
+    <div
+      class="c2 c3 c4 "
+    >
+      <div
+        class="c2 c5"
+      >
+        <div
+          class="c6 "
+        >
+          Field Title
+        </div>
+        <div
+          class="c7"
+        >
+          Field description
+        </div>
+      </div>
+      <div
+        class="c2 c3 c4 "
+      >
+        <div
+          class="c2 c5"
+        >
+          <div
+            class="c6 "
+          >
+            A String Field
+          </div>
+        </div>
+        <div
+          class=""
+        >
+          The string value
+        </div>
+      </div>
+      <div
+        class="c2 c3 c4 "
+      >
+        <div
+          class="c2 c5"
+        >
+          <div
+            class="c6 "
+          >
+            A Number Field
+          </div>
+        </div>
+        <div
+          class=""
+        >
+          12.345
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Renderer component Re-ordered fields 1`] = `
 .c0 {
   font-family: 'Source Sans Pro',Helvetica,sans-serif;

--- a/src/components/Renderer/examples.ts
+++ b/src/components/Renderer/examples.ts
@@ -207,6 +207,51 @@ const jsonDataExamples = {
 			},
 		},
 	},
+	'Explicitly specifying which fields to render': {
+		value: {
+			aString: 'The string value',
+			aNumber: 12.345,
+			anInteger: 5000,
+			aBoolean: false,
+			aNull: null,
+		},
+		schema: {
+			type: 'object',
+			title: 'Field title',
+			description: 'Field description',
+			properties: {
+				aString: {
+					type: 'string',
+					title: 'A String Field',
+				},
+				aNumber: {
+					type: 'number',
+					title: 'A Number Field',
+				},
+				anInteger: {
+					type: 'integer',
+					title: 'An Integer Field (will not be rendered)',
+				},
+				aBoolean: {
+					type: 'boolean',
+					title: 'A Boolean Field (will not be rendered)',
+				},
+				aNull: {
+					type: 'null',
+					title: 'A Null Field (will not be rendered)',
+				},
+			},
+		},
+		uiSchema: {
+			'ui:explicit': true,
+			aString: {
+				'ui:widget': 'Txt',
+			},
+			aNumber: {
+				'ui:widget': 'Txt',
+			},
+		},
+	},
 	'Re-ordered fields': {
 		value: {
 			fieldA: 'field A value',

--- a/src/components/Renderer/index.tsx
+++ b/src/components/Renderer/index.tsx
@@ -391,6 +391,33 @@ const RenditionRendererBase = asRendition<
  * |	`extraFormats` | `Format[]`     | -        | An array of extra formats to include when validating the schema. See https://www.npmjs.com/package/ajv#formats for more details. |
  * |	`extraContext` | `object`       | -        | Extra context that is passed to [json-e](https://json-e.js.org/) when transforming the UI schema. This context can even contain functions that can be invoked by json-e when executing the transformation. |
  *
+ * ## Explicitly specify which fields to render
+ *
+ * The default behaviour of the `Renderer` component is to render all fields in the `value` object. If you would like
+ * to restrict the fields that are rendered to the ones you explicitly reference in the UI schema, just set the `ui:explicit`
+ * property in the UI schema. For example, given the following value and UI schema, the `Renderer` will display `name` and `data.email` but _not_ `data.name`:
+ *
+ * ```javascript
+ * const value = {
+ *   name: 'Joe Bloggs',
+ *   data: {
+ *     name: {
+ *       first: 'Joe',
+ *       last: 'Bloggs'
+ *     },
+ *     email: 'joe@bloggs.com'
+ *   }
+ * }
+ * const uiSchema = {
+ *   data: {
+ *     'ui:explicit': true,
+ *     email: {
+ *       'ui:widget': 'Link'
+ *     }
+ *   }
+ * }
+ * ```
+ *
  * ## UI Options
  *
  * In addition to the standard widget props, each Widget component defines additional props that it accepts as 'UI options'.

--- a/src/components/Renderer/widgets/widget-util.tsx
+++ b/src/components/Renderer/widgets/widget-util.tsx
@@ -6,6 +6,7 @@ import pickBy from 'lodash/pickBy';
 import difference from 'lodash/difference';
 import isArray from 'lodash/isArray';
 import keys from 'lodash/keys';
+import has from 'lodash/has';
 import concat from 'lodash/concat';
 import get from 'lodash/get';
 import pick from 'lodash/pick';
@@ -143,9 +144,12 @@ export function getObjectPropertyNames({
 		keys(value) || [],
 		schemaPropertyNames,
 	);
-	return concat(
+	const allObjectPropertyNames = concat(
 		uiSchemaPropertyNames,
 		schemaPropertyNames,
 		nonSchemaPropertyNames,
 	);
+	return get(uiSchema, 'ui:explicit', false)
+		? allObjectPropertyNames.filter((propName) => has(uiSchema, propName))
+		: allObjectPropertyNames;
 }

--- a/src/components/Select/__snapshots__/Select.stories.storyshot
+++ b/src/components/Select/__snapshots__/Select.stories.storyshot
@@ -24,7 +24,7 @@ exports[`Storyshots Core/Select Default 1`] = `
             >
               <input
                 autocomplete="off"
-                class="StyledTextInput-sc-1x30a0s-0 ccRbRh Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP kMEjWZ"
+                class="StyledTextInput-sc-1x30a0s-0 AKkVg Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP kMEjWZ"
                 readonly=""
                 tabindex="-1"
                 type="text"
@@ -80,7 +80,7 @@ exports[`Storyshots Core/Select Emphasized 1`] = `
             >
               <input
                 autocomplete="off"
-                class="StyledTextInput-sc-1x30a0s-0 ccRbRh Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP iqwkEO"
+                class="StyledTextInput-sc-1x30a0s-0 AKkVg Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP iqwkEO"
                 readonly=""
                 tabindex="-1"
                 type="text"
@@ -136,7 +136,7 @@ exports[`Storyshots Core/Select Invalid 1`] = `
             >
               <input
                 autocomplete="off"
-                class="StyledTextInput-sc-1x30a0s-0 ccRbRh Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP kMEjWZ"
+                class="StyledTextInput-sc-1x30a0s-0 AKkVg Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP kMEjWZ"
                 readonly=""
                 tabindex="-1"
                 type="text"
@@ -192,7 +192,7 @@ exports[`Storyshots Core/Select Object Options 1`] = `
             >
               <input
                 autocomplete="off"
-                class="StyledTextInput-sc-1x30a0s-0 ccRbRh Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP kMEjWZ"
+                class="StyledTextInput-sc-1x30a0s-0 AKkVg Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP kMEjWZ"
                 readonly=""
                 tabindex="-1"
                 type="text"
@@ -248,7 +248,7 @@ exports[`Storyshots Core/Select With Custom Option 1`] = `
             >
               <input
                 autocomplete="off"
-                class="StyledTextInput-sc-1x30a0s-0 ccRbRh Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP kMEjWZ"
+                class="StyledTextInput-sc-1x30a0s-0 AKkVg Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP kMEjWZ"
                 readonly=""
                 tabindex="-1"
                 type="text"
@@ -304,7 +304,7 @@ exports[`Storyshots Core/Select With Placeholder 1`] = `
             >
               <input
                 autocomplete="off"
-                class="StyledTextInput-sc-1x30a0s-0 ccRbRh Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP kMEjWZ"
+                class="StyledTextInput-sc-1x30a0s-0 AKkVg Select__SelectTextInput-sc-17idtfo-0 bIurki sc-jeGSBP kMEjWZ"
                 placeholder="Select one..."
                 readonly=""
                 tabindex="-1"


### PR DESCRIPTION
Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

---

_From the [README](https://github.com/balena-io-modules/rendition/blob/0148bbd735cd5ad8cd6a8445775d229b5803e000/src/components/Renderer/index.tsx#L394):_

The default behaviour of the `Renderer` component is to render all fields in the `value` object. If you would like
to restrict the fields that are rendered to the ones you explicitly reference in the UI schema, just set the `ui:explicit`
property in the UI schema. For example, given the following value and UI schema, the `Renderer` will display `name` and `data.email` but _not_ `data.name`:

```javascript
const value = {
  name: 'Joe Bloggs',
  data: {
    name: {
      first: 'Joe',
      last: 'Bloggs'
    },
    email: 'joe@bloggs.com'
  }
}
const uiSchema = {
  data: {
    'ui:explicit': true,
    email: {
      'ui:widget': 'Link'
    }
  }
}
```

This change was discussed in Jellyfish: https://jel.ly.fish/67534398-9397-49f6-b8fb-13394cc7f8e1

##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
