### PR TITLE
DropDownButton: Hide empty items

### DIFF
--- a/src/components/DropDownButton/DropDownButton.stories.tsx
+++ b/src/components/DropDownButton/DropDownButton.stories.tsx
@@ -2,16 +2,41 @@ import React from 'react';
 import { Meta } from '@storybook/react';
 import { createTemplate, createStory } from '../../stories/utils';
 import { DropDownButton, DropDownButtonProps } from '.';
+import { Button, ButtonProps } from '../Button';
 import { Divider } from '../Divider';
+
+const NonZeroOrderedButton = (props: ButtonProps & { i: number }) => {
+	if (!props.i) {
+		return null;
+	}
+	return (
+		<Button plain>
+			{props.children ?? `Non-zero indexed item ${props.i}`}
+		</Button>
+	);
+};
+
+const OddIndexedButton = (props: ButtonProps & { i: number }) => {
+	if (props.i % 2 === 0) {
+		return null;
+	}
+	return (
+		<NonZeroOrderedButton i={props.i}>
+			Odd indexed item {props.i}
+		</NonZeroOrderedButton>
+	);
+};
 
 // This need to be an array, otherwise it would create
 // a single DropDown item with all elements.
 const sampleChildren = [
-	<div>Item</div>,
-	<div>Item</div>,
-	<div>Item</div>,
+	<Button plain>Item</Button>,
+	...[0, 1, 2, 3].map((i) => <NonZeroOrderedButton i={i} />),
+	<Button plain>Item</Button>,
 	<Divider />,
-	<div>Item</div>,
+	<Button plain>Item</Button>,
+	...[0, 1, 2, 3].map((i) => <OddIndexedButton i={i} />),
+	<Button plain>Item</Button>,
 ];
 
 export default {

--- a/src/components/DropDownButton/index.tsx
+++ b/src/components/DropDownButton/index.tsx
@@ -73,6 +73,10 @@ const Item = styled.div<{ border: boolean }>`
 	&:hover:enabled {
 		background: ${(props) => props.theme.colors.gray.light};
 	}
+
+	&:empty {
+		display: none;
+	}
 `;
 
 const JoinedButton = styled(Button)`


### PR DESCRIPTION
React doesn't offer a way to detect and not render
such items at all any more. This is a convenient
improvement though since it allows better
encapsulation & more flexibility in cases that that
the items need to be auto-generated based from
a definition list (eg: for device actions).

Before this change the story would render like:
![image](https://user-images.githubusercontent.com/1295829/106891948-12e54200-66f4-11eb-9184-b3698dceb2ae.png)


Change-type: minor
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
