### PR TITLE
Fix SchemaSieve.flatten for nested required fields

### DIFF
--- a/src/components/Filters/SchemaSieve.spec.ts
+++ b/src/components/Filters/SchemaSieve.spec.ts
@@ -1471,6 +1471,59 @@ describe('SchemaSieve', () => {
 			});
 		});
 
+		it('should preserve the "required" keyword', () => {
+			const schema = {
+				type: 'object',
+				required: ['data'],
+				properties: {
+					data: {
+						type: 'object',
+						required: ['status', 'category', 'profile'],
+						properties: {
+							status: {
+								type: 'string',
+							},
+							category: {
+								type: 'string',
+							},
+							profile: {
+								type: 'object',
+								required: ['name'],
+								properties: {
+									name: {
+										type: 'string',
+									},
+								},
+							},
+						},
+					},
+				},
+			} as any;
+
+			expect(sieve.flattenSchema(schema)).toEqual({
+				type: 'object',
+				required: [
+					'___data___status',
+					'___data___category',
+					'___data___profile___name',
+				],
+				properties: {
+					___data___status: {
+						type: 'string',
+						title: 'status',
+					},
+					___data___category: {
+						type: 'string',
+						title: 'category',
+					},
+					___data___profile___name: {
+						type: 'string',
+						title: 'name',
+					},
+				},
+			});
+		});
+
 		it('should preserve titles when flattening', () => {
 			const schema = {
 				type: 'object',
@@ -1756,30 +1809,56 @@ describe('SchemaSieve', () => {
 		it('should preserve the "required" keyword', () => {
 			const flattenedSchema = {
 				type: 'object',
+				required: [
+					'___data___status',
+					'___data___category',
+					'___data___profile___name',
+				],
 				properties: {
-					___nestedString___string: {
-						title: 'A string field',
+					___data___status: {
 						type: 'string',
+						title: 'status',
+					},
+					___data___category: {
+						type: 'string',
+						title: 'category',
+					},
+					___data___profile___name: {
+						type: 'string',
+						title: 'name',
 					},
 				},
-				required: ['___nestedString___string'],
 			} as any;
 
 			expect(sieve.unflattenSchema(flattenedSchema)).toEqual({
 				type: 'object',
+				required: ['data'],
 				properties: {
-					nestedString: {
+					data: {
 						type: 'object',
+						required: ['status', 'category', 'profile'],
 						properties: {
-							string: {
-								title: 'A string field',
+							status: {
+								title: 'status',
 								type: 'string',
 							},
+							category: {
+								title: 'category',
+								type: 'string',
+							},
+							profile: {
+								type: 'object',
+								required: ['name'],
+								properties: {
+									name: {
+										title: 'name',
+										type: 'string',
+									},
+								},
+							},
 						},
-						required: ['string'],
 					},
 				},
-				required: ['nestedString'],
 			});
 		});
 


### PR DESCRIPTION
SchemaSieve now handles nested required fields correctly when flattening and unflattening.

##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
