### PR TITLE
Fix download modal image size info

### DIFF
--- a/src/unstable-temp/DownloadImageModal/ImageForm.tsx
+++ b/src/unstable-temp/DownloadImageModal/ImageForm.tsx
@@ -191,7 +191,8 @@ export const ImageForm = ({
 						onClick={() => setDownloadConfigOnly(false)}
 					>
 						<Txt bold={!model.downloadConfigOnly}>
-							{t('actions.download_balenaos')}
+							{t('actions.download_balenaos') +
+								(rawVersion && downloadSize ? ` (~${downloadSize})` : '')}
 						</Txt>
 					</Button>
 				)}


### PR DESCRIPTION
Fix download modal image size info

Change-type: patch
Signed-off-by: Andrea Rosci <andrear@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
