### PR TITLE
Form: Fix throwing when the schema has non-string array examples

### DIFF
--- a/src/components/Breadcrumbs/__snapshots__/Breadcrumbs.stories.storyshot
+++ b/src/components/Breadcrumbs/__snapshots__/Breadcrumbs.stories.storyshot
@@ -33,7 +33,7 @@ exports[`Storyshots Core/Breadcrumbs Default 1`] = `
                   class="sc-gKsewC cgpPfo sc-iBPRYJ kCgyvI sc-hHftDr cuSvIJ"
                 >
                   <div
-                    class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI"
+                    class="sc-fKFyDc hECIHy sc-bBXqnf kYwmpI"
                   >
                     route 1
                   </div>
@@ -75,7 +75,7 @@ exports[`Storyshots Core/Breadcrumbs Default 1`] = `
                   class="sc-gKsewC cgpPfo sc-iBPRYJ kCgyvI sc-hHftDr cuSvIJ"
                 >
                   <div
-                    class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI"
+                    class="sc-fKFyDc hECIHy sc-bBXqnf kYwmpI"
                   >
                     route 2
                   </div>
@@ -136,7 +136,7 @@ exports[`Storyshots Core/Breadcrumbs Default 1`] = `
                     </svg>
                   </div>
                   <div
-                    class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI"
+                    class="sc-fKFyDc hECIHy sc-bBXqnf kYwmpI"
                   >
                     route 3 with icon
                   </div>
@@ -187,7 +187,7 @@ exports[`Storyshots Core/Breadcrumbs Wrapped 1`] = `
                     class="sc-gKsewC cgpPfo sc-iBPRYJ kCgyvI sc-hHftDr cuSvIJ"
                   >
                     <div
-                      class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI"
+                      class="sc-fKFyDc hECIHy sc-bBXqnf kYwmpI"
                     >
                       route 1
                     </div>
@@ -229,7 +229,7 @@ exports[`Storyshots Core/Breadcrumbs Wrapped 1`] = `
                     class="sc-gKsewC cgpPfo sc-iBPRYJ kCgyvI sc-hHftDr cuSvIJ"
                   >
                     <div
-                      class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI"
+                      class="sc-fKFyDc hECIHy sc-bBXqnf kYwmpI"
                     >
                       route 2
                     </div>
@@ -290,7 +290,7 @@ exports[`Storyshots Core/Breadcrumbs Wrapped 1`] = `
                       </svg>
                     </div>
                     <div
-                      class="sc-fKFyDc jHCVxA sc-bBXqnf kYwmpI"
+                      class="sc-fKFyDc hECIHy sc-bBXqnf kYwmpI"
                     >
                       route 3 with icon
                     </div>

--- a/src/components/Form/widgets/BaseInput.tsx
+++ b/src/components/Form/widgets/BaseInput.tsx
@@ -1,14 +1,25 @@
+import type { JSONSchema7 as JSONSchema } from 'json-schema';
 import * as React from 'react';
 import { Input } from '../../Input';
 import { FormWidgetProps } from '../';
 
-const filterSuggestions = (text: string | null, suggestions?: string[]) => {
+const filterSuggestions = (
+	text: string | null,
+	suggestions: JSONSchema['examples'],
+) => {
 	if (!text || !suggestions) {
-		return suggestions;
+		return;
+	}
+	if (!Array.isArray(suggestions)) {
+		suggestions = [suggestions];
 	}
 
 	return suggestions.filter(
-		(suggestion) => suggestion.includes(text) && suggestion !== text,
+		(suggestion): suggestion is string =>
+			// TODO: Grommet atm only supports string suggestions and throws if numbers are passed.
+			typeof suggestion === 'string' &&
+			suggestion.includes(text) &&
+			suggestion !== text,
 	);
 };
 
@@ -33,7 +44,7 @@ const BaseInput = (props: FormWidgetProps) => {
 		return props.onChange(value === '' ? options.emptyValue : value);
 	};
 
-	const suggestions = filterSuggestions(value, schema.examples as string[]);
+	const suggestions = filterSuggestions(value, schema.examples);
 	const hasExamples = ((schema.examples as string[])?.length ?? 0) > 0;
 
 	return (


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
