### PR TITLE
Add onRowClick dependency to AutoUIColleciton autouiContext useMemo

### DIFF
--- a/src/extra/AutoUi/Collection/index.tsx
+++ b/src/extra/AutoUi/Collection/index.tsx
@@ -222,7 +222,7 @@ export const AutoUICollection = <T extends AutoUIBaseResource<T>>({
 				customSort,
 				sdk,
 			} as AutoUIContext<T>),
-		[model, actions, cardRenderer, sdk],
+		[model, actions, cardRenderer, sdk, onRowClick],
 	);
 
 	const filtered = React.useMemo(


### PR DESCRIPTION
Add onRowClick dependency to AutoUIColleciton autouiContext useMemo

Change-type: patch
Signed-off-by: Matthew Yarmolinsky <matthew-timothy@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
