### PR TITLE
Adapt decode and fix edit for searchText

### DIFF
--- a/src/components/DataTypes/string.tsx
+++ b/src/components/DataTypes/string.tsx
@@ -2,6 +2,7 @@ import { JSONSchema7 as JSONSchema } from 'json-schema';
 import * as React from 'react';
 import { randomString, regexEscape } from '../../utils';
 import { DataTypeEditProps } from '../Filters';
+import { FULL_TEXT_SLUG } from '../Filters/SchemaSieve';
 import { Input, InputProps } from '../Input';
 import { Textarea, TextareaProps } from '../Textarea';
 import { getJsonDescription } from './utils';
@@ -12,6 +13,9 @@ export const operators = {
 	},
 	contains: {
 		getLabel: (_s: JSONSchema) => 'contains',
+	},
+	full_text_search: {
+		getLabel: (_s: JSONSchema) => 'full text search',
 	},
 	not_contains: {
 		getLabel: (_s: JSONSchema) => 'does not contain',
@@ -46,6 +50,10 @@ interface StringFilter extends JSONSchema {
 				description?: string;
 				not?: {
 					pattern: string;
+				};
+				regexp?: {
+					pattern: string;
+					flags: string;
 				};
 			};
 		};
@@ -95,6 +103,12 @@ export const decodeFilter = (
 			value = filter.anyOf[0].properties![field].description!;
 		} else if (operator === 'not_matches_re') {
 			value = filter.anyOf[0].properties![field].not!.pattern;
+		} else if (operator === FULL_TEXT_SLUG) {
+			return {
+				field: 'any',
+				operator,
+				value: filter.anyOf[0].properties[keys[0]].regexp!.pattern!,
+			};
 		} else {
 			return null;
 		}

