### PR TITLE
Add a widgetFactory to infer the value type based on the supported types

### DIFF
--- a/src/common-types.ts
+++ b/src/common-types.ts
@@ -13,6 +13,8 @@ import {
 
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 
+export type Overwrite<T, U> = Pick<T, Exclude<keyof T, keyof U>> & U;
+
 export { Theme } from './theme';
 
 export interface StyledSystemProps

--- a/src/components/Renderer/index.tsx
+++ b/src/components/Renderer/index.tsx
@@ -20,6 +20,7 @@ import {
 import { transformUiSchema, getBestSchemaMatch } from './widgets/widget-util';
 import { Value, JSONSchema, UiSchema, Format, JsonTypes } from './types';
 import { WidgetContext } from '../../contexts/WidgetContext';
+export { Widget, WidgetProps, widgetFactory } from './widgets/widget-util';
 
 export const getValue = (
 	value?: Value,

--- a/src/components/Renderer/types.ts
+++ b/src/components/Renderer/types.ts
@@ -13,6 +13,16 @@ export const JsonTypes = {
 	null: 'null',
 } as const;
 
+export interface JsonTypesTypeMap {
+	array: unknown[];
+	object: {};
+	number: number;
+	integer: number;
+	string: string;
+	boolean: boolean;
+	null: null;
+}
+
 export type DefinedValue =
 	| number
 	| string

--- a/src/components/Renderer/widgets/ArrayWidget.tsx
+++ b/src/components/Renderer/widgets/ArrayWidget.tsx
@@ -2,19 +2,22 @@ import * as React from 'react';
 import map from 'lodash/map';
 import get from 'lodash/get';
 import { Flex } from '../../Flex';
-import { Widget, WidgetProps, getArrayItems } from './widget-util';
+import { widgetFactory, getArrayItems } from './widget-util';
 import { Renderer } from '../index';
 import { JsonTypes } from '../types';
 import { UiOption } from './ui-options';
 
-const ArrayWidget: Widget = ({
-	value,
-	schema,
-	uiSchema,
-	extraContext,
-	extraFormats,
-	...rest
-}: WidgetProps) => {
+const ArrayWidget = widgetFactory(
+	'Array',
+	{
+		orientation: {
+			...UiOption.string,
+			enum: ['vertical', 'horizontal'],
+		},
+		truncate: UiOption.integer,
+	},
+	[JsonTypes.array],
+)(({ value, schema, uiSchema, extraContext, extraFormats, ...rest }) => {
 	const items = getArrayItems({
 		value,
 		schema,
@@ -31,23 +34,11 @@ const ArrayWidget: Widget = ({
 			}
 			flexWrap="wrap"
 		>
-			{map(items, (item: WidgetProps, index: number) => {
+			{map(items, (item, index) => {
 				return <Renderer key={index} nested {...item} {...rest} />;
 			})}
 		</Flex>
 	);
-};
-
-ArrayWidget.displayName = 'Array';
-
-ArrayWidget.uiOptions = {
-	orientation: {
-		...UiOption.string,
-		enum: ['vertical', 'horizontal'],
-	},
-	truncate: UiOption.integer,
-};
-
-ArrayWidget.supportedTypes = [JsonTypes.array];
+});
 
 export default ArrayWidget;

--- a/src/components/Renderer/widgets/BadgeWidget.tsx
+++ b/src/components/Renderer/widgets/BadgeWidget.tsx
@@ -3,15 +3,17 @@ import get from 'lodash/get';
 import { Badge } from '../../Badge';
 import { hashCode } from '../../../utils';
 import { UiOption } from './ui-options';
-import { Widget, WidgetProps } from './widget-util';
+import { widgetFactory } from './widget-util';
 import { JsonTypes } from '../types';
 
-const BadgeWidget: Widget = ({
-	value,
-	schema,
-	uiSchema,
-	...props
-}: WidgetProps) => {
+const BadgeWidget = widgetFactory(
+	'Badge',
+	{
+		shade: UiOption.number,
+	},
+	[JsonTypes.string, JsonTypes.integer, JsonTypes.number, JsonTypes.boolean],
+)(({ value, schema, uiSchema, ...props }) => {
+	// TODO: check whether we really need this
 	if (value == null) {
 		return null;
 	}
@@ -21,19 +23,6 @@ const BadgeWidget: Widget = ({
 			{value.toString()}
 		</Badge>
 	);
-};
-
-BadgeWidget.displayName = 'Badge';
-
-BadgeWidget.uiOptions = {
-	shade: UiOption.number,
-};
-
-BadgeWidget.supportedTypes = [
-	JsonTypes.string,
-	JsonTypes.integer,
-	JsonTypes.number,
-	JsonTypes.boolean,
-];
+});
 
 export default BadgeWidget;

--- a/src/components/Renderer/widgets/ButtonGroupWidget.tsx
+++ b/src/components/Renderer/widgets/ButtonGroupWidget.tsx
@@ -3,12 +3,7 @@ import isArray from 'lodash/isArray';
 import get from 'lodash/get';
 import map from 'lodash/map';
 import { ButtonGroup } from '../../ButtonGroup';
-import {
-	Widget,
-	WidgetProps,
-	getArrayItems,
-	withOptionProps,
-} from './widget-util';
+import { widgetFactory, getArrayItems, withOptionProps } from './widget-util';
 import { JsonTypes } from '../types';
 import ButtonWidget from './ButtonWidget';
 
@@ -18,43 +13,32 @@ const WrappedButtonWidget = ButtonWidget.uiOptions
 	? withOptionProps(ButtonWidget.uiOptions)(ButtonWidget)
 	: ButtonWidget;
 
-const ButtonGroupWidget: Widget = ({
-	value,
-	schema,
-	uiSchema,
-	extraContext,
-	extraFormats,
-	...props
-}: WidgetProps) => {
-	if (!isArray(value)) {
-		throw new Error(
-			`ButtonGroupWidget cannot be used to render a value of type '${typeof value}'`,
+const ButtonGroupWidget = widgetFactory('ButtonGroup', {}, [JsonTypes.array])(
+	({ value, schema, uiSchema, extraContext, extraFormats, ...props }) => {
+		if (!isArray(value)) {
+			throw new Error(
+				`ButtonGroupWidget cannot be used to render a value of type '${typeof value}'`,
+			);
+		}
+		const itemType = get(schema, ['items', 'type'], 'undefined');
+		if (!validItemTypes.includes(itemType)) {
+			throw new Error(
+				`ButtonGroupWidget cannot be used to render an array of items of type ${itemType}`,
+			);
+		}
+		const items = getArrayItems({ value, schema, uiSchema, extraContext });
+		return (
+			<ButtonGroup {...props}>
+				{map(items, (item, index) => (
+					<WrappedButtonWidget
+						key={index}
+						{...item}
+						extraFormats={extraFormats}
+					/>
+				))}
+			</ButtonGroup>
 		);
-	}
-	const itemType = get(schema, ['items', 'type'], 'undefined');
-	if (!validItemTypes.includes(itemType)) {
-		throw new Error(
-			`ButtonGroupWidget cannot be used to render an array of items of type ${itemType}`,
-		);
-	}
-	const items = getArrayItems({ value, schema, uiSchema, extraContext });
-	return (
-		<ButtonGroup {...props}>
-			{map(items, (item: WidgetProps, index: number) => (
-				<WrappedButtonWidget
-					key={index}
-					{...item}
-					extraFormats={extraFormats}
-				/>
-			))}
-		</ButtonGroup>
-	);
-};
-
-ButtonGroupWidget.displayName = 'ButtonGroup';
-
-ButtonGroupWidget.uiOptions = {};
-
-ButtonGroupWidget.supportedTypes = [JsonTypes.array];
+	},
+);
 
 export default ButtonGroupWidget;

--- a/src/components/Renderer/widgets/ButtonWidget.tsx
+++ b/src/components/Renderer/widgets/ButtonWidget.tsx
@@ -1,49 +1,37 @@
 import * as React from 'react';
 import { Button } from '../../Button';
 import { UiOption } from './ui-options';
-import { Widget, WidgetProps } from './widget-util';
+import { widgetFactory } from './widget-util';
 import { JsonTypes } from '../types';
 
-const ButtonWidget: Widget = ({
-	value,
-	schema,
-	uiSchema,
-	...props
-}: WidgetProps) => {
+const ButtonWidget = widgetFactory(
+	'Button',
+	{
+		href: UiOption.string,
+		target: {
+			...UiOption.string,
+			enum: ['_blank', '_self', '_parent', '_top'],
+		},
+		disabled: UiOption.boolean,
+		primary: UiOption.boolean,
+		secondary: UiOption.boolean,
+		tertiary: UiOption.boolean,
+		quarternary: UiOption.boolean,
+		danger: UiOption.boolean,
+		warning: UiOption.boolean,
+		success: UiOption.boolean,
+		info: UiOption.boolean,
+		light: UiOption.boolean,
+		outline: UiOption.boolean,
+		plain: UiOption.boolean,
+		underline: UiOption.boolean,
+	},
+	[JsonTypes.string, JsonTypes.boolean, JsonTypes.integer, JsonTypes.boolean],
+)(({ value, schema, uiSchema, ...props }) => {
 	if (value == null) {
 		return null;
 	}
 	return <Button {...props}>{value.toString()}</Button>;
-};
-
-ButtonWidget.displayName = 'Button';
-
-ButtonWidget.uiOptions = {
-	href: UiOption.string,
-	target: {
-		...UiOption.string,
-		enum: ['_blank', '_self', '_parent', '_top'],
-	},
-	disabled: UiOption.boolean,
-	primary: UiOption.boolean,
-	secondary: UiOption.boolean,
-	tertiary: UiOption.boolean,
-	quarternary: UiOption.boolean,
-	danger: UiOption.boolean,
-	warning: UiOption.boolean,
-	success: UiOption.boolean,
-	info: UiOption.boolean,
-	light: UiOption.boolean,
-	outline: UiOption.boolean,
-	plain: UiOption.boolean,
-	underline: UiOption.boolean,
-};
-
-ButtonWidget.supportedTypes = [
-	JsonTypes.string,
-	JsonTypes.boolean,
-	JsonTypes.integer,
-	JsonTypes.boolean,
-];
+});
 
 export default ButtonWidget;

--- a/src/components/Renderer/widgets/CheckboxWidget.tsx
+++ b/src/components/Renderer/widgets/CheckboxWidget.tsx
@@ -2,26 +2,19 @@ import * as React from 'react';
 import noop from 'lodash/noop';
 import { Checkbox } from '../../Checkbox';
 import { UiOption } from './ui-options';
-import { Widget, WidgetProps } from './widget-util';
+import { widgetFactory } from './widget-util';
 import { JsonTypes } from '../types';
 
-const CheckboxWidget: Widget = ({
-	value,
-	schema,
-	uiSchema,
-	...props
-}: WidgetProps) => {
+const CheckboxWidget = widgetFactory(
+	'Checkbox',
+	{
+		label: UiOption.string,
+		reverse: UiOption.boolean,
+		toggle: UiOption.boolean,
+	},
+	[JsonTypes.boolean],
+)(({ value, schema, uiSchema, ...props }) => {
 	return <Checkbox {...props} checked={Boolean(value)} onChange={noop} />;
-};
-
-CheckboxWidget.displayName = 'Checkbox';
-
-CheckboxWidget.uiOptions = {
-	label: UiOption.string,
-	reverse: UiOption.boolean,
-	toggle: UiOption.boolean,
-};
-
-CheckboxWidget.supportedTypes = [JsonTypes.boolean];
+});
 
 export default CheckboxWidget;

--- a/src/components/Renderer/widgets/ColorWidget.tsx
+++ b/src/components/Renderer/widgets/ColorWidget.tsx
@@ -9,60 +9,61 @@ import { Flex } from '../../Flex';
 import { Txt } from '../../Txt';
 import { JsonTypes } from '../types';
 import { UiOption } from './ui-options';
-import { Widget, WidgetProps } from './widget-util';
+import { widgetFactory } from './widget-util';
 import { isLight } from '../../../utils/colorUtils';
 
 const DEFAULT_WIDTH = '100px';
 const DEFAULT_HEIGHT = '100px';
 
-interface ColorWidgetProps extends WidgetProps {
+interface ExtraColorWidgetProps {
 	label?: string;
 	hideValueDisplay?: boolean;
 	width?: string | number;
 	height?: string | number;
 }
 
-const ColorWidget: Widget = ({
-	value,
-	schema,
-	uiSchema,
-	label,
-	hideValueDisplay,
-	width = DEFAULT_WIDTH,
-	height = DEFAULT_HEIGHT,
-	...props
-}: ColorWidgetProps) => {
-	if (value == null) {
-		return null;
-	}
-	const bg = value.toString() || 'transparent';
-	const color = isLight(bg) ? '#000' : '#FFF';
-	return (
-		<Flex
-			{...props}
-			width={width}
-			height={height}
-			bg={bg}
-			color={color}
-			alignItems="center"
-			flexDirection="column"
-			justifyContent="center"
-		>
-			{label && <Txt>{label}</Txt>}
-			{!hideValueDisplay && <Txt>{value}</Txt>}
-		</Flex>
-	);
-};
+const ColorWidget = widgetFactory(
+	'Color',
+	{
+		label: UiOption.string,
+		hideValueDisplay: UiOption.bool,
+		width: UiOption.space,
+		height: UiOption.space,
+	},
+	[JsonTypes.string],
+)<object, ExtraColorWidgetProps>(
+	({
+		value,
+		schema,
+		uiSchema,
+		label,
+		hideValueDisplay,
+		width = DEFAULT_WIDTH,
+		height = DEFAULT_HEIGHT,
+		...props
+	}) => {
+		if (value == null) {
+			return null;
+		}
 
-ColorWidget.displayName = 'Color';
-
-ColorWidget.uiOptions = {
-	label: UiOption.string,
-	hideValueDisplay: UiOption.bool,
-	width: UiOption.space,
-	height: UiOption.space,
-};
-
-ColorWidget.supportedTypes = [JsonTypes.string];
+		const bg = value.toString() || 'transparent';
+		const color = isLight(bg) ? '#000' : '#FFF';
+		return (
+			<Flex
+				{...props}
+				width={width}
+				height={height}
+				bg={bg}
+				color={color}
+				alignItems="center"
+				flexDirection="column"
+				justifyContent="center"
+			>
+				{label && <Txt>{label}</Txt>}
+				{!hideValueDisplay && <Txt>{value}</Txt>}
+			</Flex>
+		);
+	},
+);
 
 export default ColorWidget;

--- a/src/components/Renderer/widgets/DropDownButtonWidget.tsx
+++ b/src/components/Renderer/widgets/DropDownButtonWidget.tsx
@@ -3,21 +3,35 @@ import isArray from 'lodash/isArray';
 import get from 'lodash/get';
 import map from 'lodash/map';
 import { DropDownButton } from '../../DropDownButton';
-import { Widget, WidgetProps, getArrayItems } from './widget-util';
+import { widgetFactory, getArrayItems } from './widget-util';
 import { JsonTypes } from '../types';
 import { UiOption } from './ui-options';
 import { Renderer } from '../index';
 
 const validItemTypes = ['string', 'integer', 'number'];
 
-const DropDownButtonWidget: Widget = ({
-	value,
-	schema,
-	uiSchema,
-	extraContext,
-	extraFormats,
-	...props
-}: WidgetProps) => {
+const DropDownButtonWidget = widgetFactory(
+	'DropDownButton',
+	{
+		label: UiOption.string,
+		disabled: UiOption.boolean,
+		primary: UiOption.boolean,
+		secondary: UiOption.boolean,
+		tertiary: UiOption.boolean,
+		quarternary: UiOption.boolean,
+		danger: UiOption.boolean,
+		warning: UiOption.boolean,
+		success: UiOption.boolean,
+		info: UiOption.boolean,
+		emphasized: UiOption.boolean,
+		square: UiOption.boolean,
+		border: UiOption.boolean,
+		joined: UiOption.boolean,
+		alignRight: UiOption.boolean,
+		listMaxHeight: UiOption.space,
+	},
+	[JsonTypes.array],
+)(({ value, schema, uiSchema, extraContext, extraFormats, ...props }) => {
 	if (!isArray(value)) {
 		throw new Error(
 			`DropDownButtonWidget cannot be used to render a value of type '${typeof value}'`,
@@ -32,34 +46,11 @@ const DropDownButtonWidget: Widget = ({
 	const items = getArrayItems({ value, schema, uiSchema, extraContext });
 	return (
 		<DropDownButton {...props}>
-			{map(items, (item: WidgetProps, index: number) => (
+			{map(items, (item, index) => (
 				<Renderer key={index} {...item} extraFormats={extraFormats} />
 			))}
 		</DropDownButton>
 	);
-};
-
-DropDownButtonWidget.displayName = 'DropDownButton';
-
-DropDownButtonWidget.uiOptions = {
-	label: UiOption.string,
-	disabled: UiOption.boolean,
-	primary: UiOption.boolean,
-	secondary: UiOption.boolean,
-	tertiary: UiOption.boolean,
-	quarternary: UiOption.boolean,
-	danger: UiOption.boolean,
-	warning: UiOption.boolean,
-	success: UiOption.boolean,
-	info: UiOption.boolean,
-	emphasized: UiOption.boolean,
-	square: UiOption.boolean,
-	border: UiOption.boolean,
-	joined: UiOption.boolean,
-	alignRight: UiOption.boolean,
-	listMaxHeight: UiOption.space,
-};
-
-DropDownButtonWidget.supportedTypes = [JsonTypes.array];
+});
 
 export default DropDownButtonWidget;

--- a/src/components/Renderer/widgets/ElapsedTimeWidget.tsx
+++ b/src/components/Renderer/widgets/ElapsedTimeWidget.tsx
@@ -3,21 +3,19 @@ import { Txt } from '../../Txt';
 import { JsonTypes } from '../types';
 
 import { UiOption } from './ui-options';
-import { Widget, WidgetProps } from './widget-util';
+import { widgetFactory } from './widget-util';
 import { formatTimestamp, timeSince } from './widget-util';
 
-export const ElapsedTimeWidget: Widget = ({
-	value,
-}: Omit<WidgetProps, 'value'> & { value: any }) => {
+export const ElapsedTimeWidget = widgetFactory(
+	'ElapsedTime',
+	{
+		dtFormat: UiOption.string,
+	},
+	[JsonTypes.string, JsonTypes.number],
+)(({ value }) => {
 	if (!value) {
 		return null;
 	}
 
 	return <Txt tooltip={formatTimestamp(value)}>{timeSince(value)}</Txt>;
-};
-
-ElapsedTimeWidget.displayName = 'ElapsedTime';
-ElapsedTimeWidget.uiOptions = {
-	dtFormat: UiOption.string,
-};
-ElapsedTimeWidget.supportedTypes = [JsonTypes.string, JsonTypes.number];
+});

--- a/src/components/Renderer/widgets/HeadingWidget.tsx
+++ b/src/components/Renderer/widgets/HeadingWidget.tsx
@@ -2,36 +2,30 @@ import * as React from 'react';
 import get from 'lodash/get';
 import { Heading } from '../../Heading';
 import { UiOption } from './ui-options';
-import { Widget, WidgetProps } from './widget-util';
+import { widgetFactory } from './widget-util';
 import { JsonTypes } from '../types';
 
-interface HeadingWidgetProps extends WidgetProps {
+interface ExtraHeadingWidgetProps {
 	size: 1 | 2 | 3 | 4 | 5 | 6;
 }
 
-const HeadingWidget: Widget = ({
-	value,
-	schema,
-	uiSchema,
-	size,
-	...props
-}: HeadingWidgetProps) => {
-	if (value == null) {
-		return null;
-	}
-	const HeadingComponent = get(Heading, `h${size}`, Heading.h3);
-	return <HeadingComponent {...props}>{value.toString()}</HeadingComponent>;
-};
-
-HeadingWidget.displayName = 'Heading';
-
-HeadingWidget.uiOptions = {
-	size: {
-		...UiOption.number,
-		enum: [1, 2, 3, 4, 5, 6],
+const HeadingWidget = widgetFactory(
+	'Heading',
+	{
+		size: {
+			...UiOption.number,
+			enum: [1, 2, 3, 4, 5, 6],
+		},
 	},
-};
-
-HeadingWidget.supportedTypes = [JsonTypes.string];
+	[JsonTypes.string],
+)<object, ExtraHeadingWidgetProps>(
+	({ value, schema, uiSchema, size, ...props }) => {
+		if (value == null) {
+			return null;
+		}
+		const HeadingComponent = get(Heading, `h${size}`, Heading.h3);
+		return <HeadingComponent {...props}>{value.toString()}</HeadingComponent>;
+	},
+);
 
 export default HeadingWidget;

--- a/src/components/Renderer/widgets/HighlightedNameWidget.tsx
+++ b/src/components/Renderer/widgets/HighlightedNameWidget.tsx
@@ -2,16 +2,18 @@ import * as React from 'react';
 import get from 'lodash/get';
 import { HighlightedName } from '../../HighlightedName';
 import { UiOption } from './ui-options';
-import { Widget, WidgetProps } from './widget-util';
+import { widgetFactory } from './widget-util';
 import { JsonTypes } from '../types';
 import { generateColorFromString, isLight } from '../../../utils/colorUtils';
 
-const HighlightedNameWidget: Widget = ({
-	value,
-	schema,
-	uiSchema,
-	...props
-}: WidgetProps) => {
+const HighlightedNameWidget = widgetFactory(
+	'HighlightedName',
+	{
+		bg: UiOption.string,
+		color: UiOption.string,
+	},
+	[JsonTypes.string, JsonTypes.integer, JsonTypes.number, JsonTypes.boolean],
+)(({ value, schema, uiSchema, ...props }) => {
 	if (value == null) {
 		return null;
 	}
@@ -22,20 +24,6 @@ const HighlightedNameWidget: Widget = ({
 			{value.toString()}
 		</HighlightedName>
 	);
-};
-
-HighlightedNameWidget.displayName = 'HighlightedName';
-
-HighlightedNameWidget.uiOptions = {
-	bg: UiOption.string,
-	color: UiOption.string,
-};
-
-HighlightedNameWidget.supportedTypes = [
-	JsonTypes.string,
-	JsonTypes.integer,
-	JsonTypes.number,
-	JsonTypes.boolean,
-];
+});
 
 export default HighlightedNameWidget;

--- a/src/components/Renderer/widgets/ImgWidget.tsx
+++ b/src/components/Renderer/widgets/ImgWidget.tsx
@@ -1,43 +1,36 @@
 import * as React from 'react';
 import { Img } from '../../Img';
 import { UiOption } from './ui-options';
-import { Widget, WidgetProps } from './widget-util';
+import { widgetFactory } from './widget-util';
 import { JsonTypes } from '../types';
 
-const ImgWidget: Widget = ({
-	value,
-	schema,
-	uiSchema,
-	...props
-}: WidgetProps) => {
+const ImgWidget = widgetFactory(
+	'Img',
+	{
+		alt: UiOption.string,
+		height: UiOption.space,
+		width: UiOption.space,
+		crossorigin: {
+			...UiOption.string,
+			enum: ['anonymous', 'use-credentials'],
+		},
+		decoding: {
+			...UiOption.string,
+			enum: ['sync', 'async', 'auto'],
+		},
+		loading: {
+			...UiOption.string,
+			enum: ['eager', 'lazy'],
+		},
+		sizes: UiOption.string,
+		srcset: UiOption.string,
+	},
+	[JsonTypes.string],
+)(({ value, schema, uiSchema, ...props }) => {
 	if (value == null) {
 		return null;
 	}
 	return <Img {...props} src={value.toString()} />;
-};
-
-ImgWidget.uiOptions = {
-	alt: UiOption.string,
-	height: UiOption.space,
-	width: UiOption.space,
-	crossorigin: {
-		...UiOption.string,
-		enum: ['anonymous', 'use-credentials'],
-	},
-	decoding: {
-		...UiOption.string,
-		enum: ['sync', 'async', 'auto'],
-	},
-	loading: {
-		...UiOption.string,
-		enum: ['eager', 'lazy'],
-	},
-	sizes: UiOption.string,
-	srcset: UiOption.string,
-};
-
-ImgWidget.displayName = 'Img';
-
-ImgWidget.supportedTypes = [JsonTypes.string];
+});
 
 export default ImgWidget;

--- a/src/components/Renderer/widgets/LinkWidget.tsx
+++ b/src/components/Renderer/widgets/LinkWidget.tsx
@@ -2,15 +2,20 @@ import * as React from 'react';
 import get from 'lodash/get';
 import { Link } from '../../Link';
 import { UiOption } from './ui-options';
-import { Widget, WidgetProps } from './widget-util';
+import { widgetFactory } from './widget-util';
 import { JsonTypes } from '../types';
 
-const LinkWidget: Widget = ({
-	value,
-	schema,
-	uiSchema,
-	...props
-}: WidgetProps) => {
+const LinkWidget = widgetFactory(
+	'Link',
+	{
+		blank: UiOption.boolean,
+		download: UiOption.string,
+		href: UiOption.string,
+		rel: UiOption.string,
+		type: UiOption.string,
+	},
+	[JsonTypes.string],
+)(({ value, schema, uiSchema, ...props }) => {
 	if (value == null) {
 		return null;
 	}
@@ -23,18 +28,6 @@ const LinkWidget: Widget = ({
 			{value.toString()}
 		</Link>
 	);
-};
-
-LinkWidget.displayName = 'Link';
-
-LinkWidget.uiOptions = {
-	blank: UiOption.boolean,
-	download: UiOption.string,
-	href: UiOption.string,
-	rel: UiOption.string,
-	type: UiOption.string,
-};
-
-LinkWidget.supportedTypes = [JsonTypes.string];
+});
 
 export default LinkWidget;

--- a/src/components/Renderer/widgets/ListWidget.tsx
+++ b/src/components/Renderer/widgets/ListWidget.tsx
@@ -1,49 +1,54 @@
 import * as React from 'react';
 import map from 'lodash/map';
 import { List } from '../../List';
-import { Widget, WidgetProps, getArrayItems } from './widget-util';
+import { widgetFactory, getArrayItems } from './widget-util';
 import { Renderer } from '../index';
 import { JsonTypes } from '../types';
 import { UiOption } from './ui-options';
 
-interface ListWidgetProps extends WidgetProps {
+interface ExtraListWidgetProps {
 	truncate: number;
 }
 
-const ListWidget: Widget = ({
-	value,
-	schema,
-	uiSchema,
-	truncate,
-	extraFormats,
-	extraContext,
-	...props
-}: ListWidgetProps) => {
-	const items = getArrayItems({
+const ListWidget = widgetFactory(
+	'List',
+	{
+		truncate: UiOption.integer,
+		ordered: UiOption.boolean,
+	},
+	[JsonTypes.array],
+)<object, ExtraListWidgetProps>(
+	({
 		value,
 		schema,
 		uiSchema,
-		extraContext,
+		truncate,
 		extraFormats,
-	});
-	return (
-		<List {...props}>
-			{map(items, (item: WidgetProps, index: number) => {
-				return (
-					<Renderer key={index} nested {...item} extraFormats={extraFormats} />
-				);
-			})}
-		</List>
-	);
-};
-
-ListWidget.displayName = 'List';
-
-ListWidget.uiOptions = {
-	truncate: UiOption.integer,
-	ordered: UiOption.boolean,
-};
-
-ListWidget.supportedTypes = [JsonTypes.array];
+		extraContext,
+		...props
+	}) => {
+		const items = getArrayItems({
+			value,
+			schema,
+			uiSchema,
+			extraContext,
+			extraFormats,
+		});
+		return (
+			<List {...props}>
+				{map(items, (item, index) => {
+					return (
+						<Renderer
+							key={index}
+							nested
+							{...item}
+							extraFormats={extraFormats}
+						/>
+					);
+				})}
+			</List>
+		);
+	},
+);
 
 export default ListWidget;

--- a/src/components/Renderer/widgets/ObjectWidget.tsx
+++ b/src/components/Renderer/widgets/ObjectWidget.tsx
@@ -1,35 +1,32 @@
 import * as React from 'react';
 import get from 'lodash/get';
 import map from 'lodash/map';
-import { Widget, WidgetProps, getObjectPropertyNames } from './widget-util';
+import {
+	widgetFactory,
+	WidgetProps,
+	getObjectPropertyNames,
+} from './widget-util';
 import { JsonTypes } from '../types';
 import { Renderer } from '../index';
 
-const ObjectWidget: Widget = ({
-	value,
-	schema,
-	uiSchema,
-	...rest
-}: WidgetProps) => {
-	const propertyNames = getObjectPropertyNames({ value, schema, uiSchema });
-	return (
-		<React.Fragment>
-			{map(propertyNames, (key: string) => {
-				const subProps: WidgetProps = {
-					value: get(value, key),
-					schema: get(schema, ['properties', key]),
-					uiSchema: get(uiSchema, key),
-				};
-				return (
-					<Renderer key={key} nested valueKey={key} {...subProps} {...rest} />
-				);
-			})}
-		</React.Fragment>
-	);
-};
-
-ObjectWidget.displayName = 'Object';
-
-ObjectWidget.supportedTypes = [JsonTypes.object];
+const ObjectWidget = widgetFactory('Object', undefined, [JsonTypes.object])(
+	({ value, schema, uiSchema, ...rest }) => {
+		const propertyNames = getObjectPropertyNames({ value, schema, uiSchema });
+		return (
+			<React.Fragment>
+				{map(propertyNames, (key: string) => {
+					const subProps: WidgetProps = {
+						value: get(value, key),
+						schema: get(schema, ['properties', key]),
+						uiSchema: get(uiSchema, key),
+					};
+					return (
+						<Renderer key={key} nested valueKey={key} {...subProps} {...rest} />
+					);
+				})}
+			</React.Fragment>
+		);
+	},
+);
 
 export default ObjectWidget;

--- a/src/components/Renderer/widgets/ProgressBarWidget.tsx
+++ b/src/components/Renderer/widgets/ProgressBarWidget.tsx
@@ -1,21 +1,29 @@
 import * as React from 'react';
 import { ProgressBar } from '../../ProgressBar';
 import { UiOption } from './ui-options';
-import { Widget, WidgetProps } from './widget-util';
+import { widgetFactory } from './widget-util';
 import { JsonTypes } from '../types';
 
 // Note: this widget works best when the following 'ui:options' are specified:
 // 	 flex: 1
 //   alignItems: 'stretch'
 
-const ProgressBarWidget: Widget = ({
-	value,
-	schema,
-	uiSchema,
-	extraContext,
-	extraFormats,
-	...props
-}: WidgetProps) => {
+const ProgressBarWidget = widgetFactory(
+	'ProgressBar',
+	{
+		background: UiOption.string,
+		primary: UiOption.boolean,
+		secondary: UiOption.boolean,
+		tertiary: UiOption.boolean,
+		quartenary: UiOption.boolean,
+		danger: UiOption.boolean,
+		warning: UiOption.boolean,
+		success: UiOption.boolean,
+		info: UiOption.boolean,
+		emphasized: UiOption.boolean,
+	},
+	[JsonTypes.integer, JsonTypes.number],
+)(({ value, schema, uiSchema, extraContext, extraFormats, ...props }) => {
 	if (value == null) {
 		return null;
 	}
@@ -29,23 +37,6 @@ const ProgressBarWidget: Widget = ({
 			{value.toFixed(0)}%
 		</ProgressBar>
 	);
-};
-
-ProgressBarWidget.displayName = 'ProgressBar';
-
-ProgressBarWidget.uiOptions = {
-	background: UiOption.string,
-	primary: UiOption.boolean,
-	secondary: UiOption.boolean,
-	tertiary: UiOption.boolean,
-	quartenary: UiOption.boolean,
-	danger: UiOption.boolean,
-	warning: UiOption.boolean,
-	success: UiOption.boolean,
-	info: UiOption.boolean,
-	emphasized: UiOption.boolean,
-};
-
-ProgressBarWidget.supportedTypes = [JsonTypes.integer, JsonTypes.number];
+});
 
 export default ProgressBarWidget;

--- a/src/components/Renderer/widgets/TagWidget.tsx
+++ b/src/components/Renderer/widgets/TagWidget.tsx
@@ -1,32 +1,21 @@
 import * as React from 'react';
 import { Tag } from '../../Tag';
 import { UiOption } from './ui-options';
-import { Widget, WidgetProps } from './widget-util';
+import { widgetFactory } from './widget-util';
 import { JsonTypes } from '../types';
 
-const TagWidget: Widget = ({
-	value,
-	schema,
-	uiSchema,
-	...props
-}: WidgetProps) => {
+const TagWidget = widgetFactory(
+	'Tag',
+	{
+		operator: UiOption.boolean,
+		name: UiOption.string,
+	},
+	[JsonTypes.string, JsonTypes.integer, JsonTypes.number],
+)(({ value, schema, uiSchema, ...props }) => {
 	if (value == null) {
 		return null;
 	}
 	return <Tag {...props} value={value.toString()} />;
-};
-
-TagWidget.displayName = 'Tag';
-
-TagWidget.uiOptions = {
-	operator: UiOption.boolean,
-	name: UiOption.string,
-};
-
-TagWidget.supportedTypes = [
-	JsonTypes.string,
-	JsonTypes.integer,
-	JsonTypes.number,
-];
+});
 
 export default TagWidget;

--- a/src/components/Renderer/widgets/TxtWidget.tsx
+++ b/src/components/Renderer/widgets/TxtWidget.tsx
@@ -6,7 +6,7 @@ import styled from 'styled-components';
 import { Txt } from '../../Txt';
 import { JsonTypes, Value, UiSchema } from '../types';
 import { UiOption } from './ui-options';
-import { Widget, WidgetProps, formatTimestamp } from './widget-util';
+import { widgetFactory, formatTimestamp } from './widget-util';
 
 const SingleLineTxt = styled(Txt)`
 	white-space: nowrap;
@@ -28,14 +28,54 @@ const getArrayValue = (value: Value[], uiSchema?: UiSchema): string => {
 
 const DATE_TIME_FORMATS = ['date-time', 'date', 'time'];
 
-const TxtWidget: Widget = ({
-	value,
-	schema,
-	uiSchema,
-	...props
-}: WidgetProps) => {
+const TxtWidget = widgetFactory(
+	'Txt',
+	{
+		dtFormat: UiOption.string,
+		bold: UiOption.boolean,
+		italic: UiOption.boolean,
+		monospace: UiOption.boolean,
+		caps: UiOption.boolean,
+		align: {
+			...UiOption.string,
+			enum: [
+				'left',
+				'right',
+				'center',
+				'justify',
+				'justify-all',
+				'start',
+				'end',
+				'match-parent',
+				'inherit',
+				'initial',
+				'unset',
+			],
+		},
+		whitespace: {
+			...UiOption.string,
+			enum: [
+				'normal',
+				'nowrap',
+				'pre',
+				'pre-line',
+				'pre-wrap',
+				'initial',
+				'inherit',
+			],
+		},
+	},
+	[
+		JsonTypes.string,
+		JsonTypes.null,
+		JsonTypes.integer,
+		JsonTypes.number,
+		JsonTypes.boolean,
+		JsonTypes.array,
+	],
+)(({ value, schema, uiSchema, ...props }) => {
 	let displayValue = isArray(value)
-		? getArrayValue(value, uiSchema)
+		? getArrayValue(value as Array<Exclude<typeof value, any[]>>, uiSchema)
 		: value?.toString();
 	if (DATE_TIME_FORMATS.includes(schema?.format ?? '')) {
 		displayValue =
@@ -45,53 +85,6 @@ const TxtWidget: Widget = ({
 		? SingleLineTxt
 		: Txt;
 	return <Component {...props}>{displayValue || ''}</Component>;
-};
-
-TxtWidget.displayName = 'Txt';
-
-TxtWidget.uiOptions = {
-	dtFormat: UiOption.string,
-	bold: UiOption.boolean,
-	italic: UiOption.boolean,
-	monospace: UiOption.boolean,
-	caps: UiOption.boolean,
-	align: {
-		...UiOption.string,
-		enum: [
-			'left',
-			'right',
-			'center',
-			'justify',
-			'justify-all',
-			'start',
-			'end',
-			'match-parent',
-			'inherit',
-			'initial',
-			'unset',
-		],
-	},
-	whitespace: {
-		...UiOption.string,
-		enum: [
-			'normal',
-			'nowrap',
-			'pre',
-			'pre-line',
-			'pre-wrap',
-			'initial',
-			'inherit',
-		],
-	},
-};
-
-TxtWidget.supportedTypes = [
-	JsonTypes.string,
-	JsonTypes.null,
-	JsonTypes.integer,
-	JsonTypes.number,
-	JsonTypes.boolean,
-	JsonTypes.array,
-];
+});
 
 export default TxtWidget;

--- a/src/components/Renderer/widgets/index.ts
+++ b/src/components/Renderer/widgets/index.ts
@@ -18,7 +18,10 @@ import { Format } from '../types';
 import { Widget, withOptionProps } from './widget-util';
 import { ElapsedTimeWidget } from './ElapsedTimeWidget';
 export { WidgetWrapperUiOptions } from './ui-options';
-export { getObjectPropertyNames } from './widget-util';
+export {
+	getObjectPropertyNames,
+	widgetFactory as WidgetFactory,
+} from './widget-util';
 export { default as WidgetMeta } from './WidgetMeta';
 
 type Widgets = {

--- a/src/extra/Renderer/MarkdownWidget.tsx
+++ b/src/extra/Renderer/MarkdownWidget.tsx
@@ -1,23 +1,13 @@
 import * as React from 'react';
 import { Markdown } from '../Markdown';
-import {
-	Widget,
-	WidgetProps,
-} from '../../components/Renderer/widgets/widget-util';
+import { widgetFactory } from '../../components/Renderer/widgets/widget-util';
 import { JsonTypes } from '../../components/Renderer/types';
 
-export const MarkdownWidget: Widget = ({
-	value,
-	schema,
-	uiSchema,
-	...props
-}: WidgetProps) => {
+export const MarkdownWidget = widgetFactory('Markdown', undefined, [
+	JsonTypes.string,
+])(({ value, schema, uiSchema, ...props }) => {
 	if (value == null) {
 		return null;
 	}
 	return <Markdown {...props}>{value.toString()}</Markdown>;
-};
-
-MarkdownWidget.displayName = 'Markdown';
-
-MarkdownWidget.supportedTypes = [JsonTypes.string];
+});

--- a/src/extra/Renderer/MermaidWidget.tsx
+++ b/src/extra/Renderer/MermaidWidget.tsx
@@ -1,25 +1,13 @@
 import * as React from 'react';
 import { Mermaid } from '../Mermaid';
-import {
-	Widget,
-	WidgetProps,
-} from '../../components/Renderer/widgets/widget-util';
+import { widgetFactory } from '../../components/Renderer/widgets/widget-util';
 import { JsonTypes } from '../../components/Renderer/types';
 
-export const MermaidWidget: Widget = ({
-	value,
-	schema,
-	uiSchema,
-	...props
-}: WidgetProps) => {
-	if (value == null) {
-		return null;
-	}
-	return <Mermaid width="100%" {...props} value={value.toString()} />;
-};
-
-MermaidWidget.displayName = 'Mermaid';
-
-MermaidWidget.uiOptions = {};
-
-MermaidWidget.supportedTypes = [JsonTypes.string];
+export const MermaidWidget = widgetFactory('Mermaid', {}, [JsonTypes.string])(
+	({ value, schema, uiSchema, ...props }) => {
+		if (value == null) {
+			return null;
+		}
+		return <Mermaid width="100%" {...props} value={value.toString()} />;
+	},
+);

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,13 @@ export {
 	RenditionUiSchema,
 } from './components/Form';
 
-export { Renderer, RendererProps } from './components/Renderer';
+export {
+	Renderer,
+	RendererProps,
+	Widget,
+	WidgetProps,
+	widgetFactory,
+} from './components/Renderer';
 
 export { DataGrid, DataGridProps } from './components/DataGrid';
 export {


### PR DESCRIPTION
This will greatly reduce the amount of casting that we have to do for the `value` inside each widget, since we already check that the value is valid in the Renderer and autoUI's Collection.

Change-type: minor
See: https://www.flowdock.com/app/rulemotion/f-rendition/threads/Df8PTYUG0VVHe3G4SwXiz3b6o-Z
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
