### PR TITLE
Fix qs parse on loadRulesFromUrl

### DIFF
--- a/src/extra/AutoUi/Collection/PersistentFilters.tsx
+++ b/src/extra/AutoUi/Collection/PersistentFilters.tsx
@@ -53,6 +53,7 @@ const listFilterQuery = (schema: JSONSchema, rules: JSONSchema[]) => {
 			flatSchema,
 			flattenFilter,
 		) as FilterSignature[];
+		console.log(flatSchema, flattenFilter, signatures);
 		return signatures.map<ListQueryStringFilterObject>(
 			({ field, operator, value }) => ({
 				n: field,
@@ -71,7 +72,7 @@ const loadRulesFromUrl = (
 	if (!searchLocation) {
 		return [];
 	}
-	const parsed = qs.parse(searchLocation.replace(/^\?/, '')) || {};
+	const parsed = qs.parse(searchLocation) || {};
 	const rules = filter(parsed, isQueryStringFilterRuleset).map(
 		// @ts-expect-error
 		(rules: ListQueryStringFilterObject[]) => {
@@ -89,8 +90,10 @@ const loadRulesFromUrl = (
 			// TODO: fix in rendition => this should be handled by Rendition, calling the
 			// createFilter function handle the case.
 			if (signatures[0].operator === FULL_TEXT_SLUG) {
+				console.log('createFullTextSearchFilter', signatures);
 				return createFullTextSearchFilter(schema, signatures[0].value);
 			}
+			console.log('create', signatures);
 			return createFilter(schema, signatures);
 		},
 	);
@@ -124,7 +127,7 @@ export const PersistentFilters = ({
 		return !!urlRules?.length
 			? urlRules
 			: getFromLocalStorage<JSONSchema[]>(filtersRestorationKey) ?? [];
-	}, [history?.location?.search, schema, filtersRestorationKey]);
+	}, [schema, filtersRestorationKey]);
 
 	React.useEffect(() => {
 		updateUrl(storedFilters);
@@ -141,7 +144,7 @@ export const PersistentFilters = ({
 
 	const updateUrl = (filters: JSONSchema[]) => {
 		const { pathname } = window.location;
-
+		console.log(schema, filters);
 		history?.replace?.({
 			pathname,
 			search: listFilterQuery(schema, filters),


### PR DESCRIPTION
Fix qs parse on loadRulesFromUrl

See: https://www.flowdock.com/app/rulemotion/resin-frontend/threads/EEoA4xg5GNkg4cHe9b1qx7tlGyN
Change-type: patch
Signed-off-by: Andrea Rosci <andrear@balena.io>

qs does not need the replace anymore (see: https://github.com/ljharb/qs/pull/213) this was causing an infinite loop since this was changing everytime the url.

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
