### PR TITLE
Fix DownloadImageModal alignment when there are not multiple compatible device types

### DIFF
--- a/src/unstable-temp/DownloadImageModal/OsConfiguration.tsx
+++ b/src/unstable-temp/DownloadImageModal/OsConfiguration.tsx
@@ -240,9 +240,9 @@ export const OsConfiguration = ({
 
 	return (
 		<>
-			<Flex mb={3}>
+			<Flex mb={3} mx={-2}>
 				{compatibleDeviceTypes.length > 1 && (
-					<Box flex={3} mr={2}>
+					<Box flex={3} mx={2}>
 						<DownloadImageLabel>
 							{t('placeholders.select_device_type')}
 							<QuestionMark
@@ -259,7 +259,7 @@ export const OsConfiguration = ({
 					</Box>
 				)}
 				{(!isInitialDefault || !selectedOsType) && hasEsrVersions && (
-					<Box flex={2} ml={2}>
+					<Box flex={2} mx={2}>
 						<DownloadImageLabel>
 							{t('placeholders.select_os_type_status')}{' '}
 							<DocsLink
@@ -282,8 +282,8 @@ export const OsConfiguration = ({
 						{t('placeholders.select_version')}
 					</DownloadImageLabel>
 
-					<Flex alignItems="center">
-						<Box flex={3} mr={2}>
+					<Flex alignItems="center" mx={-2}>
+						<Box flex={3} mx={2}>
 							<Select<VersionSelectionOptions>
 								id="e2e-download-image-versions-list"
 								valueKey="value"
@@ -299,7 +299,7 @@ export const OsConfiguration = ({
 						</Box>
 
 						{shouldShowAllVersionsToggle && (
-							<Box flex={2} ml={2}>
+							<Box flex={2} mx={2}>
 								<Checkbox
 									checked={showAllVersions}
 									label={'Show outdated versions'}


### PR DESCRIPTION
Fix DownloadImageModal alignment when there are not multiple compatible device types

See: https://www.flowdock.com/app/rulemotion/resin-frontend/threads/6s0dQE2ma902xeyIg3Fbg1dJxei
Change-type: patch
Signed-off-by: Matthew Yarmolinsky <matthew-timothy@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
