### PR TITLE
Stop using Bluebird

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "@storybook/react": "^6.0.28",
     "@testing-library/jest-dom": "^5.11.6",
     "@testing-library/react": "^11.2.0",
-    "@types/bluebird": "^3.5.33",
     "@types/enzyme": "^3.10.8",
     "@types/googlemaps": "3.39.7",
     "@types/highlightjs": "^9.12.0",

--- a/src/components/Form/spec.tsx
+++ b/src/components/Form/spec.tsx
@@ -1,4 +1,3 @@
-import Promise from 'bluebird';
 import { mount } from 'enzyme';
 import React from 'react';
 import sinon from 'sinon';
@@ -6,6 +5,7 @@ import { JSONSchema7 } from 'json-schema';
 
 import { Alert, Form, Provider } from '../../';
 import { EXTRA_FORMATS } from './examples';
+import { delay } from '../../utils/promises';
 
 const schema = {
 	type: 'object',
@@ -139,7 +139,7 @@ describe('Form component', () => {
 			input.simulate('change', { target: { value } });
 			component.update();
 
-			return Promise.delay(150).then(() => {
+			return delay(150).then(() => {
 				component.find('form').simulate('submit');
 				expect(callback.callCount).toEqual(1);
 				expect(callback.getCall(0).args[0].formData).toEqual({ Name: value });
@@ -163,7 +163,7 @@ describe('Form component', () => {
 			input.simulate('change', { target: { value } });
 			component.update();
 
-			return Promise.delay(150).then(() => {
+			return delay(150).then(() => {
 				expect(callback.called).toEqual(true);
 				expect(callback.lastCall.args[0].formData).toEqual({ Name: value });
 
@@ -268,7 +268,7 @@ describe('Form component', () => {
 				.simulate('click');
 			component.update();
 
-			return Promise.delay(150).then(() => {
+			return delay(150).then(() => {
 				const callArg = callback.lastCall.args[0];
 				expect(callArg.formData).toEqual({ testfield: 'foo' });
 			});
@@ -335,7 +335,7 @@ describe('Form component', () => {
 
 			component.update();
 
-			return Promise.delay(150).then(() => {
+			return delay(150).then(() => {
 				const callArg = callback.lastCall.args[0];
 				expect(callArg.formData).toEqual({
 					Array: [value],
@@ -359,7 +359,7 @@ describe('Form component', () => {
 
 			component.update();
 
-			return Promise.delay(150).then(() => {
+			return delay(150).then(() => {
 				const callArg = callback.lastCall.args[0];
 				expect(callArg.formData).toEqual({
 					Array: [value1, value2],
@@ -375,7 +375,7 @@ describe('Form component', () => {
 
 			component.update();
 
-			return Promise.delay(150).then(() => {
+			return delay(150).then(() => {
 				const callArg = callback.lastCall.args[0];
 				expect(callArg.formData).toEqual({
 					Array: [value2, value1],
@@ -391,7 +391,7 @@ describe('Form component', () => {
 
 			component.update();
 
-			return Promise.delay(150).then(() => {
+			return delay(150).then(() => {
 				const callArg = callback.lastCall.args[0];
 				expect(callArg.formData).toEqual({
 					Array: [value1, value2],
@@ -407,7 +407,7 @@ describe('Form component', () => {
 
 			component.update();
 
-			return Promise.delay(150).then(() => {
+			return delay(150).then(() => {
 				const callArg = callback.lastCall.args[0];
 				expect(callArg.formData).toEqual({
 					Array: [value1],

--- a/src/utils/promises.ts
+++ b/src/utils/promises.ts
@@ -1,0 +1,4 @@
+export const delay = (ms: number) =>
+	new Promise<void>((resolve) => {
+		setTimeout(resolve, ms);
+	});


### PR DESCRIPTION
We were only using it in specs even though it was
not in our devDependencies and it only worked b/c
storybook has it as a dependency of its own. The
inline implementation atm should be tree shaked
away by consumers, since it's only used in tests.

Change-type: patch
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>


---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
