### PR TITLE
Download Image Modal Improvements

### DIFF
--- a/src/unstable-temp/DownloadImageModal/DownloadImageModal.tsx
+++ b/src/unstable-temp/DownloadImageModal/DownloadImageModal.tsx
@@ -259,7 +259,7 @@ export const UnstableTempDownloadImageModal = ({
 			done={noop}
 		>
 			<Flex flexDirection={['column', 'column', 'column', 'row']}>
-				<Box flex={1} mr={[0, 0, 0, 3]}>
+				<Box flex={2} mr={[0, 0, 0, 3]}>
 					<Spinner
 						show={isDownloadingConfig}
 						label={t('loading.generating_configuration_file')}

--- a/src/unstable-temp/DownloadImageModal/FormModel.tsx
+++ b/src/unstable-temp/DownloadImageModal/FormModel.tsx
@@ -105,7 +105,7 @@ const FormControl = ({ onModelChange, options, model }: FormControlProps) => {
 								name={options.name}
 								value={model[options.name] as string}
 							/>
-							<Box mr={4} mb={3}>
+							<Box mr={4}>
 								<RadioButtonGroup
 									options={(options.choices as string[]).map((choice) => ({
 										disabled: false,
@@ -217,7 +217,7 @@ interface FormGroupProps extends Omit<FormFieldsProps, 'options'> {
 const FormGroup = ({ onModelChange, model, options }: FormGroupProps) => {
 	return (
 		<>
-			<Divider type="dashed" my={3} />
+			<Divider type="dashed" />
 			<Collapsible
 				collapsible={!!options.isCollapsible}
 				initiallyCollapsed={options.collapsed}

--- a/src/unstable-temp/DownloadImageModal/OsConfiguration.tsx
+++ b/src/unstable-temp/DownloadImageModal/OsConfiguration.tsx
@@ -253,7 +253,7 @@ export const OsConfiguration = ({
 						/>
 					</Box>
 				)}
-				{(!isInitialDefault || !selectedOsType) && (
+				{(!isInitialDefault || !selectedOsType) && hasEsrVersions && (
 					<Box flex={2} ml={2}>
 						<DownloadImageLabel>
 							{t('placeholders.select_os_type_status')}{' '}
@@ -304,11 +304,11 @@ export const OsConfiguration = ({
 			)}
 
 			{hasEditions && (!isInitialDefault || !variant) && (
-				<Box mb={2}>
+				<Box>
 					<DownloadImageLabel>
 						{t('placeholders.select_edition')}
 					</DownloadImageLabel>
-					<Box mr={4} mb={3}>
+					<Box>
 						<VariantSelector
 							t={t}
 							version={version}


### PR DESCRIPTION
Don't show "Select OS Type" if ESR is disabled and trim dead space

Connects to: [#4849](https://github.com/balena-io/balena-ui/issues/4849)
Change-type: patch
Signed-off-by: Matthew Yarmolinsky <matthew-timothy@balena.io>


<img width="1336" alt="Screenshot 2021-07-20 at 17 47 13" src="https://user-images.githubusercontent.com/7238159/126355110-5fd59af4-cdf7-42a7-b2ba-acf0cd711f0f.png">
<img width="1342" alt="Screenshot 2021-07-20 at 17 47 22" src="https://user-images.githubusercontent.com/7238159/126355116-d1ae13a3-728e-4734-b7b1-5408d048705d.png">


---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
