### PR TITLE
Add `docsIcon` property to DownloadImageModal so it can use the docs icon

### DIFF
--- a/src/hooks/useTranslation.tsx
+++ b/src/hooks/useTranslation.tsx
@@ -97,8 +97,6 @@ const translationMap = {
 	'info.applications_support_devices_with_same_architecture':
 		'Applications can support any devices that share the same architecture as their default device type.',
 
-	'redirects.view_docs': 'View docs',
-
 	// autoUI
 
 	'labels.actions': 'Actions',

--- a/src/unstable-temp/DownloadImageModal/DownloadImageModal.tsx
+++ b/src/unstable-temp/DownloadImageModal/DownloadImageModal.tsx
@@ -27,6 +27,7 @@ import { useTranslation } from '../../hooks/useTranslation';
 import { stripVersionBuild } from './utils';
 import { OsConfiguration } from './OsConfiguration';
 import { FormModel } from './FormModel';
+import { IconProp } from '@fortawesome/fontawesome-svg-core';
 
 export const DeviceLogo = styled(Img)<{ small?: boolean }>`
 	// To prevent Save Image dialog
@@ -111,6 +112,7 @@ export interface UnstableTempDownloadImageModalProps {
 		}
 	>;
 	authToken?: string;
+	docsIcon?: IconProp;
 }
 
 export const UnstableTempDownloadImageModal = ({
@@ -131,6 +133,7 @@ export const UnstableTempDownloadImageModal = ({
 	onClose,
 	modalActions,
 	authToken,
+	docsIcon,
 }: UnstableTempDownloadImageModalProps) => {
 	const { t } = useTranslation();
 	const [deviceType, setDeviceType] = React.useState(initialDeviceType);
@@ -307,6 +310,7 @@ export const UnstableTempDownloadImageModal = ({
 												hasEsrVersions={
 													deviceTypeHasEsr[deviceType.slug] ?? false
 												}
+												docsIcon={docsIcon}
 											/>
 										}
 									/>

--- a/src/unstable-temp/DownloadImageModal/OsConfiguration.tsx
+++ b/src/unstable-temp/DownloadImageModal/OsConfiguration.tsx
@@ -23,6 +23,9 @@ import { DeviceType, OsVersionsByDeviceType } from './models';
 import { useTranslation } from '../../hooks/useTranslation';
 import styled from 'styled-components';
 import { getOsVariantDisplayText } from './utils';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { IconProp } from '@fortawesome/fontawesome-svg-core';
+import { faFileAlt } from '@fortawesome/free-regular-svg-icons/faFileAlt';
 
 export const DownloadImageLabel = styled.label`
 	display: flex;
@@ -45,6 +48,7 @@ interface OsConfigurationProps {
 	onSelectedDeviceTypeChange: (deviceType: DeviceType) => void;
 	onSelectedVersionChange: (osVersion: string) => void;
 	onSelectedOsTypeChange: (osType: string) => void;
+	docsIcon?: IconProp;
 }
 
 export type BuildVariant = 'dev' | 'prod';
@@ -150,6 +154,7 @@ export const OsConfiguration = ({
 	onSelectedVersionChange,
 	onSelectedDeviceTypeChange,
 	onSelectedOsTypeChange,
+	docsIcon,
 }: OsConfigurationProps) => {
 	const { t } = useTranslation();
 	const [showAllVersions, setShowAllVersions] = React.useState(false);
@@ -257,7 +262,10 @@ export const OsConfiguration = ({
 					<Box flex={2} ml={2}>
 						<DownloadImageLabel>
 							{t('placeholders.select_os_type_status')}{' '}
-							<DocsLink href="https://www.balena.io/docs/reference/OS/extended-support-release" />
+							<DocsLink
+								href="https://www.balena.io/docs/reference/OS/extended-support-release"
+								docsIcon={docsIcon}
+							/>
 						</DownloadImageLabel>
 						<OsTypeSelector
 							supportedOsTypes={osTypes}
@@ -324,13 +332,17 @@ export const OsConfiguration = ({
 
 interface DocsLinkProps {
 	href: string;
+	docsIcon?: IconProp;
 }
 
-export const DocsLink = ({ href }: DocsLinkProps) => {
-	const { t } = useTranslation();
+export const DocsLink = ({ href, docsIcon }: DocsLinkProps) => {
 	return (
 		<Link blank href={href} fontSize={2} ml={2}>
-			{t('redirects.view_docs')}
+			{docsIcon ? (
+				<FontAwesomeIcon icon={docsIcon} />
+			) : (
+				<FontAwesomeIcon icon={faFileAlt} />
+			)}
 		</Link>
 	);
 };


### PR DESCRIPTION
Add `docsIcon` property to DownloadImageModal so it can use the docs icon

Depends on: [#4928](https://github.com/balena-io/balena-ui/pull/4928)
Connects to: [#4849](https://github.com/balena-io/balena-ui/issues/4849)
See: https://www.flowdock.com/app/rulemotion/resin-frontend/threads/XclTvdfd1ktHtYfdKXE75Oa_vaV
Change-type: patch
Signed-off-by: Matthew Yarmolinsky <matthew-timothy@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
