### PR TITLE
Prohibit whole lodash and fontawesome icon pack imports

### DIFF
--- a/src/components/Form/index.tsx
+++ b/src/components/Form/index.tsx
@@ -1,5 +1,6 @@
 import { JSONSchema7 as JSONSchema } from 'json-schema';
 import omit from 'lodash/omit';
+import uniqBy from 'lodash/uniqBy';
 import * as React from 'react';
 import RsjfForm, {
 	IChangeEvent,
@@ -25,7 +26,6 @@ import SelectWidget from './widgets/SelectWidget';
 import TextareaWidget from './widgets/TextareaWidget';
 import { Format } from '../Renderer/types';
 import { WidgetContext } from '../../contexts/WidgetContext';
-import { uniqBy } from 'lodash';
 
 const SUPPORTED_SCHEMA_FORMATS = [
 	'data-url',

--- a/src/components/StatsBar/index.tsx
+++ b/src/components/StatsBar/index.tsx
@@ -1,5 +1,5 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { IconProp } from '@fortawesome/fontawesome-svg-core';
+import type { IconProp } from '@fortawesome/fontawesome-svg-core';
 import range from 'lodash/range';
 import React from 'react';
 import { Box } from '../Box';

--- a/tslint.json
+++ b/tslint.json
@@ -1,6 +1,12 @@
 {
   "extends": "./node_modules/@balena/lint/config/tslint-prettier.json",
   "rules": {
+    "import-blacklist": [
+      true,
+      "lodash",
+      "@fortawesome/free-solid-svg-icons",
+      "@fortawesome/free-regular-svg-icons"
+    ],
     "no-shadowed-variable": false
   }
 }


### PR DESCRIPTION
Accidentally removed in #1059

Change-type: patch
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
