### PR TITLE
Update downloadOptions to include provisioning key name

### DIFF
--- a/src/hooks/useTranslation.tsx
+++ b/src/hooks/useTranslation.tsx
@@ -60,6 +60,7 @@ const translationMap = {
 	'placeholders.select_edition': 'Select edition',
 
 	'labels.instructions': 'Instructions',
+	'labels.provisioning_key_name': 'Provisioning Key name: ',
 
 	'info.production_and_enterprise_plan_only':
 		'production and enterprise plan only',

--- a/src/unstable-temp/DownloadImageModal/DownloadImageModal.tsx
+++ b/src/unstable-temp/DownloadImageModal/DownloadImageModal.tsx
@@ -71,6 +71,7 @@ export interface DownloadOptions extends FormModel {
 	appId: number;
 	releaseId?: number;
 	deviceType: string;
+	provisioningKeyName?: string;
 	downloadConfigOnly?: boolean;
 	version: string;
 }

--- a/src/unstable-temp/DownloadImageModal/ImageForm.tsx
+++ b/src/unstable-temp/DownloadImageModal/ImageForm.tsx
@@ -13,6 +13,7 @@ import { Txt } from '../../components/Txt';
 import { DownloadFormModel, FormModel } from './FormModel';
 import { DeviceType } from './models';
 import { DownloadOptions } from './DownloadImageModal';
+import { TFunction } from '../../hooks/useTranslation';
 
 const debounceDownloadSize = debounce(
 	(getDownloadSize, deviceType, rawVersion, setDownloadSize) =>
@@ -28,7 +29,7 @@ const debounceDownloadSize = debounce(
 	},
 );
 
-const getDeviceTypeOptions = (deviceType: DeviceType) => {
+const getDeviceTypeOptions = (t: TFunction, deviceType: DeviceType) => {
 	if (!deviceType.options) {
 		return [];
 	}
@@ -43,6 +44,16 @@ const getDeviceTypeOptions = (deviceType: DeviceType) => {
 						wifi: 'Wifi + Ethernet',
 					};
 				}
+			});
+		}
+
+		// Add extra input field to advanced config
+		if (group.name === 'advanced') {
+			group.options.push({
+				message: t('labels.provisioning_key_name'),
+				name: 'provisioningKeyName',
+				default: '',
+				type: 'text',
 			});
 		}
 
@@ -232,7 +243,7 @@ export const ImageForm = ({
 				<DownloadFormModel
 					model={model}
 					onModelChange={setModel}
-					options={getDeviceTypeOptions(deviceType)}
+					options={getDeviceTypeOptions(t, deviceType)}
 				/>
 			</Flex>
 


### PR DESCRIPTION
Change-Type: minor
Signed-off-by: Nitish Agarwal <1592163+nitishagar@users.noreply.github.com>

HQ: https://jel.ly.fish/e450713f-001c-4470-b571-71724aeb0869
See: https://www.flowdock.com/app/rulemotion/r-product/threads/DZt_LvQvMCOoN6p2EceSu6MG4MF
See: https://www.flowdock.com/app/rulemotion/resin-tech/threads/IPdnkCLH2G0o7DSlkSS9nRetA4f
See: https://www.flowdock.com/app/rulemotion/resin-frontend/threads/fDT_EyII9T0EHNyfa9_0VRe4CGU
Depends-on: https://github.com/balena-io/balena-sdk/pull/1111

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
