### PR TITLE
Spinner spread props to content

### DIFF
--- a/src/components/Spinner/index.tsx
+++ b/src/components/Spinner/index.tsx
@@ -1,15 +1,14 @@
+import pick from 'lodash/pick';
 import * as React from 'react';
 import styled from 'styled-components';
-import { RenditionSystemProps } from '../../common-types';
 
 import { rotate360 } from '../../animations';
-import asRendition from '../../asRendition';
 import { px } from '../../utils';
-import { Box } from '../Box';
+import { Box, BoxProps } from '../Box';
 import { Flex } from '../Flex';
 import { Txt } from '../Txt';
 
-const CircleLoader = styled.div<Pick<InternalSpinnerProps, 'emphasized'>>`
+const CircleLoader = styled.div<Pick<SpinnerProps, 'emphasized'>>`
 	background: transparent !important;
 	width: ${(props) => px(props.emphasized ? 40 : 20)};
 	height: ${(props) => px(props.emphasized ? 40 : 20)};
@@ -34,7 +33,7 @@ const SpinnerContainer = styled(Flex)`
 	right: 0;
 `;
 
-const ChildrenContainer = styled(Box)<Pick<InternalSpinnerProps, 'show'>>`
+const ChildrenContainer = styled(Box)<Pick<SpinnerProps, 'show'>>`
 	opacity: ${(props) => (props.show ? 0.4 : 1)};
 	transition: opacity 250ms;
 `;
@@ -43,7 +42,7 @@ const Base = ({
 	label,
 	emphasized,
 	...otherProps
-}: Omit<InternalSpinnerProps, 'show'>) => {
+}: Omit<SpinnerProps, 'show'>) => {
 	return (
 		<Flex
 			flexDirection={emphasized ? 'column' : 'row'}
@@ -62,13 +61,37 @@ const Base = ({
 	);
 };
 
-const BaseSpinner = ({
+const childrenWiredPropNames = [
+	'display',
+	'alignContent',
+	'alignItems',
+	'alignSelf',
+	'flex',
+	'flexBasis',
+	'flexDirection',
+	'flexWrap',
+	'justifyContent',
+	'justifyItems',
+	'justifySelf',
+];
+
+export interface SpinnerProps extends BoxProps {
+	/** If passed, it will control whether the spinner is shown or not */
+	show?: boolean;
+	/** If true, it will render a large spinner */
+	emphasized?: boolean;
+	/** A label that will be rendered next to the spinner. Renders on right-hand side for standard spinner, and below spinner for emphasized */
+	label?: string | React.ReactNode;
+}
+
+/** [View story source](https://github.com/balena-io-modules/rendition/blob/master/src/components/Spinner/Spinner.stories.tsx) */
+export const Spinner = ({
 	show = true,
 	emphasized,
 	label,
 	children,
 	...otherProps
-}: InternalSpinnerProps) => {
+}: SpinnerProps) => {
 	if (!children) {
 		if (!show) {
 			return null;
@@ -77,9 +100,12 @@ const BaseSpinner = ({
 		return <Base label={label} emphasized={emphasized} {...otherProps} />;
 	}
 
+	const childrenWiredProps = pick(otherProps, childrenWiredPropNames);
 	return (
 		<Container {...otherProps}>
-			<ChildrenContainer show={show}>{children}</ChildrenContainer>
+			<ChildrenContainer show={show} {...childrenWiredProps}>
+				{children}
+			</ChildrenContainer>
 
 			{show && (
 				<SpinnerContainer justifyContent="center" alignItems="center">
@@ -89,18 +115,3 @@ const BaseSpinner = ({
 		</Container>
 	);
 };
-
-interface InternalSpinnerProps extends React.HTMLAttributes<HTMLElement> {
-	/** If passed, it will control whether the spinner is shown or not */
-	show?: boolean;
-	/** If true, it will render a large spinner */
-	emphasized?: boolean;
-	/** A label that will be rendered next to the spinner. Renders on right-hand side for standard spinner, and below spinner for emphasized */
-	label?: string | React.ReactNode;
-}
-
-export type SpinnerProps = InternalSpinnerProps & RenditionSystemProps;
-
-/** [View story source](https://github.com/balena-io-modules/rendition/blob/master/src/components/Spinner/Spinner.stories.tsx) */
-export const Spinner =
-	asRendition<React.FunctionComponent<SpinnerProps>>(BaseSpinner);

--- a/src/components/Spinner/index.tsx
+++ b/src/components/Spinner/index.tsx
@@ -5,6 +5,7 @@ import { RenditionSystemProps } from '../../common-types';
 import { rotate360 } from '../../animations';
 import asRendition from '../../asRendition';
 import { px } from '../../utils';
+import { Box } from '../Box';
 import { Flex } from '../Flex';
 import { Txt } from '../Txt';
 
@@ -21,7 +22,7 @@ const CircleLoader = styled.div<Pick<InternalSpinnerProps, 'emphasized'>>`
 	animation-fill-mode: both;
 `;
 
-const Container = styled.div`
+const Container = styled(Box)`
 	position: relative;
 `;
 
@@ -31,13 +32,11 @@ const SpinnerContainer = styled(Flex)`
 	left: 0;
 	bottom: 0;
 	right: 0;
-	z-index: 4;
 `;
 
-const ChildrenContainer = styled.div<Pick<InternalSpinnerProps, 'show'>>`
+const ChildrenContainer = styled(Box)<Pick<InternalSpinnerProps, 'show'>>`
 	opacity: ${(props) => (props.show ? 0.4 : 1)};
 	transition: opacity 250ms;
-	z-index: 3;
 `;
 
 const Base = ({
@@ -80,13 +79,13 @@ const BaseSpinner = ({
 
 	return (
 		<Container {...otherProps}>
+			<ChildrenContainer show={show}>{children}</ChildrenContainer>
+
 			{show && (
 				<SpinnerContainer justifyContent="center" alignItems="center">
 					<Base label={label} emphasized={emphasized} />
 				</SpinnerContainer>
 			)}
-
-			<ChildrenContainer show={show}>{children}</ChildrenContainer>
 		</Container>
 	);
 };


### PR DESCRIPTION
W/o this, styling a `<Spinner>` as a flex element doesn't seem to have any effect to the child element provided.
We obviously want to avoid copying the margin/padding props b/c they would be applied to both elements

Change-type: minor
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
