### PR TITLE
Add additionl custom download image modal actions

### DIFF
--- a/src/unstable-temp/DownloadImageModal/DownloadImageModal.tsx
+++ b/src/unstable-temp/DownloadImageModal/DownloadImageModal.tsx
@@ -18,7 +18,7 @@ import { Dictionary } from '../../common-types';
 import { Box } from '../../components/Box';
 import { Flex } from '../../components/Flex';
 import { Txt } from '../../components/Txt';
-import { Button } from '../../components/Button';
+import { Button, ButtonProps } from '../../components/Button';
 import { Spinner } from '../../components/Spinner';
 import { Alert } from '../../components/Alert';
 import { Modal } from '../../components/Modal';
@@ -67,7 +67,7 @@ const getUniqueOsTypes = (
 };
 
 export interface DownloadOptions {
-	applicationId: number;
+	appId: number;
 	releaseId?: number;
 	deviceType: string;
 	appUpdatePollInterval?: number;
@@ -105,6 +105,7 @@ export interface UnstableTempDownloadImageModalProps {
 	getDockerArtifact: (deviceTypeSlug: string, rawVersion: string) => string;
 	hasEsrVersions?: (deviceTypeSlugs: string[]) => Promise<Dictionary<boolean>>;
 	onClose: () => void;
+	modalActions?: Array<Omit<ButtonProps, 'onClick'> & { onClick: (event: React.MouseEvent, model: DownloadOptions) => void }>
 	authToken?: string;
 }
 
@@ -124,6 +125,7 @@ export const UnstableTempDownloadImageModal = ({
 	downloadConfig,
 	getDownloadSize,
 	onClose,
+	modalActions,
 	authToken,
 }: UnstableTempDownloadImageModalProps) => {
 	const { t } = useTranslation();
@@ -275,6 +277,7 @@ export const UnstableTempDownloadImageModal = ({
 										releaseId={releaseId}
 										downloadUrl={downloadUrl}
 										rawVersion={rawVersion}
+										modalActions={modalActions}
 										authToken={authToken}
 										{...(downloadConfig && {
 											downloadConfig: (model) =>


### PR DESCRIPTION
Add additionl custom download image modal actions

Change-type: minor
Signed-off-by: Andrea Rosci <andrear@balena.io>

Add a way to add custom actions on download image modal 

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
