### PR TITLE
Terminal: Use the native ResizeObserver if available

### DIFF
--- a/src/components/Terminal/index.tsx
+++ b/src/components/Terminal/index.tsx
@@ -8,9 +8,11 @@ import { Theme as ThemeType } from '../../common-types';
 import theme from '../../theme';
 import defaultXtermStyle from './XTermDefaultStyle';
 import { Flex } from '../Flex';
-// TODO: this can be replaced with types as soon as https://gist.github.com/strothj/708afcf4f01dd04de8f49c92e88093c3
-// or similar will be published as an NPM package
-import { ResizeObserver } from 'resize-observer';
+// TODO: Drop this in the next major, since TS now has the correct types and this was supposed to only be used as a type-only import.
+import { ResizeObserver as ResizeObserverPonyfill } from 'resize-observer';
+// TODO: Drop this in favor of the native TS ResizeObserver type once we bump to 4.2
+// See: https://github.com/microsoft/TypeScript/commit/16031bc429305e5daabf263f208678a6729a161e
+import type { ResizeObserver as ResizeObserverType } from 'resize-observer';
 
 const TtyContainer = styled(Flex)`
 	position: relative;
@@ -116,7 +118,7 @@ export class Terminal extends React.Component<ThemedTerminalProps, {}> {
 	// Used as the element to mount XTERM into
 	private mountElement: HTMLDivElement | null;
 	private termConfig: ITerminalOptions;
-	private resizeObserver: ResizeObserver | null;
+	private resizeObserver: ResizeObserverType | null;
 
 	constructor(props: ThemedTerminalProps) {
 		super(props);
@@ -160,11 +162,18 @@ export class Terminal extends React.Component<ThemedTerminalProps, {}> {
 				});
 			}
 			this.resize();
-			if (typeof ResizeObserver === 'function') {
-				this.resizeObserver = new ResizeObserver(() => {
+			// @ts-expect-error this was added to the window types on TS 4.2
+			const nativeResizeObserver = window.ResizeObserver;
+			const ResizeObserverCtor =
+				typeof nativeResizeObserver === 'function'
+					? nativeResizeObserver
+					: ResizeObserverPonyfill;
+			if (typeof ResizeObserverCtor === 'function') {
+				const resizeObserver = new ResizeObserverCtor(() => {
 					this.resize();
 				});
-				this.resizeObserver.observe(this.mountElement!);
+				resizeObserver.observe(this.mountElement!);
+				this.resizeObserver = resizeObserver;
 			}
 		});
 	}


### PR DESCRIPTION
Change-type: minor
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
