### PR TITLE
Markdown: improve css styling of paragraphs

### DIFF
--- a/src/components/Form/__snapshots__/Form.stories.storyshot
+++ b/src/components/Form/__snapshots__/Form.stories.storyshot
@@ -262,7 +262,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                         id="root_first_seen__description"
                       >
                         <div
-                          class="sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi sc-ciOKUB Blmka"
+                          class="sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi sc-ciOKUB iexkTS"
                         >
                           <div>
                             <p
@@ -305,7 +305,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                         id="root_poke_password__description"
                       >
                         <div
-                          class="sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi sc-ciOKUB Blmka"
+                          class="sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi sc-ciOKUB iexkTS"
                         >
                           <div>
                             <p
@@ -412,7 +412,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                           id="root_tags__description"
                         >
                           <div
-                            class="sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi sc-ciOKUB Blmka"
+                            class="sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi sc-ciOKUB iexkTS"
                           >
                             <div>
                               <p
@@ -744,7 +744,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                         id="root_first_seen__description"
                       >
                         <div
-                          class="sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi sc-ciOKUB Blmka"
+                          class="sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi sc-ciOKUB iexkTS"
                         >
                           <div>
                             <p
@@ -787,7 +787,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                         id="root_poke_password__description"
                       >
                         <div
-                          class="sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi sc-ciOKUB Blmka"
+                          class="sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi sc-ciOKUB iexkTS"
                         >
                           <div>
                             <p
@@ -894,7 +894,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                           id="root_tags__description"
                         >
                           <div
-                            class="sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi sc-ciOKUB Blmka"
+                            class="sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi sc-ciOKUB iexkTS"
                           >
                             <div>
                               <p
@@ -1234,7 +1234,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                         id="root_first_seen__description"
                       >
                         <div
-                          class="sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi sc-ciOKUB Blmka"
+                          class="sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi sc-ciOKUB iexkTS"
                         >
                           <div>
                             <p
@@ -1278,7 +1278,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                         id="root_poke_password__description"
                       >
                         <div
-                          class="sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi sc-ciOKUB Blmka"
+                          class="sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi sc-ciOKUB iexkTS"
                         >
                           <div>
                             <p
@@ -1387,7 +1387,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                           id="root_tags__description"
                         >
                           <div
-                            class="sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi sc-ciOKUB Blmka"
+                            class="sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi sc-ciOKUB iexkTS"
                           >
                             <div>
                               <p
@@ -1719,7 +1719,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                         id="root_first_seen__description"
                       >
                         <div
-                          class="sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi sc-ciOKUB Blmka"
+                          class="sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi sc-ciOKUB iexkTS"
                         >
                           <div>
                             <p
@@ -1762,7 +1762,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                         id="root_poke_password__description"
                       >
                         <div
-                          class="sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi sc-ciOKUB Blmka"
+                          class="sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi sc-ciOKUB iexkTS"
                         >
                           <div>
                             <p
@@ -1869,7 +1869,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                           id="root_tags__description"
                         >
                           <div
-                            class="sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi sc-ciOKUB Blmka"
+                            class="sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi sc-ciOKUB iexkTS"
                           >
                             <div>
                               <p
@@ -2196,7 +2196,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                         id="root_first_seen__description"
                       >
                         <div
-                          class="sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi sc-ciOKUB Blmka"
+                          class="sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi sc-ciOKUB iexkTS"
                         >
                           <div>
                             <p
@@ -2239,7 +2239,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                         id="root_poke_password__description"
                       >
                         <div
-                          class="sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi sc-ciOKUB Blmka"
+                          class="sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi sc-ciOKUB iexkTS"
                         >
                           <div>
                             <p
@@ -2346,7 +2346,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                           id="root_tags__description"
                         >
                           <div
-                            class="sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi sc-ciOKUB Blmka"
+                            class="sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi sc-ciOKUB iexkTS"
                           >
                             <div>
                               <p
