### PR TITLE
Add itemsPerPage prop to AutoUICollection

### DIFF
--- a/src/extra/AutoUi/Collection/List.tsx
+++ b/src/extra/AutoUi/Collection/List.tsx
@@ -114,6 +114,7 @@ interface ListProps<T> {
 	changeSelected: (selected: T[]) => void;
 	priorities?: Priorities<T>;
 	formats?: Format[];
+	itemsPerPage?: number;
 }
 
 export const List = <T extends AutoUIBaseResource<T>>({
@@ -126,6 +127,7 @@ export const List = <T extends AutoUIBaseResource<T>>({
 	changeSelected,
 	priorities,
 	formats,
+	itemsPerPage = 50,
 }: ListProps<T>) => {
 	// const listKey = autouiContext.baseUrl.split('/').join('-');
 	const history = useHistory();
@@ -187,7 +189,7 @@ export const List = <T extends AutoUIBaseResource<T>>({
 					{...(hasUpdateActions && { onCheck: changeSelected })}
 					usePager={data && data.length > 5}
 					pagerPosition={'bottom'}
-					itemsPerPage={50}
+					itemsPerPage={itemsPerPage}
 					getRowHref={autouiContext.getBaseUrl}
 					onRowClick={onRowClick}
 					columnStateRestorationKey={`${autouiContext.resource}__columns`}

--- a/src/extra/AutoUi/Collection/index.tsx
+++ b/src/extra/AutoUi/Collection/index.tsx
@@ -113,6 +113,7 @@ export interface AutoUICollectionProps<T> {
 		entry: T,
 		event: React.MouseEvent<HTMLAnchorElement, MouseEvent>,
 	) => void;
+	itemsPerPage?: number;
 }
 
 /** Collection component is one of the components that are part of a larger project, namely AutoUI. This component renders a list using an array of data and a template.
@@ -179,6 +180,7 @@ export const AutoUICollection = <T extends AutoUIBaseResource<T>>({
 	cardRenderer,
 	getBaseUrl,
 	onRowClick,
+	itemsPerPage,
 }: AutoUICollectionProps<T>) => {
 	const { t } = useTranslation();
 	const defaultLens = !!cardRenderer
@@ -373,6 +375,7 @@ export const AutoUICollection = <T extends AutoUIBaseResource<T>>({
 						filtered={filtered}
 						changeSelected={setSelected}
 						formats={formats}
+						itemsPerPage={itemsPerPage}
 					/>
 				)}
 


### PR DESCRIPTION
Add itemsPerPage prop to AutoUICollection

Change-type: patch
Signed-off-by: Matthew Yarmolinsky <matthew-timothy@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
