### PR TITLE
Filters: Add optional filterFieldCompareFn prop

### DIFF
--- a/src/components/Filters/FilterModal.tsx
+++ b/src/components/Filters/FilterModal.tsx
@@ -14,11 +14,22 @@ import { Select } from '../Select';
 import { Txt } from '../Txt';
 import * as SchemaSieve from './SchemaSieve';
 
+export interface FilterFieldOption {
+	field: string;
+	title: string;
+}
+
+export type FilterFieldCompareFn = (
+	a: FilterFieldOption,
+	b: FilterFieldOption,
+) => number;
+
 export interface FilterModalProps {
 	addFilter: (filters: EditModel[]) => void;
 	onClose: () => void;
 	schema: JSONSchema;
 	edit: EditModel[];
+	fieldCompareFn?: FilterFieldCompareFn;
 }
 
 export interface FilterInputProps {
@@ -33,6 +44,10 @@ export interface EditModel {
 	operator: string;
 	value: string | number | { [k: string]: string };
 }
+
+const defaultFilterCompareFn: FilterFieldCompareFn = (a, b) => {
+	return a.title.toLowerCase().localeCompare(b.title.toLowerCase());
+};
 
 const FilterInput = (props: FilterInputProps) => {
 	const model = getDataModel(props.schema);
@@ -71,6 +86,7 @@ export const FilterModal = ({
 	onClose,
 	schema,
 	edit,
+	fieldCompareFn,
 }: FilterModalProps) => {
 	const [filters, setFilters] = useState(edit);
 	const [searchTerm, setSearchTerm] = useState('');
@@ -106,13 +122,11 @@ export const FilterModal = ({
 		setFilters(currentEdit);
 	};
 
-	const fieldOptions = React.useMemo(() => {
+	const fieldOptions: FilterFieldOption[] = React.useMemo(() => {
 		return map(schema.properties, (s: JSONSchema, field) => ({
 			field,
 			title: s.title || field,
-		})).sort((a, b) =>
-			a.title.toLowerCase().localeCompare(b.title.toLowerCase()),
-		);
+		})).sort(fieldCompareFn || defaultFilterCompareFn);
 	}, [schema.properties]);
 
 	const filteredFieldOptions = React.useMemo(() => {

--- a/src/components/Filters/index.tsx
+++ b/src/components/Filters/index.tsx
@@ -15,7 +15,7 @@ import { Box } from '../Box';
 import { DropDownButtonProps } from '../DropDownButton';
 import { Flex } from '../Flex';
 import { Search } from '../Search';
-import { FilterModal } from './FilterModal';
+import { FilterFieldCompareFn, FilterModal } from './FilterModal';
 import * as SchemaSieve from './SchemaSieve';
 import Summary from './Summary';
 import ViewsMenu from './ViewsMenu';
@@ -336,6 +336,7 @@ class BaseFilters extends React.Component<FiltersProps, FiltersState> {
 							onClose={() => this.setState({ showModal: false })}
 							schema={this.state.schema}
 							edit={this.state.edit}
+							fieldCompareFn={this.props.filterFieldCompareFn}
 						/>
 					)}
 				</Flex>
@@ -452,6 +453,8 @@ export interface FiltersProps extends React.HTMLAttributes<HTMLElement> {
 	dark?: boolean;
 	/** Accept a boolean for each rendition breakpoint. If true remove `Filters` labels */
 	compact?: boolean[];
+	/** An optional callback used to sort filter field options */
+	filterFieldCompareFn?: FilterFieldCompareFn;
 }
 
 /**


### PR DESCRIPTION
This prop can be used to provide a compare function callback to determine the order in which to display filter field options in the filter modal.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

---

Note - in Jellyfish we want to ensure that all fields in _linked contracts_ appear _after_ the fields on the contract itself. This callback function will facilitate this.

##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
