### PR TITLE
Remove new browser tab from download image process

### DIFF
--- a/src/hooks/useTranslation.tsx
+++ b/src/hooks/useTranslation.tsx
@@ -78,6 +78,8 @@ const translationMap = {
 		'Download configuration file only',
 
 	'loading.generating_configuration_file': 'Generating configuration file...',
+	'loading.download_image_from_url':
+		'this operation might take several minutes. You can close the modal but do not exit from this page.',
 	'loading.fetching_versions': 'Fetching versions...',
 
 	'no_data.no_os_versions_available_for_download':

--- a/src/unstable-temp/DownloadImageModal/DownloadImageModal.tsx
+++ b/src/unstable-temp/DownloadImageModal/DownloadImageModal.tsx
@@ -3,7 +3,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import * as React from 'react';
 import styled from 'styled-components';
 import { ApplicationInstructions } from './ApplicationInstructions';
-import { ImageForm } from './ImageForm';
+import { ImageForm, DownloadTypeEnum } from './ImageForm';
 import isEmpty from 'lodash/isEmpty';
 import noop from 'lodash/noop';
 import find from 'lodash/find';
@@ -66,7 +66,6 @@ const getUniqueOsTypes = (
 
 	return uniq(osVersions[deviceTypeSlug].map((x) => x.osType));
 };
-
 export interface DownloadOptions {
 	appId: number;
 	releaseId?: number;
@@ -154,7 +153,8 @@ export const UnstableTempDownloadImageModal = ({
 			: {},
 	);
 
-	const [isDownloadingConfig, setIsDownloadingConfig] = React.useState(false);
+	const [downloadingType, setDownloadingType] =
+		React.useState<DownloadTypeEnum | null>();
 	const [isFetching, setIsFetching] = React.useState(isEmpty(osVersions));
 
 	const logoSrc = deviceType?.logoUrl ?? undefined;
@@ -264,8 +264,12 @@ export const UnstableTempDownloadImageModal = ({
 			<Flex flexDirection={['column', 'column', 'column', 'row']}>
 				<Box flex={2} mr={[0, 0, 0, 3]}>
 					<Spinner
-						show={isDownloadingConfig}
-						label={t('loading.generating_configuration_file')}
+						show={!!downloadingType}
+						label={
+							downloadingType === DownloadTypeEnum.config
+								? t('loading.generating_configuration_file')
+								: t('loading.download_image_from_url')
+						}
 					>
 						<Spinner show={isFetching} label={t('loading.fetching_versions')} />
 						{!isFetching && (
@@ -278,7 +282,7 @@ export const UnstableTempDownloadImageModal = ({
 								{!!osType && !!compatibleDeviceTypes && (
 									<ImageForm
 										onDownloadStart={onDownloadStart}
-										setIsDownloadingConfig={setIsDownloadingConfig}
+										setIsDownloadingType={setDownloadingType}
 										deviceType={deviceType}
 										appId={application.id}
 										releaseId={releaseId}


### PR DESCRIPTION
Remove new browser tab from download image process

Change-type: patch
See: https://www.flowdock.com/app/rulemotion/resin-frontend/threads/6pSNP96tIs2hwDa5s_0CvBI0nQm
Signed-off-by: Andrea Rosci <andrear@balena.io>


<img width="1454" alt="Screenshot 2021-09-24 at 16 18 18" src="https://user-images.githubusercontent.com/7238159/134691517-22931084-c726-4d28-a846-4274f3c70632.png">


---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
