### PR TITLE
fix: handle empty timestamp string in formatTimestamp

### DIFF
--- a/src/components/Renderer/widgets/widget-util.tsx
+++ b/src/components/Renderer/widgets/widget-util.tsx
@@ -33,6 +33,9 @@ const DATE_FORMAT = 'MMM do yyyy';
 const TIME_FORMAT = 'h:mm a';
 
 export function formatTimestamp(timestamp: string, uiSchema: UiSchema = {}) {
+	if (!timestamp) {
+		return '';
+	}
 	const uiFormat =
 		get(uiSchema, ['ui:options', 'dtFormat']) ||
 		`${DATE_FORMAT}, ${TIME_FORMAT}`;


### PR DESCRIPTION
Need to handle the case where the timestamp string is an empty string - in which case we should just return an empty string.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

---

Relates to: https://github.com/product-os/jellyfish/issues/5862

##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