@@ -2571,7 +2571,7 @@ exports[`Storyshots Core/Form With Extra Widgets 1`] = `
       class="sc-gKAaRy iZvmHx sc-iCoGMd hOhWwQ"
     >
       <div
-        class="sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi sc-ciOKUB Blmka"
+        class="sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi sc-ciOKUB iexkTS"
       >
         <div>
           <h1
@@ -3751,7 +3751,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                         id="root_Name"
                       >
                         <div
-                          class="sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi sc-ciOKUB Blmka"
+                          class="sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi sc-ciOKUB iexkTS"
                         >
                           <div>
                             <p
@@ -3961,7 +3961,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                         id="root_first_seen__description"
                       >
                         <div
-                          class="sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi sc-ciOKUB Blmka"
+                          class="sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi sc-ciOKUB iexkTS"
                         >
                           <div>
                             <p
@@ -4004,7 +4004,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                         id="root_poke_password__description"
                       >
                         <div
-                          class="sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi sc-ciOKUB Blmka"
+                          class="sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi sc-ciOKUB iexkTS"
                         >
                           <div>
                             <p
@@ -4135,7 +4135,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                           id="root_tags__description"
                         >
                           <div
-                            class="sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi sc-ciOKUB Blmka"
+                            class="sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi sc-ciOKUB iexkTS"
                           >
                             <div>
                               <p
@@ -4821,7 +4821,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                         id="root_first_seen__description"
                       >
                         <div
-                          class="sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi sc-ciOKUB Blmka"
+                          class="sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi sc-ciOKUB iexkTS"
                         >
                           <div>
                             <p
@@ -4864,7 +4864,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                         id="root_poke_password__description"
                       >
                         <div
-                          class="sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi sc-ciOKUB Blmka"
+                          class="sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi sc-ciOKUB iexkTS"
                         >
                           <div>
                             <p
@@ -4995,7 +4995,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                           id="root_tags__description"
                         >
                           <div
-                            class="sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi sc-ciOKUB Blmka"
+                            class="sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi sc-ciOKUB iexkTS"
                           >
                             <div>
                               <p
@@ -5136,7 +5136,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                             class="sc-gKAaRy iZvmHx sc-iCoGMd eZYjXy sc-hHEiqL fOpvOh sc-dtLLSn plZaY"
                           >
                             <div
-                              class="sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi sc-ciOKUB Blmka"
+                              class="sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi sc-ciOKUB iexkTS"
                             >
                               <div>
                                 <p
@@ -5366,7 +5366,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                         id="root_first_seen__description"
                       >
                         <div
-                          class="sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi sc-ciOKUB Blmka"
+                          class="sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi sc-ciOKUB iexkTS"
                         >
                           <div>
                             <p
@@ -5409,7 +5409,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                         id="root_poke_password__description"
                       >
                         <div
-                          class="sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi sc-ciOKUB Blmka"
+                          class="sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi sc-ciOKUB iexkTS"
                         >
                           <div>
                             <p
@@ -5540,7 +5540,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                           id="root_tags__description"
                         >
                           <div
-                            class="sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi sc-ciOKUB Blmka"
+                            class="sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi sc-ciOKUB iexkTS"
                           >
                             <div>
                               <p

--- a/src/components/Renderer/__snapshots__/spec.tsx.snap
+++ b/src/components/Renderer/__snapshots__/spec.tsx.snap
@@ -1759,7 +1759,12 @@ exports[`Renderer component A markdown field 1`] = `
 }
 
 .c5 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c5 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c5 pre {

--- a/src/extra/Markdown/__snapshots__/Markdown.stories.storyshot
+++ b/src/extra/Markdown/__snapshots__/Markdown.stories.storyshot
@@ -76,7 +76,7 @@ exports[`Storyshots Extra/Markdown Customized 1`] = `
                         class="sc-gKAaRy iZvmHx sc-iCoGMd fNpRDf"
                       >
                         <div
-                          class="sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi sc-ciOKUB Blmka"
+                          class="sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi sc-ciOKUB iexkTS"
                         >
                           <div>
                             <h1
@@ -113,7 +113,7 @@ exports[`Storyshots Extra/Markdown Customized 1`] = `
                         class="sc-gKAaRy iZvmHx sc-iCoGMd fNpRDf"
                       >
                         <div
-                          class="sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi sc-ciOKUB Blmka"
+                          class="sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi sc-ciOKUB iexkTS"
                         >
                           <div>
                             A title
@@ -167,7 +167,7 @@ exports[`Storyshots Extra/Markdown Customized 1`] = `
                         class="sc-gKAaRy iZvmHx sc-iCoGMd fNpRDf"
                       >
                         <div
-                          class="sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi sc-ciOKUB Blmka"
+                          class="sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi sc-ciOKUB iexkTS"
                         >
                           <div>
                             <h1
@@ -204,7 +204,7 @@ exports[`Storyshots Extra/Markdown Customized 1`] = `
                         class="sc-gKAaRy iZvmHx sc-iCoGMd fNpRDf"
                       >
                         <div
-                          class="sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi sc-ciOKUB Blmka"
+                          class="sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi sc-ciOKUB iexkTS"
                         >
                           <div>
                             A title
@@ -252,7 +252,7 @@ exports[`Storyshots Extra/Markdown Customized 1`] = `
                         class="sc-gKAaRy iZvmHx sc-iCoGMd fNpRDf"
                       >
                         <div
-                          class="sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi sc-ciOKUB Blmka"
+                          class="sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi sc-ciOKUB iexkTS"
                         >
                           <div>
                             <h1
@@ -289,7 +289,7 @@ exports[`Storyshots Extra/Markdown Customized 1`] = `
                         class="sc-gKAaRy iZvmHx sc-iCoGMd fNpRDf"
                       >
                         <div
-                          class="sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi sc-ciOKUB Blmka"
+                          class="sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi sc-ciOKUB iexkTS"
                         >
                           <div>
                             <h1
@@ -320,7 +320,7 @@ exports[`Storyshots Extra/Markdown Default 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 jXAVEG sc-eEVmNe jhNcBG"
   >
     <div
-      class="sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi sc-ciOKUB Blmka"
+      class="sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi sc-ciOKUB iexkTS"
     >
       <div>
         <h1
@@ -936,7 +936,7 @@ exports[`Storyshots Extra/Markdown With Decorators 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 jXAVEG sc-eEVmNe jhNcBG"
   >
     <div
-      class="sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi sc-ciOKUB Blmka"
+      class="sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi sc-ciOKUB iexkTS"
     >
       <div>
         <p

--- a/src/extra/Markdown/__snapshots__/spec.tsx.snap
+++ b/src/extra/Markdown/__snapshots__/spec.tsx.snap
@@ -162,7 +162,12 @@ exports[`Markdown component Custom sanitizer options: allowedAttributes can be o
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -456,7 +461,12 @@ exports[`Markdown component Custom sanitizer options: allowedTags can be overrid
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -771,7 +781,12 @@ exports[`Markdown component should decorate the text matching the condition 1`] 
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -1101,7 +1116,12 @@ exports[`Markdown component should drop the content of style elements tag 1`] = 
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -1392,7 +1412,12 @@ exports[`Markdown component should drop the content of textarea elements tag 1`]
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -1696,7 +1721,12 @@ exports[`Markdown component should not highlight code when disabled 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -2024,7 +2054,12 @@ exports[`Markdown component should not render raw html when disabled 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -2363,7 +2398,12 @@ exports[`Markdown component should not sanitize html when disabled 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -2656,7 +2696,12 @@ exports[`Markdown component should render html images 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -2966,7 +3011,12 @@ exports[`Markdown component should render html links 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -3284,7 +3334,12 @@ exports[`Markdown component should render link type strings as links 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -3585,7 +3640,12 @@ exports[`Markdown component should render markdown blockquotes 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -3886,7 +3946,12 @@ exports[`Markdown component should render markdown bold using ** 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -4183,7 +4248,12 @@ exports[`Markdown component should render markdown bold using __ 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -4480,7 +4550,12 @@ exports[`Markdown component should render markdown code blocks 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -4778,7 +4853,12 @@ exports[`Markdown component should render markdown code blocks with language spe
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -5147,7 +5227,12 @@ exports[`Markdown component should render markdown h1 headers 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -5451,7 +5536,12 @@ exports[`Markdown component should render markdown h2 headers 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -5755,7 +5845,12 @@ exports[`Markdown component should render markdown h3 headers 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -6060,7 +6155,12 @@ exports[`Markdown component should render markdown h4 headers 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -6365,7 +6465,12 @@ exports[`Markdown component should render markdown h4 headers 2`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -6670,7 +6775,12 @@ exports[`Markdown component should render markdown h5 headers 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -6975,7 +7085,12 @@ exports[`Markdown component should render markdown h5 headers 2`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -7270,7 +7385,12 @@ exports[`Markdown component should render markdown images 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -7568,7 +7688,12 @@ exports[`Markdown component should render markdown inline code 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -7865,7 +7990,12 @@ exports[`Markdown component should render markdown italics using * 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -8162,7 +8292,12 @@ exports[`Markdown component should render markdown italics using _ 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -8476,7 +8611,12 @@ exports[`Markdown component should render markdown links 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -8777,7 +8917,12 @@ exports[`Markdown component should render markdown ordered lists 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -9091,7 +9236,12 @@ exports[`Markdown component should render markdown strikethroughs 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -9388,7 +9538,12 @@ exports[`Markdown component should render markdown tables 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -9726,7 +9881,12 @@ exports[`Markdown component should render markdown task lists 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -10057,7 +10217,12 @@ exports[`Markdown component should render markdown unordered lists 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -10378,7 +10543,12 @@ exports[`Markdown component xss: 1 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -10667,7 +10837,12 @@ exports[`Markdown component xss: 2 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -10962,7 +11137,12 @@ exports[`Markdown component xss: 3 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -11255,7 +11435,12 @@ exports[`Markdown component xss: 4 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -11548,7 +11733,12 @@ exports[`Markdown component xss: 5 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -11843,7 +12033,12 @@ exports[`Markdown component xss: 6 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -12138,7 +12333,12 @@ exports[`Markdown component xss: 7 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -12433,7 +12633,12 @@ exports[`Markdown component xss: 8 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -12729,7 +12934,12 @@ exports[`Markdown component xss: 9 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -13022,7 +13232,12 @@ exports[`Markdown component xss: 10 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -13317,7 +13532,12 @@ exports[`Markdown component xss: 11 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -13612,7 +13832,12 @@ exports[`Markdown component xss: 12 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -13907,7 +14132,12 @@ exports[`Markdown component xss: 13 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -14202,7 +14432,12 @@ exports[`Markdown component xss: 14 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -14497,7 +14732,12 @@ exports[`Markdown component xss: 15 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -14793,7 +15033,12 @@ exports[`Markdown component xss: 16 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -15088,7 +15333,12 @@ exports[`Markdown component xss: 17 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -15383,7 +15633,12 @@ exports[`Markdown component xss: 18 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -15678,7 +15933,12 @@ exports[`Markdown component xss: 19 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -15973,7 +16233,12 @@ exports[`Markdown component xss: 20 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -16268,7 +16533,12 @@ exports[`Markdown component xss: 21 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -16563,7 +16833,12 @@ exports[`Markdown component xss: 22 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -16858,7 +17133,12 @@ exports[`Markdown component xss: 23 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -17153,7 +17433,12 @@ exports[`Markdown component xss: 24 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -17447,7 +17732,12 @@ exports[`Markdown component xss: 25 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -17742,7 +18032,12 @@ exports[`Markdown component xss: 26 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -18037,7 +18332,12 @@ exports[`Markdown component xss: 27 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -18332,7 +18632,12 @@ exports[`Markdown component xss: 28 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -18627,7 +18932,12 @@ exports[`Markdown component xss: 29 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -18922,7 +19232,12 @@ exports[`Markdown component xss: 30 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -19217,7 +19532,12 @@ exports[`Markdown component xss: 31 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -19512,7 +19832,12 @@ exports[`Markdown component xss: 32 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -19807,7 +20132,12 @@ exports[`Markdown component xss: 33 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -20102,7 +20432,12 @@ exports[`Markdown component xss: 34 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -20397,7 +20732,12 @@ exports[`Markdown component xss: 35 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -20692,7 +21032,12 @@ exports[`Markdown component xss: 36 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -20993,7 +21338,12 @@ exports[`Markdown component xss: 37 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -21294,7 +21644,12 @@ exports[`Markdown component xss: 38 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -21595,7 +21950,12 @@ exports[`Markdown component xss: 39 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -21896,7 +22256,12 @@ exports[`Markdown component xss: 40 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -22197,7 +22562,12 @@ exports[`Markdown component xss: 41 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -22498,7 +22868,12 @@ exports[`Markdown component xss: 42 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -22799,7 +23174,12 @@ exports[`Markdown component xss: 43 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -23100,7 +23480,12 @@ exports[`Markdown component xss: 44 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -23401,7 +23786,12 @@ exports[`Markdown component xss: 45 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -23702,7 +24092,12 @@ exports[`Markdown component xss: 46 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -24003,7 +24398,12 @@ exports[`Markdown component xss: 47 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -24304,7 +24704,12 @@ exports[`Markdown component xss: 48 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -24605,7 +25010,12 @@ exports[`Markdown component xss: 49 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -24906,7 +25316,12 @@ exports[`Markdown component xss: 50 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -25207,7 +25622,12 @@ exports[`Markdown component xss: 51 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -25508,7 +25928,12 @@ exports[`Markdown component xss: 52 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -25809,7 +26234,12 @@ exports[`Markdown component xss: 53 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -26110,7 +26540,12 @@ exports[`Markdown component xss: 54 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -26411,7 +26846,12 @@ exports[`Markdown component xss: 55 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -26712,7 +27152,12 @@ exports[`Markdown component xss: 56 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -27013,7 +27458,12 @@ exports[`Markdown component xss: 57 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -27314,7 +27764,12 @@ exports[`Markdown component xss: 58 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -27615,7 +28070,12 @@ exports[`Markdown component xss: 59 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -27916,7 +28376,12 @@ exports[`Markdown component xss: 60 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -28217,7 +28682,12 @@ exports[`Markdown component xss: 61 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -28518,7 +28988,12 @@ exports[`Markdown component xss: 62 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -28836,7 +29311,12 @@ exports[`Markdown component xss: 63 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -29154,7 +29634,12 @@ exports[`Markdown component xss: 64 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -29472,7 +29957,12 @@ exports[`Markdown component xss: 65 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -29790,7 +30280,12 @@ exports[`Markdown component xss: 66 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -30108,7 +30603,12 @@ exports[`Markdown component xss: 67 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -30426,7 +30926,12 @@ exports[`Markdown component xss: 68 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -30744,7 +31249,12 @@ exports[`Markdown component xss: 69 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -31062,7 +31572,12 @@ exports[`Markdown component xss: 70 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -31380,7 +31895,12 @@ exports[`Markdown component xss: 71 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -31698,7 +32218,12 @@ exports[`Markdown component xss: 72 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -32016,7 +32541,12 @@ exports[`Markdown component xss: 73 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -32334,7 +32864,12 @@ exports[`Markdown component xss: 74 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -32652,7 +33187,12 @@ exports[`Markdown component xss: 75 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -32970,7 +33510,12 @@ exports[`Markdown component xss: 76 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -33288,7 +33833,12 @@ exports[`Markdown component xss: 77 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -33606,7 +34156,12 @@ exports[`Markdown component xss: 78 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -33924,7 +34479,12 @@ exports[`Markdown component xss: 79 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -34242,7 +34802,12 @@ exports[`Markdown component xss: 80 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -34560,7 +35125,12 @@ exports[`Markdown component xss: 81 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -34878,7 +35448,12 @@ exports[`Markdown component xss: 82 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -35196,7 +35771,12 @@ exports[`Markdown component xss: 83 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -35514,7 +36094,12 @@ exports[`Markdown component xss: 84 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -35832,7 +36417,12 @@ exports[`Markdown component xss: 85 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -36150,7 +36740,12 @@ exports[`Markdown component xss: 86 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -36468,7 +37063,12 @@ exports[`Markdown component xss: 87 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -36786,7 +37386,12 @@ exports[`Markdown component xss: 88 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -37104,7 +37709,12 @@ exports[`Markdown component xss: 89 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -37422,7 +38032,12 @@ exports[`Markdown component xss: 90 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -37740,7 +38355,12 @@ exports[`Markdown component xss: 91 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -38058,7 +38678,12 @@ exports[`Markdown component xss: 92 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -38376,7 +39001,12 @@ exports[`Markdown component xss: 93 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -38694,7 +39324,12 @@ exports[`Markdown component xss: 94 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -39012,7 +39647,12 @@ exports[`Markdown component xss: 95 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -39330,7 +39970,12 @@ exports[`Markdown component xss: 96 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -39648,7 +40293,12 @@ exports[`Markdown component xss: 97 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -39966,7 +40616,12 @@ exports[`Markdown component xss: 98 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -40284,7 +40939,12 @@ exports[`Markdown component xss: 99 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -40602,7 +41262,12 @@ exports[`Markdown component xss: 100 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -40920,7 +41585,12 @@ exports[`Markdown component xss: 101 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -41238,7 +41908,12 @@ exports[`Markdown component xss: 102 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -41556,7 +42231,12 @@ exports[`Markdown component xss: 103 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -41874,7 +42554,12 @@ exports[`Markdown component xss: 104 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -42192,7 +42877,12 @@ exports[`Markdown component xss: 105 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -42510,7 +43200,12 @@ exports[`Markdown component xss: 106 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -42828,7 +43523,12 @@ exports[`Markdown component xss: 107 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -43146,7 +43846,12 @@ exports[`Markdown component xss: 108 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -43464,7 +44169,12 @@ exports[`Markdown component xss: 109 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -43782,7 +44492,12 @@ exports[`Markdown component xss: 110 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -44100,7 +44815,12 @@ exports[`Markdown component xss: 111 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -44418,7 +45138,12 @@ exports[`Markdown component xss: 112 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -44736,7 +45461,12 @@ exports[`Markdown component xss: 113 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -45054,7 +45784,12 @@ exports[`Markdown component xss: 114 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -45372,7 +46107,12 @@ exports[`Markdown component xss: 115 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -45690,7 +46430,12 @@ exports[`Markdown component xss: 116 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -46008,7 +46753,12 @@ exports[`Markdown component xss: 117 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -46326,7 +47076,12 @@ exports[`Markdown component xss: 118 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -46644,7 +47399,12 @@ exports[`Markdown component xss: 119 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -46945,7 +47705,12 @@ exports[`Markdown component xss: 120 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -47240,7 +48005,12 @@ exports[`Markdown component xss: 121 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -47535,7 +48305,12 @@ exports[`Markdown component xss: 122 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -47830,7 +48605,12 @@ exports[`Markdown component xss: 123 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -48125,7 +48905,12 @@ exports[`Markdown component xss: 124 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -48420,7 +49205,12 @@ exports[`Markdown component xss: 125 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -48715,7 +49505,12 @@ exports[`Markdown component xss: 126 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -49010,7 +49805,12 @@ exports[`Markdown component xss: 127 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -49305,7 +50105,12 @@ exports[`Markdown component xss: 128 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -49600,7 +50405,12 @@ exports[`Markdown component xss: 129 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -49895,7 +50705,12 @@ exports[`Markdown component xss: 130 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -50190,7 +51005,12 @@ exports[`Markdown component xss: 131 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -50485,7 +51305,12 @@ exports[`Markdown component xss: 132 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -50780,7 +51605,12 @@ exports[`Markdown component xss: 133 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -51075,7 +51905,12 @@ exports[`Markdown component xss: 134 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -51370,7 +52205,12 @@ exports[`Markdown component xss: 135 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -51665,7 +52505,12 @@ exports[`Markdown component xss: 136 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -51960,7 +52805,12 @@ exports[`Markdown component xss: 137 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -52255,7 +53105,12 @@ exports[`Markdown component xss: 138 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -52550,7 +53405,12 @@ exports[`Markdown component xss: 139 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -52845,7 +53705,12 @@ exports[`Markdown component xss: 140 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -53140,7 +54005,12 @@ exports[`Markdown component xss: 141 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -53435,7 +54305,12 @@ exports[`Markdown component xss: 142 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -53730,7 +54605,12 @@ exports[`Markdown component xss: 143 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -54025,7 +54905,12 @@ exports[`Markdown component xss: 144 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -54320,7 +55205,12 @@ exports[`Markdown component xss: 145 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -54615,7 +55505,12 @@ exports[`Markdown component xss: 146 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -54910,7 +55805,12 @@ exports[`Markdown component xss: 147 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -55205,7 +56105,12 @@ exports[`Markdown component xss: 148 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -55500,7 +56405,12 @@ exports[`Markdown component xss: 149 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -55795,7 +56705,12 @@ exports[`Markdown component xss: 150 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -56090,7 +57005,12 @@ exports[`Markdown component xss: 151 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -56385,7 +57305,12 @@ exports[`Markdown component xss: 152 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -56680,7 +57605,12 @@ exports[`Markdown component xss: 153 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -56975,7 +57905,12 @@ exports[`Markdown component xss: 154 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -57270,7 +58205,12 @@ exports[`Markdown component xss: 155 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -57565,7 +58505,12 @@ exports[`Markdown component xss: 156 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -57860,7 +58805,12 @@ exports[`Markdown component xss: 157 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -58155,7 +59105,12 @@ exports[`Markdown component xss: 158 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -58450,7 +59405,12 @@ exports[`Markdown component xss: 159 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -58745,7 +59705,12 @@ exports[`Markdown component xss: 160 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -59040,7 +60005,12 @@ exports[`Markdown component xss: 161 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -59335,7 +60305,12 @@ exports[`Markdown component xss: 162 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -59630,7 +60605,12 @@ exports[`Markdown component xss: 163 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -59925,7 +60905,12 @@ exports[`Markdown component xss: 164 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -60220,7 +61205,12 @@ exports[`Markdown component xss: 165 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -60515,7 +61505,12 @@ exports[`Markdown component xss: 166 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -60810,7 +61805,12 @@ exports[`Markdown component xss: 167 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -61105,7 +62105,12 @@ exports[`Markdown component xss: 168 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -61400,7 +62405,12 @@ exports[`Markdown component xss: 169 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -61695,7 +62705,12 @@ exports[`Markdown component xss: 170 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -61990,7 +63005,12 @@ exports[`Markdown component xss: 171 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -62285,7 +63305,12 @@ exports[`Markdown component xss: 172 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -62580,7 +63605,12 @@ exports[`Markdown component xss: 173 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -62875,7 +63905,12 @@ exports[`Markdown component xss: 174 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -63170,7 +64205,12 @@ exports[`Markdown component xss: 175 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -63465,7 +64505,12 @@ exports[`Markdown component xss: 176 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -63760,7 +64805,12 @@ exports[`Markdown component xss: 177 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -64055,7 +65105,12 @@ exports[`Markdown component xss: 178 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -64350,7 +65405,12 @@ exports[`Markdown component xss: 179 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -64645,7 +65705,12 @@ exports[`Markdown component xss: 180 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -64940,7 +66005,12 @@ exports[`Markdown component xss: 181 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -65235,7 +66305,12 @@ exports[`Markdown component xss: 182 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -65530,7 +66605,12 @@ exports[`Markdown component xss: 183 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -65825,7 +66905,12 @@ exports[`Markdown component xss: 184 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -66120,7 +67205,12 @@ exports[`Markdown component xss: 185 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -66415,7 +67505,12 @@ exports[`Markdown component xss: 186 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -66710,7 +67805,12 @@ exports[`Markdown component xss: 187 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -67005,7 +68105,12 @@ exports[`Markdown component xss: 188 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -67300,7 +68405,12 @@ exports[`Markdown component xss: 189 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -67595,7 +68705,12 @@ exports[`Markdown component xss: 190 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -67890,7 +69005,12 @@ exports[`Markdown component xss: 191 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -68185,7 +69305,12 @@ exports[`Markdown component xss: 192 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -68480,7 +69605,12 @@ exports[`Markdown component xss: 193 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -68775,7 +69905,12 @@ exports[`Markdown component xss: 194 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -69070,7 +70205,12 @@ exports[`Markdown component xss: 195 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -69365,7 +70505,12 @@ exports[`Markdown component xss: 196 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -69660,7 +70805,12 @@ exports[`Markdown component xss: 197 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -69955,7 +71105,12 @@ exports[`Markdown component xss: 198 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -70250,7 +71405,12 @@ exports[`Markdown component xss: 199 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -70545,7 +71705,12 @@ exports[`Markdown component xss: 200 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -70857,7 +72022,12 @@ exports[`Markdown component xss: 201 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -71157,7 +72327,12 @@ exports[`Markdown component xss: 202 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -71460,7 +72635,12 @@ exports[`Markdown component xss: 203 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -71755,7 +72935,12 @@ exports[`Markdown component xss: 204 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -72061,7 +73246,12 @@ exports[`Markdown component xss: 205 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -72366,7 +73556,12 @@ exports[`Markdown component xss: 206 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -72655,7 +73850,12 @@ exports[`Markdown component xss: 207 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -72944,7 +74144,12 @@ exports[`Markdown component xss: 208 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -73233,7 +74438,12 @@ exports[`Markdown component xss: 209 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -73522,7 +74732,12 @@ exports[`Markdown component xss: 210 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -73818,7 +75033,12 @@ exports[`Markdown component xss: 211 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -74109,7 +75329,12 @@ exports[`Markdown component xss: 212 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -74402,7 +75627,12 @@ exports[`Markdown component xss: 213 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -74697,7 +75927,12 @@ exports[`Markdown component xss: 214 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -74988,7 +76223,12 @@ exports[`Markdown component xss: 215 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -75279,7 +76519,12 @@ exports[`Markdown component xss: 216 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -75570,7 +76815,12 @@ exports[`Markdown component xss: 217 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -75861,7 +77111,12 @@ exports[`Markdown component xss: 218 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -76152,7 +77407,12 @@ exports[`Markdown component xss: 219 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -76443,7 +77703,12 @@ exports[`Markdown component xss: 220 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -76734,7 +77999,12 @@ exports[`Markdown component xss: 221 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -77025,7 +78295,12 @@ exports[`Markdown component xss: 222 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -77320,7 +78595,12 @@ exports[`Markdown component xss: 223 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -77628,7 +78908,12 @@ exports[`Markdown component xss: 224 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -77930,7 +79215,12 @@ exports[`Markdown component xss: 225 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -78236,7 +79526,12 @@ exports[`Markdown component xss: 226 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -78536,7 +79831,12 @@ exports[`Markdown component xss: 227 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -78831,7 +80131,12 @@ exports[`Markdown component xss: 228 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -79120,7 +80425,12 @@ exports[`Markdown component xss: 229 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -79409,7 +80719,12 @@ exports[`Markdown component xss: 230 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -79704,7 +81019,12 @@ exports[`Markdown component xss: 231 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -79993,7 +81313,12 @@ exports[`Markdown component xss: 232 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -80288,7 +81613,12 @@ exports[`Markdown component xss: 233 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -80583,7 +81913,12 @@ exports[`Markdown component xss: 234 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -80880,7 +82215,12 @@ exports[`Markdown component xss: 235 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -81169,7 +82509,12 @@ exports[`Markdown component xss: 236 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {
@@ -81464,7 +82809,12 @@ exports[`Markdown component xss: 237 1`] = `
 }
 
 .c2 p {
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.c2 p:last-child {
+  margin-bottom: 0 !important;
 }
 
 .c2 pre {

--- a/src/extra/Markdown/index.tsx
+++ b/src/extra/Markdown/index.tsx
@@ -11,6 +11,7 @@ import sanitize from 'rehype-sanitize';
 import raw from 'rehype-raw';
 import prism from '@mapbox/rehype-prism';
 import { Divider } from '../../components/Divider';
+import { px } from 'styled-system';
 import styled, { withTheme } from 'styled-components';
 import gh from 'hast-util-sanitize/lib/github.json';
 import { Theme } from '../../common-types';
@@ -35,7 +36,11 @@ const MarkdownWrapper = styled(Txt)`
 	}
 
 	& p {
-		margin: 0;
+		margin-top: 0;
+		margin-bottom: ${(props) => px(props.theme.space[2])};
+		&:last-child {
+			margin-bottom: 0 !important;
+		}
 	}
 
 	& pre {


### PR DESCRIPTION
Paragraphs should have a bottom margin set - except for the last paragraph.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

---

##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
