### PR TITLE
DropDownButton: add support for dropping 'up'

### DIFF
--- a/src/components/DropDownButton/DropDownButton.stories.tsx
+++ b/src/components/DropDownButton/DropDownButton.stories.tsx
@@ -3,6 +3,7 @@ import { Meta } from '@storybook/react';
 import { createTemplate, createStory } from '../../stories/utils';
 import { DropDownButton, DropDownButtonProps } from '.';
 import { Button, ButtonProps } from '../Button';
+import { Box } from '../Box';
 import { Divider } from '../Divider';
 
 const NonZeroOrderedButton = (props: ButtonProps & { i: number }) => {
@@ -44,6 +45,15 @@ export default {
 	component: DropDownButton,
 } as Meta;
 
+const OpenUpStory = (props: DropDownButtonProps) => {
+	return (
+		<Box mt="300px">
+			<DropDownButton {...props} />
+		</Box>
+	);
+};
+const OpenUpTemplate = createTemplate<DropDownButtonProps>(OpenUpStory);
+
 const Template = createTemplate<DropDownButtonProps>(DropDownButton);
 
 export const Default = createStory<DropDownButtonProps>(Template, {
@@ -79,5 +89,11 @@ export const IconOnly = createStory<DropDownButtonProps>(Template, {
 export const NoListFormatting = createStory<DropDownButtonProps>(Template, {
 	noListFormat: true,
 	primary: true,
+	children: sampleChildren,
+});
+
+export const DropUp = createStory<DropDownButtonProps>(OpenUpTemplate, {
+	label: 'Dropdown',
+	dropUp: true,
 	children: sampleChildren,
 });

--- a/src/components/DropDownButton/__snapshots__/DropDownButton.stories.storyshot
+++ b/src/components/DropDownButton/__snapshots__/DropDownButton.stories.storyshot
@@ -82,6 +82,51 @@ exports[`Storyshots Core/DropDownButton Default 1`] = `
 </div>
 `;
 
+exports[`Storyshots Core/DropDownButton Drop Up 1`] = `
+<div>
+  <div
+    class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
+  >
+    <div
+      class="sc-gKsewC cgpPfo sc-iBPRYJ jXUUkp"
+    >
+      <div
+        class="sc-gKsewC cgpPfo sc-iBPRYJ dWRxlP sc-jONnTn fFdndA sc-bTvRPi habiYC"
+      >
+        <span>
+          <button
+            class="StyledButton-sc-323bzc-0 cfpfuP sc-bqyKva sc-hBEYos gjQfnS kmijuE sc-dIUggk YDvpG sc-jHVexB jChkJc"
+            type="button"
+          >
+            Dropdown
+          </button>
+          <button
+            class="StyledButton-sc-323bzc-0 gMxQVt sc-bqyKva sc-hBEYos gjQfnS kmijuE sc-dIUggk YDvpG sc-TmcTc fedNbr"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="svg-inline--fa fa-chevron-down fa-w-14 "
+              data-icon="chevron-down"
+              data-prefix="fas"
+              focusable="false"
+              role="img"
+              viewBox="0 0 448 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
+                fill="currentColor"
+              />
+            </svg>
+          </button>
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storyshots Core/DropDownButton Icon Only 1`] = `
 <div>
   <div

--- a/src/components/DropDownButton/index.tsx
+++ b/src/components/DropDownButton/index.tsx
@@ -38,6 +38,7 @@ const ButtonBase = styled(Button)`
 
 const MenuBase = styled(Box)<{
 	alignRight?: boolean;
+	dropUp?: boolean;
 }>`
 	background: white;
 	position: absolute;
@@ -45,7 +46,9 @@ const MenuBase = styled(Box)<{
 	border-radius: ${(props) => px(props.theme.radius)};
 	border: ${(props) => '1px solid ' + props.theme.colors.gray.main};
 	z-index: 1;
-	margin-top: 2px;
+	margin-top: ${(props) => (props.dropUp ? 0 : '2px')};
+	margin-bottom: ${(props) => (props.dropUp ? '2px' : 0)};
+	bottom: ${(props) => (props.dropUp ? props.theme.button.height : 'auto')};
 	left: ${(props) => (props.alignRight ? 'auto' : 0)};
 	right: ${(props) => (!props.alignRight ? 'auto' : 0)};
 	white-space: nowrap;
@@ -196,6 +199,7 @@ class BaseDropDownButton extends React.Component<
 
 	public render() {
 		const {
+			dropUp,
 			alignRight,
 			children,
 			label,
@@ -241,6 +245,7 @@ class BaseDropDownButton extends React.Component<
 				{this.state.open && <Fixed onClick={this.toggle} />}
 				{this.state.open && (
 					<MenuBase
+						dropUp={dropUp}
 						alignRight={alignRight}
 						onClick={this.toggle}
 						minWidth={`${this.state.minWidth}px`}
@@ -278,6 +283,8 @@ export interface InternalDropDownButtonProps extends ButtonProps {
 	joined?: boolean;
 	/** If true, put the dropdown list on the right */
 	alignRight?: boolean;
+	/** If true, the dropdown list will open up, rather than down */
+	dropUp?: boolean;
 	/** If true, render children as a single JSX element instead of iterating over each of them */
 	noListFormat?: boolean;
 	/** If setted, it defines the maximum height of the dropdown list */

--- a/src/components/Form/__snapshots__/Form.stories.storyshot
+++ b/src/components/Form/__snapshots__/Form.stories.storyshot
@@ -3363,7 +3363,7 @@ Rendition contains widgets for rendering Markdown and Mermaid text formats that 
                         Markdown
                       </label>
                       <div
-                        class="sc-tkKAw ddBawh"
+                        class="sc-tkKAw iFVvED"
                         id="simplemde-editor-1-wrapper"
                       >
                         <textarea

--- a/src/extra/MarkdownEditor/__snapshots__/MarkdownEditor.stories.storyshot
+++ b/src/extra/MarkdownEditor/__snapshots__/MarkdownEditor.stories.storyshot
@@ -6,7 +6,7 @@ exports[`Storyshots Extra/MarkdownEditor Default 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 jdcmMW sc-eFubAy kVQCHm"
   >
     <div
-      class="sc-tkKAw ddBawh"
+      class="sc-tkKAw iFVvED"
       id="simplemde-editor-2-wrapper"
     >
       <textarea

--- a/src/extra/MarkdownEditor/defaultStyle.ts
+++ b/src/extra/MarkdownEditor/defaultStyle.ts
@@ -19,7 +19,7 @@ export default css`
 	}
 	.CodeMirror-gutter-filler,
 	.CodeMirror-scrollbar-filler {
-		background-color: #fff;
+		background-color: transparent;
 	}
 	.CodeMirror-gutters {
 		border-right: 1px solid #ddd;
@@ -460,24 +460,12 @@ export default css`
 		-ms-user-select: none;
 		-o-user-select: none;
 		user-select: none;
-		padding: 0 10px;
+		padding: 9px 10px;
 		border-top: 1px solid #bbb;
 		border-left: 1px solid #bbb;
 		border-right: 1px solid #bbb;
 		border-top-left-radius: 4px;
 		border-top-right-radius: 4px;
-	}
-	.editor-toolbar:after,
-	.editor-toolbar:before {
-		display: block;
-		content: ' ';
-		height: 1px;
-	}
-	.editor-toolbar:before {
-		margin-bottom: 8px;
-	}
-	.editor-toolbar:after {
-		margin-top: 8px;
 	}
 	.editor-toolbar.fullscreen {
 		width: 100%;
@@ -742,7 +730,8 @@ export default css`
 		);
 	}
 	.easymde-dropdown-content {
-		display: none;
+		display: block;
+		visibility: hidden;
 		position: absolute;
 		background-color: #f9f9f9;
 		box-shadow: 0 8px 16px 0 rgba(0, 0, 0, 0.2);
@@ -752,9 +741,9 @@ export default css`
 	}
 	.easymde-dropdown:active .easymde-dropdown-content,
 	.easymde-dropdown:focus .easymde-dropdown-content {
-		display: block;
+		visibility: visible;
 	}
-	span[data-img-src]::before {
+	span[data-img-src]::after {
 		content: '';
 		background-image: var(--bg-image);
 		display: block;


### PR DESCRIPTION
When the DropDownButton is located at the bottom of the screen, it can be useful to specify that the DropDownButton's menu should open _above_ the button, rather than below (as is the default).

Obviously it would be even nicer to be able to specify that it should automatically work out whether to open up or down - but adding this `dropUp` prop is a good first step for now.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

---

##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
