### PR TITLE
Add disabled tooltip to DownloadImageModal ("Add device" modal)

### DIFF
--- a/src/hooks/useTranslation.tsx
+++ b/src/hooks/useTranslation.tsx
@@ -33,6 +33,10 @@ const translationMap = {
 		'A tag name group exists on {{count}} other {{itemType}} and will be overwritten.',
 	'warnings.tag_name_group_exists_and_will_be_overwritten_plural':
 		'A tag name group exists on {{count}} other {{itemType}}s and will be overwritten.',
+	'warnings.fill_wifi_credentials':
+		'Please fill in the wifi credentials or select "Ethernet only" in the "Network Connection" section',
+	'warnings.image_deployed_to_docker':
+		'This image is deployed to docker so you can only download its config',
 
 	'errors.no_tags_for_selected_itemtype':
 		'The selected {{itemType}} has no tags',

--- a/src/unstable-temp/DownloadImageModal/ImageForm.tsx
+++ b/src/unstable-temp/DownloadImageModal/ImageForm.tsx
@@ -211,6 +211,11 @@ export const ImageForm = ({
 						primary
 						type="submit"
 						disabled={hasDockerImageDownload}
+						tooltip={
+							hasDockerImageDownload
+								? t('warnings.image_deployed_to_docker')
+								: ''
+						}
 						onClick={() => setDownloadConfigOnly(false)}
 					>
 						<Txt bold={!model.downloadConfigOnly}>
@@ -227,6 +232,11 @@ export const ImageForm = ({
 						className="e2e-download-image-submit"
 						type={!model.downloadConfigOnly ? 'submit' : 'button'}
 						disabled={isDownloadDisabled(model, rawVersion)}
+						tooltip={
+							isDownloadDisabled(model, rawVersion)
+								? t('warnings.fill_wifi_credentials')
+								: ''
+						}
 						onClick={async () => {
 							if (model.downloadConfigOnly && downloadConfig) {
 								setIsDownloadingConfig(true);
@@ -247,6 +257,11 @@ export const ImageForm = ({
 						<Button
 							plain
 							disabled={hasDockerImageDownload}
+							tooltip={
+								hasDockerImageDownload
+									? t('warnings.image_deployed_to_docker')
+									: ''
+							}
 							onClick={() => setDownloadConfigOnly(false)}
 						>
 							<Txt bold={!model.downloadConfigOnly}>


### PR DESCRIPTION
Add disabled tooltip to DownloadImageModal ("Add device" modal)

Connects to: [#4511](https://github.com/balena-io/balena-ui/issues/4511)
Change-type: patch
Signed-off-by: Matthew Yarmolinsky <matthew-timothy@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
