### PR TITLE
FilterModal: Fields drop-down is searchable

### DIFF
--- a/src/components/Filters/FilterModal.spec.tsx
+++ b/src/components/Filters/FilterModal.spec.tsx
@@ -1,0 +1,68 @@
+import { mount } from 'enzyme';
+import sinon from 'sinon';
+import React from 'react';
+import { JSONSchema7 as JSONSchema } from 'json-schema';
+import { Provider } from '../..';
+import { FilterModal } from './FilterModal';
+
+const sandbox = sinon.createSandbox();
+
+describe('FilterModal', () => {
+	it('lets the user search for filter fields', () => {
+		const addFilter = sandbox.stub();
+		const onClose = sandbox.stub();
+		const edit = [
+			{
+				field: 'name',
+				operator: 'is',
+				value: '',
+			},
+		];
+		// A schema with two properties that will be filter targets
+		const schema: JSONSchema = {
+			type: 'object',
+			properties: {
+				name: {
+					type: 'string',
+				},
+				type: {
+					type: 'string',
+				},
+			},
+		};
+
+		const component = mount(
+			<Provider>
+				<FilterModal
+					schema={schema}
+					addFilter={addFilter}
+					edit={edit}
+					onClose={onClose}
+				/>
+			</Provider>,
+		);
+
+		// Open the filter select
+		const fieldSelect = component.find('Select').first();
+		fieldSelect.simulate('click');
+
+		// Both 'name' and 'type' are available options
+		let options = component.find(
+			'#filtermodal__fieldselect__select-drop button[role="menuitem"]',
+		);
+		expect(options.length).toBe(2);
+		expect(options.at(0).text()).toBe('name');
+		expect(options.at(1).text()).toBe('type');
+
+		// Search for 'type'
+		const searchInput = component.find('input[placeholder="Search..."]');
+		searchInput.simulate('change', { target: { value: 'type' } });
+
+		// Now only the 'type' option is available
+		options = component.find(
+			'#filtermodal__fieldselect__select-drop button[role="menuitem"]',
+		);
+		expect(options.length).toBe(1);
+		expect(options.at(0).text()).toBe('type');
+	});
+});

--- a/src/components/Filters/FilterModal.tsx
+++ b/src/components/Filters/FilterModal.tsx
@@ -72,6 +72,7 @@ export const FilterModal = ({
 	edit,
 }: FilterModalProps) => {
 	const [filters, setFilters] = useState(edit);
+	const [searchTerm, setSearchTerm] = useState('');
 
 	const setEditField = (field: string, index: number) => {
 		const currentEdit = filters.map((filter, i) =>
@@ -101,6 +102,27 @@ export const FilterModal = ({
 		);
 		setFilters(currentEdit);
 	};
+
+	const fieldOptions = React.useMemo(() => {
+		return map(schema.properties, (s: JSONSchema, field) => ({
+			field,
+			title: s.title || field,
+		}));
+	}, [schema.properties]);
+
+	const filteredFieldOptions = React.useMemo(() => {
+		if (!searchTerm) {
+			return fieldOptions;
+		}
+		const searchTermRegEx = new RegExp(searchTerm, 'i');
+		return fieldOptions.filter((option) => {
+			return (
+				option.title.match(searchTermRegEx) ||
+				option.field.match(searchTermRegEx)
+			);
+		});
+	}, [searchTerm, fieldOptions]);
+
 	return (
 		<Modal
 			title="Filter by"
@@ -116,10 +138,10 @@ export const FilterModal = ({
 						<Flex>
 							<Box flex={1}>
 								<Select<{ field: string; title: string }>
-									options={map(schema.properties, (s: JSONSchema, field) => ({
-										field,
-										title: s.title || field,
-									}))}
+									id="filtermodal__fieldselect"
+									options={filteredFieldOptions}
+									onSearch={setSearchTerm}
+									searchPlaceholder="Search..."
 									valueKey="field"
 									labelKey="title"
 									// TODO: Remove this logic and pass the primitive value when this is fixed https://github.com/grommet/grommet/issues/3154

--- a/src/components/Filters/FilterModal.tsx
+++ b/src/components/Filters/FilterModal.tsx
@@ -107,7 +107,9 @@ export const FilterModal = ({
 		return map(schema.properties, (s: JSONSchema, field) => ({
 			field,
 			title: s.title || field,
-		}));
+		})).sort((a, b) =>
+			a.title.toLowerCase().localeCompare(b.title.toLowerCase()),
+		);
 	}, [schema.properties]);
 
 	const filteredFieldOptions = React.useMemo(() => {


### PR DESCRIPTION
Add ability to search for field options. This is useful if there are a large number of options. Also if the field name and the title are different and the user is looking for the field name but can't find it because the title is displayed.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

---

Sort filter field options alphabetically

Case insensitive!

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>
***

![Filter field search](https://user-images.githubusercontent.com/2925657/124439295-73f86b00-dda3-11eb-9f28-f1d39084f049.gif)


##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
