### PR TITLE
autoUI: Fix sorting non-string colums

### DIFF
--- a/src/extra/AutoUi/Collection/List.tsx
+++ b/src/extra/AutoUi/Collection/List.tsx
@@ -20,23 +20,28 @@ import { diff } from '../../../utils';
 
 const formatSorters: Dictionary<TableSortFunction<any>> = {};
 
-const getSortingFunction = (schemaKey: string, schemaValue: JSONSchema) => {
+const getSortingFunction = <T extends any>(
+	schemaKey: keyof T,
+	schemaValue: JSONSchema,
+): TableSortFunction<T> => {
 	if (formatSorters[schemaValue.format ?? '']) {
 		return formatSorters[schemaValue.format ?? ''];
 	}
 
 	const types = castArray(schemaValue.type);
 	if (types.includes(JsonTypes.string)) {
-		return (a: Record<string, any>, b: Record<string, any>) => {
-			const aa = a[schemaKey] ?? '';
-			const bb = b[schemaKey] ?? '';
+		return (a: T, b: T) => {
+			const aa = (a[schemaKey] ?? '') as string;
+			const bb = (b[schemaKey] ?? '') as string;
 			if (typeof aa === 'string' && typeof bb === 'string') {
 				return aa.toLowerCase().localeCompare(bb.toLowerCase());
 			}
 			return diff(aa, bb);
 		};
 	}
-	return diff;
+	return (a: T, b: T) =>
+		// @ts-expect-error
+		diff(a[schemaKey], b[schemaKey]);
 };
 
 const getSelected = <T, K extends keyof T>(


### PR DESCRIPTION
Change-type: patch
See: https://github.com/balena-io-modules/rendition/pull/1359
See: https://www.flowdock.com/app/rulemotion/resin-frontend/threads/tONHAYGyMuDto2AqZx_mKINc5pJ
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
