### PR TITLE
download-image-modal: allow modal to accept releaseId

### DIFF
--- a/src/unstable-temp/DownloadImageModal/DownloadImageModal.tsx
+++ b/src/unstable-temp/DownloadImageModal/DownloadImageModal.tsx
@@ -68,6 +68,7 @@ const getUniqueOsTypes = (
 
 export interface DownloadOptions {
 	applicationId: number;
+	releaseId?: number;
 	deviceType: string;
 	appUpdatePollInterval?: number;
 	downloadConfigOnly?: boolean;
@@ -77,6 +78,7 @@ export interface DownloadOptions {
 
 export interface UnstableTempDownloadImageModalProps {
 	application: Application;
+	releaseId?: number;
 	compatibleDeviceTypes: DeviceType[] | null;
 	initialDeviceType?: DeviceType;
 	initialOsVersions?: OsVersionsByDeviceType;
@@ -109,6 +111,7 @@ export interface UnstableTempDownloadImageModalProps {
 export const UnstableTempDownloadImageModal = ({
 	downloadUrl,
 	application,
+	releaseId,
 	compatibleDeviceTypes,
 	initialDeviceType,
 	initialOsVersions,
@@ -269,6 +272,7 @@ export const UnstableTempDownloadImageModal = ({
 										setIsDownloadingConfig={setIsDownloadingConfig}
 										deviceType={deviceType}
 										appId={application.id}
+										releaseId={releaseId}
 										downloadUrl={downloadUrl}
 										rawVersion={rawVersion}
 										authToken={authToken}

--- a/src/unstable-temp/DownloadImageModal/ImageForm.tsx
+++ b/src/unstable-temp/DownloadImageModal/ImageForm.tsx
@@ -64,6 +64,7 @@ const isDownloadDisabled = (
 interface ImageFormProps {
 	downloadUrl: string;
 	appId: number;
+	releaseId?: number;
 	rawVersion: string | null;
 	deviceType: DeviceType;
 	authToken?: string;
@@ -80,6 +81,7 @@ interface ImageFormProps {
 export const ImageForm = ({
 	downloadUrl,
 	appId,
+	releaseId,
 	rawVersion,
 	deviceType,
 	authToken,
@@ -101,6 +103,7 @@ export const ImageForm = ({
 	const setDownloadConfigOnly = (downloadConfigOnly: boolean) => {
 		const downloadOptions = {
 			applicationId: appId,
+			releaseId,
 			deviceType: deviceType.slug,
 			appUpdatePollInterval: model.appUpdatePollInterval,
 			downloadConfigOnly,
@@ -149,6 +152,7 @@ export const ImageForm = ({
 			style={{ display: 'flex', flexDirection: 'column', height: '100%' }}
 		>
 			<input type="hidden" name="appId" value={appId} />
+			{releaseId && <input type="hidden" name="releaseId" value={releaseId} />}
 			<input type="hidden" name="_token" value={authToken} />
 			<input name="version" value={rawVersion ?? ''} type="hidden" />
 			<input name="deviceType" value={deviceType?.slug} type="hidden" />


### PR DESCRIPTION
Allow download modal to take in a `releaseId`. This allows the modal to get preloaded images from S3.

Change-type: minor
Signed-off-by: Tomás Migone <tomas@balena.io>