### PR TITLE
Fix monaco editor build error

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "jsdom": "^11.6.2",
     "lint-staged": "^4.1.1",
     "match-media-mock": "^0.1.1",
-    "monaco-editor-webpack-plugin": "^2.0.0",
+    "monaco-editor-webpack-plugin": "^3.0.0",
     "prettier": "^2.0.5",
     "react": "^16.8.5",
     "react-dom": "^16.8.5",


### PR DESCRIPTION
Fix monaco edito build error, cannot find module onTypeRename

See: https://github.com/microsoft/monaco-editor-webpack-plugin/issues/139
See: https://github.com/microsoft/monaco-editor-webpack-plugin/issues/140
Change-type: minor
Signed-off-by: Andrea Rosci <andrear@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
