### PR TITLE
Fix select interface accoridng to grommet v2.16.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "color-hash": "^1.0.3",
     "copy-to-clipboard": "^3.0.8",
     "date-fns": "^2.16.1",
-    "grommet": "^2.14.0",
+    "grommet": "^2.16.3",
     "hast-util-sanitize": "^3.0.0",
     "json-e": "^4.1.0",
     "lodash": "^4.17.11",

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -72,7 +72,7 @@ interface InternalSelectProps<T>
 	extends AdjustedGrommetSelectProps,
 		Omit<
 			React.HTMLAttributes<HTMLElement>,
-			'onChange' | 'children' | 'placeholder' | 'color'
+			'defaultValue' | 'onChange' | 'children' | 'placeholder' | 'color'
 		> {
 	emphasized?: boolean;
 	invalid?: boolean;


### PR DESCRIPTION
Fix select interface according to grommet release v2.16.3

See: https://github.com/grommet/grommet/releases/tag/v2.16.3
Change-type: patch|minor|major
Signed-off-by: Andrea Rosci <andrear@balena.io>


This PR fix a build error due to an added prop on the GrommetSelectProps interface

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
