### PR TITLE
Tag: add support for limiting max items to display

### DIFF
--- a/src/components/Form/__snapshots__/Form.stories.storyshot
+++ b/src/components/Form/__snapshots__/Form.stories.storyshot
@@ -3363,7 +3363,7 @@ Rendition contains widgets for rendering Markdown and Mermaid text formats that 
                         Markdown
                       </label>
                       <div
-                        class="sc-tkKAw ddBawh"
+                        class="sc-tkKAw iFVvED"
                         id="simplemde-editor-1-wrapper"
                       >
                         <textarea

--- a/src/components/Tag/Tag.stories.tsx
+++ b/src/components/Tag/Tag.stories.tsx
@@ -39,6 +39,30 @@ export const MultipleValues = createStory<TagProps>(Template, {
 	],
 });
 
+export const Overflow = createStory<TagProps>(Template, {
+	multiple: [
+		{ name: 'Tag1', operator: 'contains', value: 'value1' },
+		{
+			prefix: 'or',
+			name: 'Tag2',
+			operator: 'contains',
+			value: 'value2',
+		},
+		{
+			prefix: 'or',
+			name: 'Tag3',
+			operator: 'contains',
+			value: 'value3',
+		},
+		{
+			prefix: 'or',
+			name: 'Tag4',
+			operator: 'contains',
+			value: 'value4',
+		},
+	],
+});
+
 export const Clickable = createStory<TagProps>(Template, {
 	name: 'Tag',
 	value: 'Value',

--- a/src/components/Tag/__snapshots__/Tag.stories.storyshot
+++ b/src/components/Tag/__snapshots__/Tag.stories.storyshot
@@ -213,3 +213,35 @@ exports[`Storyshots Core/Tag Only Value 1`] = `
   </div>
 </div>
 `;
+
+exports[`Storyshots Core/Tag Overflow 1`] = `
+<div>
+  <div
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+  >
+    <div
+      class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-hHftDr cLDXoV sc-GqfZa cHWpcm"
+    >
+      <div
+        class="sc-gKsewC cgpPfo sc-iBPRYJ egHqKA sc-hHftDr sc-clsHhM cLDXoV bjaVYF"
+      >
+        <div
+          class="sc-fKFyDc dTkenA sc-bBXqnf iHGIIw"
+        >
+          Tag1 contains 
+        </div>
+        <div
+          class="sc-fKFyDc euqOvB sc-bBXqnf iHGIIw"
+        >
+          value1
+        </div>
+        <div
+          class="sc-fKFyDc dTkenA sc-bBXqnf iHGIIw"
+        >
+          ... and 3 more
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/components/Tag/index.tsx
+++ b/src/components/Tag/index.tsx
@@ -8,6 +8,9 @@ import { Button } from '../Button';
 import { Flex } from '../Flex';
 import { Txt } from '../Txt';
 
+// Prevent the filters taking up too much horizontal space
+const MAX_ITEMS_TO_DISPLAY = 3;
+
 const Container = styled(Flex)`
 	background-color: ${(props) => props.theme.colors.info.light};
 	border: 1px solid ${(props) => props.theme.colors.info.main};
@@ -19,6 +22,19 @@ const DeleteButton = styled(Button)`
 	color: ${(props) => props.theme.colors.tertiary.semilight};
 `;
 
+const tagItemsToString = (items: TagItem[]) => {
+	return items
+		.map((item, index) => {
+			const prefix = index > 0 ? `${item.prefix || ','} ` : '';
+			const separator = item.operator ? ` ${item.operator} ` : ': ';
+			return (
+				prefix +
+				(item.value ? `${item.name}${separator}${item.value}` : item.name)
+			);
+		})
+		.join('\n');
+};
+
 const BaseTag = ({
 	name,
 	operator,
@@ -28,14 +44,27 @@ const BaseTag = ({
 	onClick,
 	className,
 }: InternalTagProps) => {
-	const tagArray = multiple || [{ name, operator, value }];
+	let tagArray = multiple || [{ name, operator, value }];
 
 	if (!tagArray.length) {
 		return null;
 	}
+	const overflow = tagArray.length > MAX_ITEMS_TO_DISPLAY;
+
+	if (overflow) {
+		tagArray = [tagArray[0], { name: `... and ${tagArray.length - 1} more` }];
+	}
 
 	const tagContent = (
-		<Container py={1} px={2}>
+		<Container
+			py={1}
+			px={2}
+			tooltip={
+				overflow
+					? { text: tagItemsToString(multiple ?? []), placement: 'bottom' }
+					: undefined
+			}
+		>
 			{tagArray.map((tagEntry, index) => {
 				const nameValueSeparator = tagEntry.operator
 					? ` ${tagEntry.operator} `
@@ -43,7 +72,7 @@ const BaseTag = ({
 
 				return (
 					<React.Fragment key={index}>
-						{index > 0 && (
+						{index > 0 && !overflow && (
 							<Txt whitespace="pre" color="info.main" fontSize={1} italic>{`  ${
 								tagEntry.prefix || ','
 							}  `}</Txt>
@@ -90,6 +119,13 @@ const BaseTag = ({
 	);
 };
 
+export interface TagItem {
+	value?: string;
+	name?: string;
+	operator?: string;
+	prefix?: string;
+}
+
 export interface InternalTagProps {
 	/** The value part of the tag */
 	value?: string;
@@ -98,12 +134,7 @@ export interface InternalTagProps {
 	/** The operator that goes between the name and value of the tag */
 	operator?: string;
 	/** An array of name-value pairs, with an optional delimiter to be used between the previous and current tag entry */
-	multiple?: Array<{
-		value?: string;
-		name?: string;
-		operator?: string;
-		prefix?: string;
-	}>;
+	multiple?: TagItem[];
 	/** Callback method, that if passed, a "close" button will be added to the right-hand side of the tag */
 	onClose?: (event: React.MouseEvent<HTMLElement, MouseEvent>) => void;
 	/** Callback method, that if passed, the tag will become clickable */

--- a/src/extra/MarkdownEditor/__snapshots__/MarkdownEditor.stories.storyshot
+++ b/src/extra/MarkdownEditor/__snapshots__/MarkdownEditor.stories.storyshot
@@ -6,7 +6,7 @@ exports[`Storyshots Extra/MarkdownEditor Default 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
   >
     <div
-      class="sc-tkKAw ddBawh"
+      class="sc-tkKAw iFVvED"
       id="simplemde-editor-2-wrapper"
     >
       <textarea

--- a/src/extra/MarkdownEditor/defaultStyle.ts
+++ b/src/extra/MarkdownEditor/defaultStyle.ts
@@ -19,7 +19,7 @@ export default css`
 	}
 	.CodeMirror-gutter-filler,
 	.CodeMirror-scrollbar-filler {
-		background-color: #fff;
+		background-color: transparent;
 	}
 	.CodeMirror-gutters {
 		border-right: 1px solid #ddd;
@@ -460,24 +460,12 @@ export default css`
 		-ms-user-select: none;
 		-o-user-select: none;
 		user-select: none;
-		padding: 0 10px;
+		padding: 9px 10px;
 		border-top: 1px solid #bbb;
 		border-left: 1px solid #bbb;
 		border-right: 1px solid #bbb;
 		border-top-left-radius: 4px;
 		border-top-right-radius: 4px;
-	}
-	.editor-toolbar:after,
-	.editor-toolbar:before {
-		display: block;
-		content: ' ';
-		height: 1px;
-	}
-	.editor-toolbar:before {
-		margin-bottom: 8px;
-	}
-	.editor-toolbar:after {
-		margin-top: 8px;
 	}
 	.editor-toolbar.fullscreen {
 		width: 100%;
@@ -742,7 +730,8 @@ export default css`
 		);
 	}
 	.easymde-dropdown-content {
-		display: none;
+		display: block;
+		visibility: hidden;
 		position: absolute;
 		background-color: #f9f9f9;
 		box-shadow: 0 8px 16px 0 rgba(0, 0, 0, 0.2);
@@ -752,9 +741,9 @@ export default css`
 	}
 	.easymde-dropdown:active .easymde-dropdown-content,
 	.easymde-dropdown:focus .easymde-dropdown-content {
-		display: block;
+		visibility: visible;
 	}
-	span[data-img-src]::before {
+	span[data-img-src]::after {
 		content: '';
 		background-image: var(--bg-image);
 		display: block;

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,7 +87,7 @@ export { Link, LinkProps } from './components/Link';
 export { List, ListProps } from './components/List';
 export { Popover, PopoverProps, PopoverOptions } from './components/Popover';
 export { Tab, TabProps, Tabs, TabsProps } from './components/Tabs';
-export { Tag, TagProps } from './components/Tag';
+export { Tag, TagProps, TagItem } from './components/Tag';
 
 export { Avatar, AvatarProps } from './components/Avatar';
 export { Box, BoxProps } from './components/Box';


### PR DESCRIPTION
If there are too many items (more than 3), only the
first item is displayed, suffixed with `... and # more`. All
items are then displayed in a tooltip for convenience.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

---

![Overflowing Tags](https://user-images.githubusercontent.com/2925657/107729065-5eb26f80-6d22-11eb-8650-0e54caded32d.PNG)

##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
