### PR TITLE
Fix DownloadImageModal instructions step 1 typo

### DIFF
--- a/src/hooks/useTranslation.tsx
+++ b/src/hooks/useTranslation.tsx
@@ -65,7 +65,7 @@ const translationMap = {
 
 	'actions.add_new_device': 'Add new device',
 	'actions.use_from_to_configure_and_download':
-		'Use the form on the left above to configure and download balenaOS for your new device.',
+		'Use the form on the left to configure and download balenaOS for your new device.',
 	'actions_messages.appearance_device_explanation':
 		'Your device should appear in your application dashboard within a few minutes. Have fun!',
 	'actions.download_configuration_file': 'Download configuration file',


### PR DESCRIPTION
Fix DownloadImageModal instructions step 1 typo

See: https://docs.google.com/document/d/1H9LUbU_0BFRgIqwsCD992z7sf2GMCaaMpHtqLYiCBq8/edit#heading=h.d3tbsqqamv3q
Change-type: patch
Signed-off-by: Matthew Yarmolinsky <matthew-timothy@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
