### PR TITLE
DropDownButton: Prevent the menu button from submitting parent forms

### DIFF
--- a/src/components/DropDownButton/index.tsx
+++ b/src/components/DropDownButton/index.tsx
@@ -98,49 +98,31 @@ const Toggle = ({
 	open: boolean;
 	handler: React.MouseEventHandler<HTMLElement>;
 }) => {
+	const toggleProps = {
+		...props,
+		// Avoid submitting parent forms when
+		// clicking on the toggle.
+		type: 'button',
+		onClick: handler,
+	};
+	const icon = open ? faChevronUp : faChevronDown;
 	const shouldCompact = useBreakpoint(compact || [false]);
 	if (joined) {
 		if (label || props.icon) {
 			return (
-				<JoinedButton {...props} onClick={handler}>
+				<JoinedButton {...toggleProps}>
 					<Flex justifyContent="space-between" alignItems="center">
 						{!shouldCompact && <Box mr={2}>{label}</Box>}
-						{open ? (
-							<FontAwesomeIcon icon={faChevronUp} />
-						) : (
-							<FontAwesomeIcon icon={faChevronDown} />
-						)}
+						{<FontAwesomeIcon icon={icon} />}
 					</Flex>
 				</JoinedButton>
 			);
 		}
 		return (
-			<JoinedButton
-				{...props}
-				icon={
-					open ? (
-						<FontAwesomeIcon icon={faChevronUp} />
-					) : (
-						<FontAwesomeIcon icon={faChevronDown} />
-					)
-				}
-				onClick={handler}
-			/>
+			<JoinedButton {...toggleProps} icon={<FontAwesomeIcon icon={icon} />} />
 		);
 	}
-	return (
-		<ToggleBase
-			{...props}
-			icon={
-				open ? (
-					<FontAwesomeIcon icon={faChevronUp} />
-				) : (
-					<FontAwesomeIcon icon={faChevronDown} />
-				)
-			}
-			onClick={handler}
-		/>
-	);
+	return <ToggleBase {...toggleProps} icon={<FontAwesomeIcon icon={icon} />} />;
 };
 
 interface DropDownButtonState {


### PR DESCRIPTION
Atm if the DropDownButton is inside a form, clocking the menu toggle submits the form.
Found it while working on:
![image](https://user-images.githubusercontent.com/1295829/114916100-12bc9d80-9e2d-11eb-9b83-9a42f38b3771.png)


Change-type: patch
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
