### PR TITLE
Bump node engine to v12 to keep up with our dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "README.md"
   ],
   "engines": {
-    "node": ">=10.13.0",
+    "node": ">=12.0.0",
     "npm": ">=5.7.0"
   },
   "scripts": {


### PR DESCRIPTION
Decided to use patch since: rendition is a UI library,
node 10 is already EOL, our dependencies already
require node 12 features which causes the tests on
master to fail.

Change-type: major
See: https://www.flowdock.com/app/rulemotion/f-rendition/threads/Gb8zYhKYx5wG_7CayvFOW_6QvHm
See: https://www.flowdock.com/app/rulemotion/resin-frontend/threads/-49BZqG8lxBArlyipDC939HL4wQ
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>


---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
