### PR TITLE
Allow null values on autoUIColletion widget

### DIFF
--- a/src/extra/AutoUi/Collection/List.tsx
+++ b/src/extra/AutoUi/Collection/List.tsx
@@ -2,7 +2,12 @@ import React from 'react';
 import { JSONSchema7 as JSONSchema } from 'json-schema';
 import { CollectionLenses } from './Lenses';
 import { Dictionary } from '../../../common-types';
-import { Format, UiSchema, Value } from '../../../components/Renderer/types';
+import {
+	Format,
+	UiSchema,
+	Value,
+	JsonTypes,
+} from '../../../components/Renderer/types';
 import { DataGrid } from '../../../components/DataGrid';
 import { transformUiSchema } from '../../../components/Renderer/widgets/widget-util';
 import { getValue, getWidget } from '../../../components/Renderer';
@@ -10,6 +15,7 @@ import { Table, TableColumn } from '../../../components/Table';
 import type { TableSortFunction } from '../../../components/Table/TableRow';
 import { useHistory } from '../../../hooks/useHistory';
 import { AutoUIContext, AutoUIBaseResource, Priorities } from '../schemaOps';
+import castArray from 'lodash/castArray';
 
 const formatSorters: Dictionary<TableSortFunction<any>> = {};
 
@@ -224,8 +230,12 @@ export const CustomWidget = ({
 	});
 
 	const processedValue = getValue(value, schema, processedUiSchema);
+	const types = schema?.type != null ? castArray(schema.type) : [];
 
-	if (processedValue === undefined || processedValue === null) {
+	if (
+		processedValue === undefined ||
+		(processedValue === null && !types.includes(JsonTypes.null))
+	) {
 		return null;
 	}
 


### PR DESCRIPTION
Allow null values on autoUIColletion widget

Change-type: patch
Signed-off-by: Andrea Rosci <andrear@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
