### PR TITLE
feat: Add new ProgressBar Renderer widget

### DIFF
--- a/src/components/DataGrid/__snapshots__/DataGrid.stories.storyshot
+++ b/src/components/DataGrid/__snapshots__/DataGrid.stories.storyshot
@@ -6,10 +6,10 @@ exports[`Storyshots Core/DataGrid Default 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 jXAVEG sc-eEVmNe jhNcBG"
   >
     <div
-      class="sc-xGAEC hvdpjQ"
+      class="sc-EZqKI jWWxzw"
     >
       <div
-        class="sc-dWBRfb AWoBo"
+        class="sc-jXcxbT cQBPyc"
       >
         <div
           class="sc-gKAaRy iZvmHx sc-iCoGMd fbiImu sc-hHEiqL sc-dlMDgC bJSggk kroMsA sc-cTJkRt cTUKZa sc-jNnpgg jXFDMT"
@@ -30,7 +30,7 @@ exports[`Storyshots Core/DataGrid Default 1`] = `
         </div>
       </div>
       <div
-        class="sc-dWBRfb AWoBo"
+        class="sc-jXcxbT cQBPyc"
       >
         <div
           class="sc-gKAaRy iZvmHx sc-iCoGMd fbiImu sc-hHEiqL sc-dlMDgC bJSggk kroMsA sc-cTJkRt cTUKZa sc-jNnpgg jXFDMT"
@@ -51,7 +51,7 @@ exports[`Storyshots Core/DataGrid Default 1`] = `
         </div>
       </div>
       <div
-        class="sc-dWBRfb AWoBo"
+        class="sc-jXcxbT cQBPyc"
       >
         <div
           class="sc-gKAaRy iZvmHx sc-iCoGMd fbiImu sc-hHEiqL sc-dlMDgC bJSggk kroMsA sc-cTJkRt cTUKZa sc-jNnpgg jXFDMT"
@@ -72,7 +72,7 @@ exports[`Storyshots Core/DataGrid Default 1`] = `
         </div>
       </div>
       <div
-        class="sc-dWBRfb AWoBo"
+        class="sc-jXcxbT cQBPyc"
       >
         <div
           class="sc-gKAaRy iZvmHx sc-iCoGMd fbiImu sc-hHEiqL sc-dlMDgC bJSggk kroMsA sc-cTJkRt cTUKZa sc-jNnpgg jXFDMT"
@@ -93,7 +93,7 @@ exports[`Storyshots Core/DataGrid Default 1`] = `
         </div>
       </div>
       <div
-        class="sc-dWBRfb AWoBo"
+        class="sc-jXcxbT cQBPyc"
       >
         <div
           class="sc-gKAaRy iZvmHx sc-iCoGMd fbiImu sc-hHEiqL sc-dlMDgC bJSggk kroMsA sc-cTJkRt cTUKZa sc-jNnpgg jXFDMT"
@@ -114,7 +114,7 @@ exports[`Storyshots Core/DataGrid Default 1`] = `
         </div>
       </div>
       <div
-        class="sc-dWBRfb AWoBo"
+        class="sc-jXcxbT cQBPyc"
       >
         <div
           class="sc-gKAaRy iZvmHx sc-iCoGMd fbiImu sc-hHEiqL sc-dlMDgC bJSggk kroMsA sc-cTJkRt cTUKZa sc-jNnpgg jXFDMT"

--- a/src/components/Form/__snapshots__/Form.stories.storyshot
+++ b/src/components/Form/__snapshots__/Form.stories.storyshot
@@ -12,7 +12,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
         class="sc-gKAaRy bzVAry sc-iCoGMd foQObC"
       >
         <div
-          class="sc-gKAaRy iZvmHx sc-iCoGMd fbiImu sc-kYPZxB xXuob"
+          class="sc-gKAaRy iZvmHx sc-iCoGMd fbiImu sc-fXgAZx brwreb"
         >
           <form
             class="rjsf"
@@ -22,7 +22,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
             >
               <section>
                 <legend
-                  class="sc-dkQUaI inpicx"
+                  class="sc-eHEENL cWbOtx"
                   id="root__title"
                 >
                   Pokèmon
@@ -37,7 +37,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-string rendition-form__field--root_Name"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_Name"
                       >
                         Name
@@ -69,7 +69,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-number rendition-form__field--root_Height"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_Height"
                       >
                         Height
@@ -96,7 +96,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-number rendition-form__field--root_Weight"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_Weight"
                       >
                         Weight
@@ -123,7 +123,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-string rendition-form__field--root_Description"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_Description"
                       >
                         Description
@@ -150,7 +150,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-string rendition-form__field--root_Category"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_Category"
                       >
                         Category
@@ -177,7 +177,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-string rendition-form__field--root_Abilities"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_Abilities"
                       >
                         Abilities
@@ -204,7 +204,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-number rendition-form__field--root_pokedex_number"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_pokedex_number"
                       >
                         National Pokèdex Number
@@ -252,13 +252,13 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-string rendition-form__field--root_first_seen"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_first_seen"
                       >
                         First seen
                       </label>
                       <div
-                        class="sc-gKAaRy iZvmHx sc-iCoGMd eZYjXy sc-hHEiqL fOpvOh sc-dtLLSn bDHteQ rendition-form-description"
+                        class="sc-gKAaRy iZvmHx sc-iCoGMd eZYjXy sc-hHEiqL fOpvOh sc-biJonm hfJkTg rendition-form-description"
                         id="root_first_seen__description"
                       >
                         <div
@@ -295,13 +295,13 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-string rendition-form__field--root_poke_password"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_poke_password"
                       >
                         Poke Password
                       </label>
                       <div
-                        class="sc-gKAaRy iZvmHx sc-iCoGMd eZYjXy sc-hHEiqL fOpvOh sc-dtLLSn bDHteQ rendition-form-description"
+                        class="sc-gKAaRy iZvmHx sc-iCoGMd eZYjXy sc-hHEiqL fOpvOh sc-biJonm hfJkTg rendition-form-description"
                         id="root_poke_password__description"
                       >
                         <div
@@ -338,7 +338,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-string rendition-form__field--root_environment"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_environment"
                       >
                         environment
@@ -402,13 +402,13 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                     >
                       <div>
                         <legend
-                          class="sc-dkQUaI inpicx"
+                          class="sc-eHEENL cWbOtx"
                           id="root_tags__title"
                         >
                           Tags
                         </legend>
                         <div
-                          class="sc-gKAaRy iZvmHx sc-iCoGMd eZYjXy sc-hHEiqL fOpvOh sc-dtLLSn bDHteQ rendition-form-description"
+                          class="sc-gKAaRy iZvmHx sc-iCoGMd eZYjXy sc-hHEiqL fOpvOh sc-biJonm hfJkTg rendition-form-description"
                           id="root_tags__description"
                         >
                           <div
@@ -494,7 +494,7 @@ exports[`Storyshots Core/Form Default 1`] = `
         class="sc-gKAaRy bzVAry sc-iCoGMd foQObC"
       >
         <div
-          class="sc-gKAaRy iZvmHx sc-iCoGMd fbiImu sc-kYPZxB xXuob"
+          class="sc-gKAaRy iZvmHx sc-iCoGMd fbiImu sc-fXgAZx brwreb"
         >
           <form
             class="rjsf"
@@ -504,7 +504,7 @@ exports[`Storyshots Core/Form Default 1`] = `
             >
               <section>
                 <legend
-                  class="sc-dkQUaI inpicx"
+                  class="sc-eHEENL cWbOtx"
                   id="root__title"
                 >
                   Pokèmon
@@ -519,7 +519,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-string rendition-form__field--root_Name"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_Name"
                       >
                         Name
@@ -551,7 +551,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-number rendition-form__field--root_Height"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_Height"
                       >
                         Height
@@ -578,7 +578,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-number rendition-form__field--root_Weight"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_Weight"
                       >
                         Weight
@@ -605,7 +605,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-string rendition-form__field--root_Description"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_Description"
                       >
                         Description
@@ -632,7 +632,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-string rendition-form__field--root_Category"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_Category"
                       >
                         Category
@@ -659,7 +659,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-string rendition-form__field--root_Abilities"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_Abilities"
                       >
                         Abilities
@@ -686,7 +686,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-number rendition-form__field--root_pokedex_number"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_pokedex_number"
                       >
                         National Pokèdex Number
@@ -734,13 +734,13 @@ exports[`Storyshots Core/Form Default 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-string rendition-form__field--root_first_seen"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_first_seen"
                       >
                         First seen
                       </label>
                       <div
-                        class="sc-gKAaRy iZvmHx sc-iCoGMd eZYjXy sc-hHEiqL fOpvOh sc-dtLLSn bDHteQ rendition-form-description"
+                        class="sc-gKAaRy iZvmHx sc-iCoGMd eZYjXy sc-hHEiqL fOpvOh sc-biJonm hfJkTg rendition-form-description"
                         id="root_first_seen__description"
                       >
                         <div
@@ -777,13 +777,13 @@ exports[`Storyshots Core/Form Default 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-string rendition-form__field--root_poke_password"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_poke_password"
                       >
                         Poke Password
                       </label>
                       <div
-                        class="sc-gKAaRy iZvmHx sc-iCoGMd eZYjXy sc-hHEiqL fOpvOh sc-dtLLSn bDHteQ rendition-form-description"
+                        class="sc-gKAaRy iZvmHx sc-iCoGMd eZYjXy sc-hHEiqL fOpvOh sc-biJonm hfJkTg rendition-form-description"
                         id="root_poke_password__description"
                       >
                         <div
@@ -820,7 +820,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-string rendition-form__field--root_environment"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_environment"
                       >
                         environment
@@ -884,13 +884,13 @@ exports[`Storyshots Core/Form Default 1`] = `
                     >
                       <div>
                         <legend
-                          class="sc-dkQUaI inpicx"
+                          class="sc-eHEENL cWbOtx"
                           id="root_tags__title"
                         >
                           Tags
                         </legend>
                         <div
-                          class="sc-gKAaRy iZvmHx sc-iCoGMd eZYjXy sc-hHEiqL fOpvOh sc-dtLLSn bDHteQ rendition-form-description"
+                          class="sc-gKAaRy iZvmHx sc-iCoGMd eZYjXy sc-hHEiqL fOpvOh sc-biJonm hfJkTg rendition-form-description"
                           id="root_tags__description"
                         >
                           <div
@@ -976,7 +976,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
         class="sc-gKAaRy bzVAry sc-iCoGMd foQObC"
       >
         <div
-          class="sc-gKAaRy iZvmHx sc-iCoGMd fbiImu sc-kYPZxB xXuob"
+          class="sc-gKAaRy iZvmHx sc-iCoGMd fbiImu sc-fXgAZx brwreb"
         >
           <form
             class="rjsf"
@@ -986,7 +986,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
             >
               <section>
                 <legend
-                  class="sc-dkQUaI inpicx"
+                  class="sc-eHEENL cWbOtx"
                   id="root__title"
                 >
                   Pokèmon
@@ -1001,7 +1001,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-string rendition-form__field--root_Name"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_Name"
                       >
                         Name
@@ -1034,7 +1034,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-number rendition-form__field--root_Height"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_Height"
                       >
                         Height
@@ -1062,7 +1062,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-number rendition-form__field--root_Weight"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_Weight"
                       >
                         Weight
@@ -1090,7 +1090,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-string rendition-form__field--root_Description"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_Description"
                       >
                         Description
@@ -1118,7 +1118,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-string rendition-form__field--root_Category"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_Category"
                       >
                         Category
@@ -1146,7 +1146,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-string rendition-form__field--root_Abilities"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_Abilities"
                       >
                         Abilities
@@ -1174,7 +1174,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-number rendition-form__field--root_pokedex_number"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_pokedex_number"
                       >
                         National Pokèdex Number
@@ -1224,13 +1224,13 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-string rendition-form__field--root_first_seen"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_first_seen"
                       >
                         First seen
                       </label>
                       <div
-                        class="sc-gKAaRy iZvmHx sc-iCoGMd eZYjXy sc-hHEiqL fOpvOh sc-dtLLSn bDHteQ rendition-form-description"
+                        class="sc-gKAaRy iZvmHx sc-iCoGMd eZYjXy sc-hHEiqL fOpvOh sc-biJonm hfJkTg rendition-form-description"
                         id="root_first_seen__description"
                       >
                         <div
@@ -1268,13 +1268,13 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-string rendition-form__field--root_poke_password"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_poke_password"
                       >
                         Poke Password
                       </label>
                       <div
-                        class="sc-gKAaRy iZvmHx sc-iCoGMd eZYjXy sc-hHEiqL fOpvOh sc-dtLLSn bDHteQ rendition-form-description"
+                        class="sc-gKAaRy iZvmHx sc-iCoGMd eZYjXy sc-hHEiqL fOpvOh sc-biJonm hfJkTg rendition-form-description"
                         id="root_poke_password__description"
                       >
                         <div
@@ -1312,7 +1312,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-string rendition-form__field--root_environment"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_environment"
                       >
                         environment
@@ -1377,13 +1377,13 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                     >
                       <div>
                         <legend
-                          class="sc-dkQUaI inpicx"
+                          class="sc-eHEENL cWbOtx"
                           id="root_tags__title"
                         >
                           Tags
                         </legend>
                         <div
-                          class="sc-gKAaRy iZvmHx sc-iCoGMd eZYjXy sc-hHEiqL fOpvOh sc-dtLLSn bDHteQ rendition-form-description"
+                          class="sc-gKAaRy iZvmHx sc-iCoGMd eZYjXy sc-hHEiqL fOpvOh sc-biJonm hfJkTg rendition-form-description"
                           id="root_tags__description"
                         >
                           <div
@@ -1469,7 +1469,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
         class="sc-gKAaRy bzVAry sc-iCoGMd foQObC"
       >
         <div
-          class="sc-gKAaRy iZvmHx sc-iCoGMd fbiImu sc-kYPZxB xXuob"
+          class="sc-gKAaRy iZvmHx sc-iCoGMd fbiImu sc-fXgAZx brwreb"
         >
           <form
             class="rjsf"
@@ -1479,7 +1479,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
             >
               <section>
                 <legend
-                  class="sc-dkQUaI inpicx"
+                  class="sc-eHEENL cWbOtx"
                   id="root__title"
                 >
                   Pokèmon
@@ -1494,7 +1494,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-string rendition-form__field--root_Name"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_Name"
                       >
                         Name
@@ -1526,7 +1526,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-number rendition-form__field--root_Height"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_Height"
                       >
                         Height
@@ -1553,7 +1553,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-number rendition-form__field--root_Weight"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_Weight"
                       >
                         Weight
@@ -1580,7 +1580,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-string rendition-form__field--root_Description"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_Description"
                       >
                         Description
@@ -1607,7 +1607,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-string rendition-form__field--root_Category"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_Category"
                       >
                         Category
@@ -1634,7 +1634,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-string rendition-form__field--root_Abilities"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_Abilities"
                       >
                         Abilities
@@ -1661,7 +1661,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-number rendition-form__field--root_pokedex_number"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_pokedex_number"
                       >
                         National Pokèdex Number
@@ -1709,13 +1709,13 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-string rendition-form__field--root_first_seen"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_first_seen"
                       >
                         First seen
                       </label>
                       <div
-                        class="sc-gKAaRy iZvmHx sc-iCoGMd eZYjXy sc-hHEiqL fOpvOh sc-dtLLSn bDHteQ rendition-form-description"
+                        class="sc-gKAaRy iZvmHx sc-iCoGMd eZYjXy sc-hHEiqL fOpvOh sc-biJonm hfJkTg rendition-form-description"
                         id="root_first_seen__description"
                       >
                         <div
@@ -1752,13 +1752,13 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-string rendition-form__field--root_poke_password"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_poke_password"
                       >
                         Poke Password
                       </label>
                       <div
-                        class="sc-gKAaRy iZvmHx sc-iCoGMd eZYjXy sc-hHEiqL fOpvOh sc-dtLLSn bDHteQ rendition-form-description"
+                        class="sc-gKAaRy iZvmHx sc-iCoGMd eZYjXy sc-hHEiqL fOpvOh sc-biJonm hfJkTg rendition-form-description"
                         id="root_poke_password__description"
                       >
                         <div
@@ -1795,7 +1795,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-string rendition-form__field--root_environment"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_environment"
                       >
                         environment
@@ -1859,13 +1859,13 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                     >
                       <div>
                         <legend
-                          class="sc-dkQUaI inpicx"
+                          class="sc-eHEENL cWbOtx"
                           id="root_tags__title"
                         >
                           Tags
                         </legend>
                         <div
-                          class="sc-gKAaRy iZvmHx sc-iCoGMd eZYjXy sc-hHEiqL fOpvOh sc-dtLLSn bDHteQ rendition-form-description"
+                          class="sc-gKAaRy iZvmHx sc-iCoGMd eZYjXy sc-hHEiqL fOpvOh sc-biJonm hfJkTg rendition-form-description"
                           id="root_tags__description"
                         >
                           <div
@@ -1946,7 +1946,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
         class="sc-gKAaRy bzVAry sc-iCoGMd foQObC"
       >
         <div
-          class="sc-gKAaRy iZvmHx sc-iCoGMd fbiImu sc-kYPZxB xXuob"
+          class="sc-gKAaRy iZvmHx sc-iCoGMd fbiImu sc-fXgAZx brwreb"
         >
           <form
             class="rjsf"
@@ -1956,7 +1956,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
             >
               <section>
                 <legend
-                  class="sc-dkQUaI inpicx"
+                  class="sc-eHEENL cWbOtx"
                   id="root__title"
                 >
                   Pokèmon
@@ -1971,7 +1971,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-string rendition-form__field--root_Name"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_Name"
                       >
                         Name
@@ -2003,7 +2003,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-number rendition-form__field--root_Height"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_Height"
                       >
                         Height
@@ -2030,7 +2030,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-number rendition-form__field--root_Weight"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_Weight"
                       >
                         Weight
@@ -2057,7 +2057,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-string rendition-form__field--root_Description"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_Description"
                       >
                         Description
@@ -2084,7 +2084,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-string rendition-form__field--root_Category"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_Category"
                       >
                         Category
@@ -2111,7 +2111,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-string rendition-form__field--root_Abilities"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_Abilities"
                       >
                         Abilities
@@ -2138,7 +2138,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-number rendition-form__field--root_pokedex_number"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_pokedex_number"
                       >
                         National Pokèdex Number
@@ -2186,13 +2186,13 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-string rendition-form__field--root_first_seen"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_first_seen"
                       >
                         First seen
                       </label>
                       <div
-                        class="sc-gKAaRy iZvmHx sc-iCoGMd eZYjXy sc-hHEiqL fOpvOh sc-dtLLSn bDHteQ rendition-form-description"
+                        class="sc-gKAaRy iZvmHx sc-iCoGMd eZYjXy sc-hHEiqL fOpvOh sc-biJonm hfJkTg rendition-form-description"
                         id="root_first_seen__description"
                       >
                         <div
@@ -2229,13 +2229,13 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-string rendition-form__field--root_poke_password"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_poke_password"
                       >
                         Poke Password
                       </label>
                       <div
-                        class="sc-gKAaRy iZvmHx sc-iCoGMd eZYjXy sc-hHEiqL fOpvOh sc-dtLLSn bDHteQ rendition-form-description"
+                        class="sc-gKAaRy iZvmHx sc-iCoGMd eZYjXy sc-hHEiqL fOpvOh sc-biJonm hfJkTg rendition-form-description"
                         id="root_poke_password__description"
                       >
                         <div
@@ -2272,7 +2272,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-string rendition-form__field--root_environment"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_environment"
                       >
                         environment
@@ -2336,13 +2336,13 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                     >
                       <div>
                         <legend
-                          class="sc-dkQUaI inpicx"
+                          class="sc-eHEENL cWbOtx"
                           id="root_tags__title"
                         >
                           Tags
                         </legend>
                         <div
-                          class="sc-gKAaRy iZvmHx sc-iCoGMd eZYjXy sc-hHEiqL fOpvOh sc-dtLLSn bDHteQ rendition-form-description"
+                          class="sc-gKAaRy iZvmHx sc-iCoGMd eZYjXy sc-hHEiqL fOpvOh sc-biJonm hfJkTg rendition-form-description"
                           id="root_tags__description"
                         >
                           <div
@@ -2434,7 +2434,7 @@ exports[`Storyshots Core/Form With Dependants 1`] = `
         class="sc-gKAaRy bzVAry sc-iCoGMd foQObC"
       >
         <div
-          class="sc-gKAaRy iZvmHx sc-iCoGMd fbiImu sc-kYPZxB xXuob"
+          class="sc-gKAaRy iZvmHx sc-iCoGMd fbiImu sc-fXgAZx brwreb"
         >
           <form
             class="rjsf"
@@ -2454,7 +2454,7 @@ exports[`Storyshots Core/Form With Dependants 1`] = `
                     >
                       <div>
                         <legend
-                          class="sc-dkQUaI inpicx"
+                          class="sc-eHEENL cWbOtx"
                           id="root_application_config_variable__title"
                         >
                           Application configuration variables
@@ -2498,7 +2498,7 @@ exports[`Storyshots Core/Form With Dependants 1`] = `
                     >
                       <div>
                         <legend
-                          class="sc-dkQUaI inpicx"
+                          class="sc-eHEENL cWbOtx"
                           id="root_application_environment_variable__title"
                         >
                           Application environment variables
@@ -3260,7 +3260,7 @@ Rendition contains widgets for rendering Markdown and Mermaid text formats that 
         class="sc-gKAaRy bzVAry sc-iCoGMd foQObC"
       >
         <div
-          class="sc-gKAaRy iZvmHx sc-iCoGMd fbiImu sc-kYPZxB xXuob"
+          class="sc-gKAaRy iZvmHx sc-iCoGMd fbiImu sc-fXgAZx brwreb"
         >
           <form
             class="rjsf"
@@ -3279,7 +3279,7 @@ Rendition contains widgets for rendering Markdown and Mermaid text formats that 
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-string rendition-form__field--root_Mermaid"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_Mermaid"
                       >
                         Mermaid
@@ -3357,7 +3357,7 @@ Rendition contains widgets for rendering Markdown and Mermaid text formats that 
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-string rendition-form__field--root_Markdown"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_Markdown"
                       >
                         Markdown
@@ -3648,7 +3648,7 @@ Rendition contains widgets for rendering Markdown and Mermaid text formats that 
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-string rendition-form__field--root_Captcha"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_Captcha"
                       >
                         Captcha
@@ -3698,7 +3698,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
         class="sc-gKAaRy bzVAry sc-iCoGMd foQObC"
       >
         <div
-          class="sc-gKAaRy iZvmHx sc-iCoGMd fbiImu sc-kYPZxB xXuob"
+          class="sc-gKAaRy iZvmHx sc-iCoGMd fbiImu sc-fXgAZx brwreb"
         >
           <form
             class="rjsf"
@@ -3708,7 +3708,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
             >
               <section>
                 <legend
-                  class="sc-dkQUaI inpicx"
+                  class="sc-eHEENL cWbOtx"
                   id="root__title"
                 >
                   Pokèmon
@@ -3723,7 +3723,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-string rendition-form__field--root_Name"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_Name"
                       >
                         Name
@@ -3747,7 +3747,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                         id="dummy-datalist"
                       />
                       <div
-                        class="sc-gKAaRy iZvmHx sc-iCoGMd eZYjXy sc-hHEiqL fOpvOh sc-dtLLSn lhhgqV rendition-form-help"
+                        class="sc-gKAaRy iZvmHx sc-iCoGMd eZYjXy sc-hHEiqL fOpvOh sc-biJonm bJimhd rendition-form-help"
                         id="root_Name"
                       >
                         <div
@@ -3796,7 +3796,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-string rendition-form__field--root_Description"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_Description"
                       >
                         Description
@@ -3816,7 +3816,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-string rendition-form__field--root_Abilities"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_Abilities"
                       >
                         Abilities
@@ -3843,7 +3843,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-number rendition-form__field--root_Height"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_Height"
                       >
                         Height
@@ -3870,7 +3870,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-number rendition-form__field--root_Weight"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_Weight"
                       >
                         Weight
@@ -3897,7 +3897,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-string rendition-form__field--root_Category"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_Category"
                       >
                         Category
@@ -3924,7 +3924,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-number rendition-form__field--root_pokedex_number"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_pokedex_number"
                       >
                         National Pokèdex Number
@@ -3951,13 +3951,13 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-string rendition-form__field--root_first_seen"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_first_seen"
                       >
                         First seen
                       </label>
                       <div
-                        class="sc-gKAaRy iZvmHx sc-iCoGMd eZYjXy sc-hHEiqL fOpvOh sc-dtLLSn bDHteQ rendition-form-description"
+                        class="sc-gKAaRy iZvmHx sc-iCoGMd eZYjXy sc-hHEiqL fOpvOh sc-biJonm hfJkTg rendition-form-description"
                         id="root_first_seen__description"
                       >
                         <div
@@ -3994,13 +3994,13 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-string rendition-form__field--root_poke_password"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_poke_password"
                       >
                         Poke Password
                       </label>
                       <div
-                        class="sc-gKAaRy iZvmHx sc-iCoGMd eZYjXy sc-hHEiqL fOpvOh sc-dtLLSn bDHteQ rendition-form-description"
+                        class="sc-gKAaRy iZvmHx sc-iCoGMd eZYjXy sc-hHEiqL fOpvOh sc-biJonm hfJkTg rendition-form-description"
                         id="root_poke_password__description"
                       >
                         <div
@@ -4032,7 +4032,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                           />
                         </div>
                         <button
-                          class="StyledButton-sc-323bzc-0 kDzTIW sc-bqGGPW sc-bkbkJK ffJBuc ejJZLx sc-dIvrsQ bodFGu sc-biJonm jvVGtz"
+                          class="StyledButton-sc-323bzc-0 kDzTIW sc-bqGGPW sc-bkbkJK ffJBuc ejJZLx sc-dIvrsQ bodFGu sc-dWBRfb gVYOdJ"
                           type="button"
                         >
                           <svg
@@ -4061,7 +4061,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-string rendition-form__field--root_environment"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_environment"
                       >
                         environment
@@ -4125,13 +4125,13 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                     >
                       <div>
                         <legend
-                          class="sc-dkQUaI inpicx"
+                          class="sc-eHEENL cWbOtx"
                           id="root_tags__title"
                         >
                           Tags
                         </legend>
                         <div
-                          class="sc-gKAaRy iZvmHx sc-iCoGMd eZYjXy sc-hHEiqL fOpvOh sc-dtLLSn bDHteQ rendition-form-description"
+                          class="sc-gKAaRy iZvmHx sc-iCoGMd eZYjXy sc-hHEiqL fOpvOh sc-biJonm hfJkTg rendition-form-description"
                           id="root_tags__description"
                         >
                           <div
@@ -4217,7 +4217,7 @@ exports[`Storyshots Core/Form With Pattern Properties 1`] = `
         class="sc-gKAaRy bzVAry sc-iCoGMd foQObC"
       >
         <div
-          class="sc-gKAaRy iZvmHx sc-iCoGMd fbiImu sc-kYPZxB xXuob"
+          class="sc-gKAaRy iZvmHx sc-iCoGMd fbiImu sc-fXgAZx brwreb"
         >
           <form
             class="rjsf"
@@ -4237,7 +4237,7 @@ exports[`Storyshots Core/Form With Pattern Properties 1`] = `
                     >
                       <section>
                         <legend
-                          class="sc-dkQUaI inpicx"
+                          class="sc-eHEENL cWbOtx"
                           id="root_dynamicObject__title"
                         >
                           Rules
@@ -4338,7 +4338,7 @@ exports[`Storyshots Core/Form With Titles 1`] = `
         class="sc-gKAaRy bzVAry sc-iCoGMd foQObC"
       >
         <div
-          class="sc-gKAaRy iZvmHx sc-iCoGMd fbiImu sc-kYPZxB xXuob"
+          class="sc-gKAaRy iZvmHx sc-iCoGMd fbiImu sc-fXgAZx brwreb"
         >
           <form
             class="rjsf"
@@ -4348,7 +4348,7 @@ exports[`Storyshots Core/Form With Titles 1`] = `
             >
               <section>
                 <legend
-                  class="sc-dkQUaI inpicx"
+                  class="sc-eHEENL cWbOtx"
                   id="root__title"
                 >
                   Networking
@@ -4364,7 +4364,7 @@ exports[`Storyshots Core/Form With Titles 1`] = `
                     >
                       <section>
                         <legend
-                          class="sc-dkQUaI inpicx"
+                          class="sc-eHEENL cWbOtx"
                           id="root_vpn__title"
                         >
                           Virtual Private Network
@@ -4379,7 +4379,7 @@ exports[`Storyshots Core/Form With Titles 1`] = `
                               class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-string rendition-form__field--root_vpn_endpoint"
                             >
                               <label
-                                class="sc-ikXwFM gTeKMs control-label"
+                                class="sc-kYPZxB bPXPk control-label"
                                 for="root_vpn_endpoint"
                               >
                                 Endpoint
@@ -4406,7 +4406,7 @@ exports[`Storyshots Core/Form With Titles 1`] = `
                               class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-string rendition-form__field--root_vpn_certificate"
                             >
                               <label
-                                class="sc-ikXwFM gTeKMs control-label"
+                                class="sc-kYPZxB bPXPk control-label"
                                 for="root_vpn_certificate"
                               >
                                 Certificate
@@ -4438,7 +4438,7 @@ exports[`Storyshots Core/Form With Titles 1`] = `
                     >
                       <section>
                         <legend
-                          class="sc-dkQUaI inpicx"
+                          class="sc-eHEENL cWbOtx"
                           id="root_wifiNetwork__title"
                         >
                           WiFi Network
@@ -4463,7 +4463,7 @@ exports[`Storyshots Core/Form With Titles 1`] = `
                                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-string rendition-form__field--root_wifiNetwork_wifi_ssid"
                                     >
                                       <label
-                                        class="sc-ikXwFM gTeKMs control-label"
+                                        class="sc-kYPZxB bPXPk control-label"
                                         for="root_wifiNetwork_wifi_ssid"
                                       >
                                         Network SSID
@@ -4504,7 +4504,7 @@ exports[`Storyshots Core/Form With Titles 1`] = `
                                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-string rendition-form__field--root_wifiNetwork_wifiSecurity_psk"
                                     >
                                       <label
-                                        class="sc-ikXwFM gTeKMs control-label"
+                                        class="sc-kYPZxB bPXPk control-label"
                                         for="root_wifiNetwork_wifiSecurity_psk"
                                       >
                                         Network Passphrase
@@ -4578,7 +4578,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
         class="sc-gKAaRy bzVAry sc-iCoGMd foQObC"
       >
         <div
-          class="sc-gKAaRy iZvmHx sc-iCoGMd fbiImu sc-kYPZxB xXuob"
+          class="sc-gKAaRy iZvmHx sc-iCoGMd fbiImu sc-fXgAZx brwreb"
         >
           <form
             class="rjsf"
@@ -4588,7 +4588,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
             >
               <section>
                 <legend
-                  class="sc-dkQUaI inpicx"
+                  class="sc-eHEENL cWbOtx"
                   id="root__title"
                 >
                   Pokèmon
@@ -4603,7 +4603,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-string rendition-form__field--root_Name"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_Name"
                       >
                         Name
@@ -4656,7 +4656,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-string rendition-form__field--root_Description"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_Description"
                       >
                         Description
@@ -4676,7 +4676,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-string rendition-form__field--root_Abilities"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_Abilities"
                       >
                         Abilities
@@ -4703,7 +4703,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-number rendition-form__field--root_Height"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_Height"
                       >
                         Height
@@ -4730,7 +4730,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-number rendition-form__field--root_Weight"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_Weight"
                       >
                         Weight
@@ -4757,7 +4757,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-string rendition-form__field--root_Category"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_Category"
                       >
                         Category
@@ -4784,7 +4784,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-number rendition-form__field--root_pokedex_number"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_pokedex_number"
                       >
                         National Pokèdex Number
@@ -4811,13 +4811,13 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-string rendition-form__field--root_first_seen"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_first_seen"
                       >
                         First seen
                       </label>
                       <div
-                        class="sc-gKAaRy iZvmHx sc-iCoGMd eZYjXy sc-hHEiqL fOpvOh sc-dtLLSn bDHteQ rendition-form-description"
+                        class="sc-gKAaRy iZvmHx sc-iCoGMd eZYjXy sc-hHEiqL fOpvOh sc-biJonm hfJkTg rendition-form-description"
                         id="root_first_seen__description"
                       >
                         <div
@@ -4854,13 +4854,13 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-string rendition-form__field--root_poke_password"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_poke_password"
                       >
                         Poke Password
                       </label>
                       <div
-                        class="sc-gKAaRy iZvmHx sc-iCoGMd eZYjXy sc-hHEiqL fOpvOh sc-dtLLSn bDHteQ rendition-form-description"
+                        class="sc-gKAaRy iZvmHx sc-iCoGMd eZYjXy sc-hHEiqL fOpvOh sc-biJonm hfJkTg rendition-form-description"
                         id="root_poke_password__description"
                       >
                         <div
@@ -4892,7 +4892,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                           />
                         </div>
                         <button
-                          class="StyledButton-sc-323bzc-0 kDzTIW sc-bqGGPW sc-bkbkJK ffJBuc ejJZLx sc-dIvrsQ bodFGu sc-biJonm jvVGtz"
+                          class="StyledButton-sc-323bzc-0 kDzTIW sc-bqGGPW sc-bkbkJK ffJBuc ejJZLx sc-dIvrsQ bodFGu sc-dWBRfb gVYOdJ"
                           type="button"
                         >
                           <svg
@@ -4921,7 +4921,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-string rendition-form__field--root_environment"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_environment"
                       >
                         environment
@@ -4985,13 +4985,13 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                     >
                       <div>
                         <legend
-                          class="sc-dkQUaI inpicx"
+                          class="sc-eHEENL cWbOtx"
                           id="root_tags__title"
                         >
                           Tags
                         </legend>
                         <div
-                          class="sc-gKAaRy iZvmHx sc-iCoGMd eZYjXy sc-hHEiqL fOpvOh sc-dtLLSn bDHteQ rendition-form-description"
+                          class="sc-gKAaRy iZvmHx sc-iCoGMd eZYjXy sc-hHEiqL fOpvOh sc-biJonm hfJkTg rendition-form-description"
                           id="root_tags__description"
                         >
                           <div
@@ -5077,7 +5077,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
         class="sc-gKAaRy bzVAry sc-iCoGMd foQObC"
       >
         <div
-          class="sc-gKAaRy iZvmHx sc-iCoGMd fbiImu sc-kYPZxB xXuob"
+          class="sc-gKAaRy iZvmHx sc-iCoGMd fbiImu sc-fXgAZx brwreb"
         >
           <form
             class="rjsf"
@@ -5087,7 +5087,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
             >
               <section>
                 <legend
-                  class="sc-dkQUaI inpicx"
+                  class="sc-eHEENL cWbOtx"
                   id="root__title"
                 >
                   Pokèmon
@@ -5102,7 +5102,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-string rendition-form__field--root_Name"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_Name"
                       >
                         Name
@@ -5133,7 +5133,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                           class="sc-fKgJPI jlSUcY sc-iwajpm fnHQTV"
                         >
                           <div
-                            class="sc-gKAaRy iZvmHx sc-iCoGMd eZYjXy sc-hHEiqL fOpvOh sc-dtLLSn plZaY"
+                            class="sc-gKAaRy iZvmHx sc-iCoGMd eZYjXy sc-hHEiqL fOpvOh sc-biJonm kpIKCs"
                           >
                             <div
                               class="sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi sc-ciOKUB iexkTS"
@@ -5201,7 +5201,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-string rendition-form__field--root_Description"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_Description"
                       >
                         Description
@@ -5221,7 +5221,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-string rendition-form__field--root_Abilities"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_Abilities"
                       >
                         Abilities
@@ -5248,7 +5248,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-number rendition-form__field--root_Height"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_Height"
                       >
                         Height
@@ -5275,7 +5275,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-number rendition-form__field--root_Weight"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_Weight"
                       >
                         Weight
@@ -5302,7 +5302,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-string rendition-form__field--root_Category"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_Category"
                       >
                         Category
@@ -5329,7 +5329,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-number rendition-form__field--root_pokedex_number"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_pokedex_number"
                       >
                         National Pokèdex Number
@@ -5356,13 +5356,13 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-string rendition-form__field--root_first_seen"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_first_seen"
                       >
                         First seen
                       </label>
                       <div
-                        class="sc-gKAaRy iZvmHx sc-iCoGMd eZYjXy sc-hHEiqL fOpvOh sc-dtLLSn bDHteQ rendition-form-description"
+                        class="sc-gKAaRy iZvmHx sc-iCoGMd eZYjXy sc-hHEiqL fOpvOh sc-biJonm hfJkTg rendition-form-description"
                         id="root_first_seen__description"
                       >
                         <div
@@ -5399,13 +5399,13 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-string rendition-form__field--root_poke_password"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_poke_password"
                       >
                         Poke Password
                       </label>
                       <div
-                        class="sc-gKAaRy iZvmHx sc-iCoGMd eZYjXy sc-hHEiqL fOpvOh sc-dtLLSn bDHteQ rendition-form-description"
+                        class="sc-gKAaRy iZvmHx sc-iCoGMd eZYjXy sc-hHEiqL fOpvOh sc-biJonm hfJkTg rendition-form-description"
                         id="root_poke_password__description"
                       >
                         <div
@@ -5437,7 +5437,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                           />
                         </div>
                         <button
-                          class="StyledButton-sc-323bzc-0 kDzTIW sc-bqGGPW sc-bkbkJK ffJBuc ejJZLx sc-dIvrsQ bodFGu sc-biJonm jvVGtz"
+                          class="StyledButton-sc-323bzc-0 kDzTIW sc-bqGGPW sc-bkbkJK ffJBuc ejJZLx sc-dIvrsQ bodFGu sc-dWBRfb gVYOdJ"
                           type="button"
                         >
                           <svg
@@ -5466,7 +5466,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                       class="sc-gKAaRy iZvmHx sc-iCoGMd hHyBbL form-group field field-string rendition-form__field--root_environment"
                     >
                       <label
-                        class="sc-ikXwFM gTeKMs control-label"
+                        class="sc-kYPZxB bPXPk control-label"
                         for="root_environment"
                       >
                         environment
@@ -5530,13 +5530,13 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                     >
                       <div>
                         <legend
-                          class="sc-dkQUaI inpicx"
+                          class="sc-eHEENL cWbOtx"
                           id="root_tags__title"
                         >
                           Tags
                         </legend>
                         <div
-                          class="sc-gKAaRy iZvmHx sc-iCoGMd eZYjXy sc-hHEiqL fOpvOh sc-dtLLSn bDHteQ rendition-form-description"
+                          class="sc-gKAaRy iZvmHx sc-iCoGMd eZYjXy sc-hHEiqL fOpvOh sc-biJonm hfJkTg rendition-form-description"
                           id="root_tags__description"
                         >
                           <div

--- a/src/components/Form/__snapshots__/spec.tsx.snap
+++ b/src/components/Form/__snapshots__/spec.tsx.snap
@@ -1,5 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Form component description keyword should support markdown 1`] = `"<div id=\\"root_foo__description\\" class=\\"sc-gKAaRy iZvmHx sc-iCoGMd eZYjXy sc-hHEiqL fOpvOh sc-dtLLSn bDHteQ rendition-form-description\\"><div class=\\"sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi\\">Lorem ipsum *dolor* sit amet</div></div>"`;
+exports[`Form component description keyword should support markdown 1`] = `"<div id=\\"root_foo__description\\" class=\\"sc-gKAaRy iZvmHx sc-iCoGMd eZYjXy sc-hHEiqL fOpvOh sc-biJonm hfJkTg rendition-form-description\\"><div class=\\"sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi\\">Lorem ipsum *dolor* sit amet</div></div>"`;
 
-exports[`Form component ui:help keyword should support markdown 1`] = `"<div id=\\"root_foo\\" class=\\"sc-gKAaRy iZvmHx sc-iCoGMd eZYjXy sc-hHEiqL fOpvOh sc-dtLLSn lhhgqV rendition-form-help\\"><div class=\\"sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi\\">Lorem ipsum *dolor* sit amet</div></div>"`;
+exports[`Form component ui:help keyword should support markdown 1`] = `"<div id=\\"root_foo\\" class=\\"sc-gKAaRy iZvmHx sc-iCoGMd eZYjXy sc-hHEiqL fOpvOh sc-biJonm bJimhd rendition-form-help\\"><div class=\\"sc-fKgJPI jlSUcY sc-bCwfaz ecGcZi\\">Lorem ipsum *dolor* sit amet</div></div>"`;

--- a/src/components/ProgressBar/__snapshots__/ProgressBar.stories.storyshot
+++ b/src/components/ProgressBar/__snapshots__/ProgressBar.stories.storyshot
@@ -6,21 +6,21 @@ exports[`Storyshots Core/ProgressBar Default 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 jXAVEG sc-eEVmNe jhNcBG"
   >
     <div
-      class="sc-EZqKI btQcRO sc-jXcxbT AQTQX"
+      class="sc-WZYut bucJPz sc-ikXwFM hzaHUi"
       color="#fff"
     >
       <div
-        class="sc-bQCEYZ jiukjW"
+        class="sc-dtLLSn hCgWJd"
       >
         10
         %
       </div>
       <div
-        class="sc-jHcXXw bcuOvF"
+        class="sc-fHCHyC dlMiAc"
         style="width: 10%;"
       >
         <div
-          class="sc-fXgAZx hcKfZC"
+          class="sc-dkQUaI bpwCpL"
           style="width: 1000%;"
         >
           10
@@ -38,22 +38,22 @@ exports[`Storyshots Core/ProgressBar Different Color 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 jXAVEG sc-eEVmNe jhNcBG"
   >
     <div
-      class="sc-EZqKI btQcRO sc-jXcxbT AQTQX"
+      class="sc-WZYut bucJPz sc-ikXwFM hzaHUi"
       color="#fff"
       type="danger"
     >
       <div
-        class="sc-bQCEYZ jiukjW"
+        class="sc-dtLLSn hCgWJd"
       >
         10
         %
       </div>
       <div
-        class="sc-jHcXXw crFisn"
+        class="sc-fHCHyC femlEu"
         style="width: 10%;"
       >
         <div
-          class="sc-fXgAZx hcKfZC"
+          class="sc-dkQUaI bpwCpL"
           style="width: 1000%;"
         >
           10
@@ -71,21 +71,21 @@ exports[`Storyshots Core/ProgressBar Emphasized 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 jXAVEG sc-eEVmNe jhNcBG"
   >
     <div
-      class="sc-EZqKI hAzvtr sc-jXcxbT AQTQX"
+      class="sc-WZYut fKFfGu sc-ikXwFM hzaHUi"
       color="#fff"
     >
       <div
-        class="sc-bQCEYZ jiukjW"
+        class="sc-dtLLSn hCgWJd"
       >
         10
         %
       </div>
       <div
-        class="sc-jHcXXw bcuOvF"
+        class="sc-fHCHyC dlMiAc"
         style="width: 10%;"
       >
         <div
-          class="sc-fXgAZx hcKfZC"
+          class="sc-dkQUaI bpwCpL"
           style="width: 1000%;"
         >
           10

--- a/src/components/Renderer/__snapshots__/spec.tsx.snap
+++ b/src/components/Renderer/__snapshots__/spec.tsx.snap
@@ -385,6 +385,154 @@ exports[`Renderer component A List widget 1`] = `
 </div>
 `;
 
+exports[`Renderer component A ProgressBar widget 1`] = `
+.c0 {
+  font-family: 'Source Sans Pro',Helvetica,sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c2 {
+  box-sizing: border-box;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.c5 {
+  box-sizing: border-box;
+}
+
+.c3 {
+  margin-bottom: 4px;
+  min-width: 0;
+  min-height: 0;
+}
+
+.c6 {
+  margin-right: 8px;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+}
+
+.c7 {
+  font-weight: 600;
+}
+
+.c11 {
+  position: relative;
+  height: 38px;
+  overflow: hidden;
+  background: #527699;
+  -webkit-transition: width linear 250ms;
+  transition: width linear 250ms;
+  text-align: center;
+}
+
+.c10 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  text-align: center;
+  color: #000;
+  text-shadow: 0 0 3px rgba(255,255,255,0.5);
+}
+
+.c12 {
+  text-align: center;
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  top: 0;
+  text-shadow: 0 0 3px rgba(0,0,0,0.5);
+  -webkit-transition: width linear 250ms;
+  transition: width linear 250ms;
+}
+
+.c8 {
+  position: relative;
+  border-radius: 3px;
+  height: 16px;
+  line-height: 16px;
+  background: #DDE1f0;
+  font-size: 0.6em;
+  overflow: hidden;
+}
+
+.c9 {
+  color: #fff;
+}
+
+.c1 {
+  font-family: 'Source Sans Pro',Helvetica,sans-serif;
+  font-size: 14px;
+  color: #2A506F;
+}
+
+<div>
+  <div
+    class="c0 c1"
+  >
+    <div
+      class="c2 c3 c4 "
+    >
+      <div
+        class="c5 c6"
+      >
+        <div
+          class="c7 "
+        >
+          Progress
+        </div>
+      </div>
+      <div
+        class="c8 c9"
+        color="#fff"
+        type="tertiary"
+      >
+        <div
+          class="c10"
+        >
+          83
+          %
+        </div>
+        <div
+          class="c11"
+          style="width: 82.63512353%;"
+        >
+          <div
+            class="c12"
+            style="width: 121.0139172402832%;"
+          >
+            83
+            %
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Renderer component A Tag widget 1`] = `
 .c0 {
   font-family: 'Source Sans Pro',Helvetica,sans-serif;

--- a/src/components/Renderer/examples.ts
+++ b/src/components/Renderer/examples.ts
@@ -509,6 +509,22 @@ const jsonDataExamples = {
 			},
 		},
 	},
+	'A ProgressBar widget': {
+		value: 82.63512353,
+		schema: {
+			type: 'number',
+		},
+		uiSchema: {
+			'ui:title': 'Progress',
+			'ui:widget': 'ProgressBar',
+			'ui:options': {
+				flex: 1,
+				alignItems: 'stretch',
+				background: '',
+				tertiary: true,
+			},
+		},
+	},
 	'A HighlightedName widget': {
 		value: 'Jellyfish',
 		schema: {

--- a/src/components/Renderer/widgets/ProgressBarWidget.tsx
+++ b/src/components/Renderer/widgets/ProgressBarWidget.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react';
+import { ProgressBar } from '../../ProgressBar';
+import { UiOption } from './ui-options';
+import { Widget, WidgetProps } from './widget-util';
+import { JsonTypes } from '../types';
+
+// Note: this widget works best when the following 'ui:options' are specified:
+// 	 flex: 1
+//   alignItems: 'stretch'
+
+const ProgressBarWidget: Widget = ({
+	value,
+	schema,
+	uiSchema,
+	extraContext,
+	extraFormats,
+	...props
+}: WidgetProps) => {
+	if (value == null) {
+		return null;
+	}
+	if (typeof value !== 'number') {
+		throw new Error(
+			`ProgressBarWidget cannot be used to render a value of type '${typeof value}'`,
+		);
+	}
+	return (
+		<ProgressBar {...props} value={value}>
+			{value.toFixed(0)}%
+		</ProgressBar>
+	);
+};
+
+ProgressBarWidget.displayName = 'ProgressBar';
+
+ProgressBarWidget.uiOptions = {
+	background: UiOption.string,
+	primary: UiOption.boolean,
+	secondary: UiOption.boolean,
+	tertiary: UiOption.boolean,
+	quartenary: UiOption.boolean,
+	danger: UiOption.boolean,
+	warning: UiOption.boolean,
+	success: UiOption.boolean,
+	info: UiOption.boolean,
+	emphasized: UiOption.boolean,
+};
+
+ProgressBarWidget.supportedTypes = [JsonTypes.integer, JsonTypes.number];
+
+export default ProgressBarWidget;

--- a/src/components/Renderer/widgets/index.ts
+++ b/src/components/Renderer/widgets/index.ts
@@ -11,6 +11,7 @@ import ImgWidget from './ImgWidget';
 import LinkWidget from './LinkWidget';
 import ListWidget from './ListWidget';
 import ObjectWidget from './ObjectWidget';
+import ProgressBarWidget from './ProgressBarWidget';
 import TagWidget from './TagWidget';
 import TxtWidget from './TxtWidget';
 import { Format } from '../types';
@@ -59,6 +60,7 @@ export const defaultFormats: Format[] = [
 		LinkWidget,
 		ListWidget,
 		ObjectWidget,
+		ProgressBarWidget,
 		TagWidget,
 		TxtWidget,
 	].map((widget) => ({

--- a/src/components/StatsBar/__snapshots__/StatsBar.stories.storyshot
+++ b/src/components/StatsBar/__snapshots__/StatsBar.stories.storyshot
@@ -66,19 +66,19 @@ exports[`Storyshots Core/StatsBar Cpu Temp 1`] = `
           class="sc-gKAaRy bzVAry sc-iCoGMd gxfzzc"
         >
           <div
-            class="sc-EZqKI btQcRO sc-jXcxbT AQTQX"
+            class="sc-WZYut bucJPz sc-ikXwFM hzaHUi"
             color="#fff"
             type="success"
           >
             <div
-              class="sc-bQCEYZ jiukjW"
+              class="sc-dtLLSn hCgWJd"
             />
             <div
-              class="sc-jHcXXw jkOYNu"
+              class="sc-fHCHyC flfikb"
               style="width: 34%;"
             >
               <div
-                class="sc-fXgAZx hcKfZC"
+                class="sc-dkQUaI bpwCpL"
                 style="width: 294.11764705882354%;"
               />
             </div>
@@ -156,19 +156,19 @@ exports[`Storyshots Core/StatsBar Cpu Usage 1`] = `
           class="sc-gKAaRy bzVAry sc-iCoGMd iQsJTs"
         >
           <div
-            class="sc-EZqKI btQcRO sc-jXcxbT AQTQX"
+            class="sc-WZYut bucJPz sc-ikXwFM hzaHUi"
             color="#fff"
             type="success"
           >
             <div
-              class="sc-bQCEYZ jiukjW"
+              class="sc-dtLLSn hCgWJd"
             />
             <div
-              class="sc-jHcXXw jkOYNu"
+              class="sc-fHCHyC flfikb"
               style="width: 100%;"
             >
               <div
-                class="sc-fXgAZx hcKfZC"
+                class="sc-dkQUaI bpwCpL"
                 style="width: 100%;"
               />
             </div>
@@ -178,19 +178,19 @@ exports[`Storyshots Core/StatsBar Cpu Usage 1`] = `
           class="sc-gKAaRy bzVAry sc-iCoGMd iQsJTs"
         >
           <div
-            class="sc-EZqKI btQcRO sc-jXcxbT AQTQX"
+            class="sc-WZYut bucJPz sc-ikXwFM hzaHUi"
             color="#fff"
             type="success"
           >
             <div
-              class="sc-bQCEYZ jiukjW"
+              class="sc-dtLLSn hCgWJd"
             />
             <div
-              class="sc-jHcXXw jkOYNu"
+              class="sc-fHCHyC flfikb"
               style="width: 100%;"
             >
               <div
-                class="sc-fXgAZx hcKfZC"
+                class="sc-dkQUaI bpwCpL"
                 style="width: 100%;"
               />
             </div>
@@ -200,19 +200,19 @@ exports[`Storyshots Core/StatsBar Cpu Usage 1`] = `
           class="sc-gKAaRy bzVAry sc-iCoGMd iQsJTs"
         >
           <div
-            class="sc-EZqKI btQcRO sc-jXcxbT AQTQX"
+            class="sc-WZYut bucJPz sc-ikXwFM hzaHUi"
             color="#fff"
             type="success"
           >
             <div
-              class="sc-bQCEYZ jiukjW"
+              class="sc-dtLLSn hCgWJd"
             />
             <div
-              class="sc-jHcXXw jkOYNu"
+              class="sc-fHCHyC flfikb"
               style="width: 0%;"
             >
               <div
-                class="sc-fXgAZx hcKfZC"
+                class="sc-dkQUaI bpwCpL"
                 style="width: 0%;"
               />
             </div>
@@ -222,19 +222,19 @@ exports[`Storyshots Core/StatsBar Cpu Usage 1`] = `
           class="sc-gKAaRy bzVAry sc-iCoGMd iQsJTs"
         >
           <div
-            class="sc-EZqKI btQcRO sc-jXcxbT AQTQX"
+            class="sc-WZYut bucJPz sc-ikXwFM hzaHUi"
             color="#fff"
             type="success"
           >
             <div
-              class="sc-bQCEYZ jiukjW"
+              class="sc-dtLLSn hCgWJd"
             />
             <div
-              class="sc-jHcXXw jkOYNu"
+              class="sc-fHCHyC flfikb"
               style="width: 0%;"
             >
               <div
-                class="sc-fXgAZx hcKfZC"
+                class="sc-dkQUaI bpwCpL"
                 style="width: 0%;"
               />
             </div>
@@ -244,19 +244,19 @@ exports[`Storyshots Core/StatsBar Cpu Usage 1`] = `
           class="sc-gKAaRy bzVAry sc-iCoGMd gxfzzc"
         >
           <div
-            class="sc-EZqKI btQcRO sc-jXcxbT AQTQX"
+            class="sc-WZYut bucJPz sc-ikXwFM hzaHUi"
             color="#fff"
             type="success"
           >
             <div
-              class="sc-bQCEYZ jiukjW"
+              class="sc-dtLLSn hCgWJd"
             />
             <div
-              class="sc-jHcXXw jkOYNu"
+              class="sc-fHCHyC flfikb"
               style="width: 0%;"
             >
               <div
-                class="sc-fXgAZx hcKfZC"
+                class="sc-dkQUaI bpwCpL"
                 style="width: 0%;"
               />
             </div>
@@ -344,19 +344,19 @@ exports[`Storyshots Core/StatsBar Memory 1`] = `
           class="sc-gKAaRy bzVAry sc-iCoGMd gxfzzc"
         >
           <div
-            class="sc-EZqKI btQcRO sc-jXcxbT AQTQX"
+            class="sc-WZYut bucJPz sc-ikXwFM hzaHUi"
             color="#fff"
             type="success"
           >
             <div
-              class="sc-bQCEYZ jiukjW"
+              class="sc-dtLLSn hCgWJd"
             />
             <div
-              class="sc-jHcXXw jkOYNu"
+              class="sc-fHCHyC flfikb"
               style="width: 45.300000000000004%;"
             >
               <div
-                class="sc-fXgAZx hcKfZC"
+                class="sc-dkQUaI bpwCpL"
                 style="width: 220.75055187637966%;"
               />
             </div>
@@ -444,19 +444,19 @@ exports[`Storyshots Core/StatsBar Storage 1`] = `
           class="sc-gKAaRy bzVAry sc-iCoGMd gxfzzc"
         >
           <div
-            class="sc-EZqKI btQcRO sc-jXcxbT AQTQX"
+            class="sc-WZYut bucJPz sc-ikXwFM hzaHUi"
             color="#fff"
             type="warning"
           >
             <div
-              class="sc-bQCEYZ jiukjW"
+              class="sc-dtLLSn hCgWJd"
             />
             <div
-              class="sc-jHcXXw huuZAy"
+              class="sc-fHCHyC dcLGxn"
               style="width: 62.3%;"
             >
               <div
-                class="sc-fXgAZx hcKfZC"
+                class="sc-dkQUaI bpwCpL"
                 style="width: 160.51364365971108%;"
               />
             </div>


### PR DESCRIPTION
This widget supports numeric values only.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

---
```js
{
		value: 82.63512353,
		schema: {
			type: 'number',
		},
		uiSchema: {
			'ui:title': 'Progress',
			'ui:widget': 'ProgressBar',
			'ui:options': {
				flex: 1,
				alignItems: 'stretch',
				background: '',
				tertiary: true,
			},
		},
	}
```

![Screenshot from 2021-07-14 16-05-46](https://user-images.githubusercontent.com/2925657/125595360-31790983-962b-4163-9c98-dde8ed5253ac.png)

##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