--- a/src/components/Filters/Filters.stories.tsx
+++ b/src/components/Filters/Filters.stories.tsx
@@ -19,20 +19,20 @@ const StyledTable = styled.table`
 const schema = {
 	type: 'object',
 	properties: {
-		Name: {
+		name: {
 			title: 'Pokemon Name',
-			type: ['string', 'null'],
-		},
-		Description: {
 			type: 'string',
 		},
-		Abilities: {
+		description: {
+			type: 'string',
+		},
+		abilities: {
 			type: 'array',
 			items: {
 				type: 'string',
 			},
 		},
-		Tag: {
+		tag: {
 			type: 'object',
 			properties: {
 				tag_name: {
@@ -71,7 +71,7 @@ const schema = {
 			title: 'National pokedex number',
 			type: 'number',
 		},
-		Category: {
+		category: {
 			enum: uniq(PokeDex.map((p) => p.Category)),
 		},
 		nationality: {

--- a/src/components/Filters/SchemaSieve.spec.ts
+++ b/src/components/Filters/SchemaSieve.spec.ts
@@ -3,6 +3,7 @@ import Ajv from 'ajv';
 import ajvKeywords from 'ajv-keywords';
 
 import { SchemaSieve as sieve } from '../../';
+import { FULL_TEXT_SLUG } from './SchemaSieve';
 
 const expectMatchesKeys = (data: any, keys: any) =>
 	expect(Object.keys(data).sort()).toEqual(keys.sort());
@@ -1279,7 +1280,14 @@ describe('SchemaSieve', () => {
 							value,
 						},
 					] as any;
-					const filter = sieve.createFilter(schema, signatures);
+
+					let filter;
+					if (slug === FULL_TEXT_SLUG) {
+						signatures[0].field = 'any';
+						filter = sieve.createFullTextSearchFilter(schema, value as string);
+					} else {
+						filter = sieve.createFilter(schema, signatures);
+					}
 
 					expect(sieve.decodeFilter(schema, filter)).toEqual(signatures);
 				});

--- a/src/components/Filters/SchemaSieve.ts
+++ b/src/components/Filters/SchemaSieve.ts
@@ -80,6 +80,7 @@ export const createFullTextSearchFilter = (
 		title: FULL_TEXT_SLUG,
 		anyOf: [
 			{
+				title: FULL_TEXT_SLUG,
 				description: `Any field contains ${term}`,
 				anyOf: filteredItems.map((item) => ({
 					properties: {

--- a/src/components/Filters/index.tsx
+++ b/src/components/Filters/index.tsx
@@ -29,10 +29,11 @@ const FilterWrapper = styled(Box)`
 `;
 
 class BaseFilters extends React.Component<FiltersProps, FiltersState> {
+	private searchElementRef = React.createRef<HTMLInputElement>();
+
 	constructor(props: FiltersProps) {
 		super(props);
 		const { filters = [], schema, views = [] } = this.props;
-
 		const flatSchema = SchemaSieve.flattenSchema(schema);
 		const flatViews = this.flattenViews(views);
 		const flatFilters = filters.map((filter) =>
@@ -172,8 +173,12 @@ class BaseFilters extends React.Component<FiltersProps, FiltersState> {
 	}
 
 	public editFilter(filter: JSONSchema) {
-		const { schema } = this.state;
+		if (filter.title === SchemaSieve.FULL_TEXT_SLUG) {
+			this.searchElementRef.current?.focus();
+			return;
+		}
 
+		const { schema } = this.state;
 		const signatures = SchemaSieve.decodeFilter(schema, filter);
 
 		this.setState({
@@ -304,6 +309,7 @@ class BaseFilters extends React.Component<FiltersProps, FiltersState> {
 								onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
 									this.setSimpleSearch(e.target.value)
 								}
+								ref={this.searchElementRef}
 							/>
 						</SearchWrapper>
 					)}

--- a/src/components/Search/index.tsx
+++ b/src/components/Search/index.tsx
@@ -41,27 +41,33 @@ const Wrapper = styled.div`
 	}
 `;
 
-const BaseSearch = ({
-	className,
-	dark,
-	disabled,
-	placeholder,
-	value,
-	onChange,
-}: InternalSearchProps) => {
-	return (
-		<Wrapper className={className}>
-			<input
-				style={{ color: dark ? '#fff' : undefined }}
-				disabled={disabled}
-				placeholder={placeholder || 'Search entries...'}
-				value={value}
-				onChange={onChange}
-			/>
-			<FontAwesomeIcon icon={faSearch} className="search-icon" />
-		</Wrapper>
-	);
-};
+const BaseSearch = React.forwardRef(
+	(
+		{
+			className,
+			dark,
+			disabled,
+			placeholder,
+			value,
+			onChange,
+		}: InternalSearchProps,
+		ref,
+	) => {
+		return (
+			<Wrapper className={className}>
+				<input
+					style={{ color: dark ? '#fff' : undefined }}
+					disabled={disabled}
+					placeholder={placeholder || 'Search entries...'}
+					value={value}
+					onChange={onChange}
+					ref={ref as any}
+				/>
+				<FontAwesomeIcon icon={faSearch} className="search-icon" />
+			</Wrapper>
+		);
+	},
+);
 
 export interface InternalSearchProps extends React.HTMLAttributes<HTMLElement> {
 	/** If true, uses a light colorscheme for use on a dark background */
@@ -83,6 +89,8 @@ export type SearchProps = InternalSearchProps & RenditionSystemProps;
  *
  * [View story source](https://github.com/balena-io-modules/rendition/blob/master/src/components/Search/Search.stories.tsx)
  */
-export const Search = asRendition<React.FunctionComponent<SearchProps>>(
-	BaseSearch,
-);
+export const Search = asRendition<
+	React.ForwardRefExoticComponent<
+		SearchProps & React.RefAttributes<HTMLInputElement>
+	>
+>(BaseSearch);


### PR DESCRIPTION
Adapt decodeFilter to also decode searchText filter and fix searchText filter edit

Change-type: patch
Signed-off-by: Andrea Rosci <andrear@balena.io>

This PR: 
1) Adapt the use of decodeFilter function to be able to also decode searchText filter
2) Fix the searchText entry in the summary when clicked. Instead of opening an empty modal is now focusing the search input.

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
