### PR TITLE
Remove console logs and fix missing dependency

### DIFF
--- a/src/extra/AutoUi/Collection/PersistentFilters.tsx
+++ b/src/extra/AutoUi/Collection/PersistentFilters.tsx
@@ -53,7 +53,6 @@ const listFilterQuery = (schema: JSONSchema, rules: JSONSchema[]) => {
 			flatSchema,
 			flattenFilter,
 		) as FilterSignature[];
-		console.log(flatSchema, flattenFilter, signatures);
 		return signatures.map<ListQueryStringFilterObject>(
 			({ field, operator, value }) => ({
 				n: field,
@@ -90,10 +89,8 @@ const loadRulesFromUrl = (
 			// TODO: fix in rendition => this should be handled by Rendition, calling the
 			// createFilter function handle the case.
 			if (signatures[0].operator === FULL_TEXT_SLUG) {
-				console.log('createFullTextSearchFilter', signatures);
 				return createFullTextSearchFilter(schema, signatures[0].value);
 			}
-			console.log('create', signatures);
 			return createFilter(schema, signatures);
 		},
 	);
@@ -127,7 +124,7 @@ export const PersistentFilters = ({
 		return !!urlRules?.length
 			? urlRules
 			: getFromLocalStorage<JSONSchema[]>(filtersRestorationKey) ?? [];
-	}, [schema, filtersRestorationKey]);
+	}, [history?.location?.search, schema, filtersRestorationKey]);
 
 	React.useEffect(() => {
 		updateUrl(storedFilters);
@@ -144,7 +141,6 @@ export const PersistentFilters = ({
 
 	const updateUrl = (filters: JSONSchema[]) => {
 		const { pathname } = window.location;
-		console.log(schema, filters);
 		history?.replace?.({
 			pathname,
 			search: listFilterQuery(schema, filters),


### PR DESCRIPTION
Remove console logs and fix missing dependency

See: https://github.com/balena-io-modules/rendition/pull/1313/files
Change-type: patch
Signed-off-by: Andrea Rosci <andrear@balena.io>

Remove console logs and add back a dependency for the filters. This was a mistake made on  https://github.com/balena-io-modules/rendition/pull/1313/files

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
