### PR TITLE
UnstableTempDownloadImageModal: Drop unnecessary types & helper code

### DIFF
--- a/src/unstable-temp/DownloadImageModal/models.ts
+++ b/src/unstable-temp/DownloadImageModal/models.ts
@@ -62,73 +62,11 @@ export interface OsVersion {
 export interface OsVersionsByDeviceType {
 	[deviceTypeSlug: string]: OsVersion[];
 }
-export interface User {
-	id: number;
-	actor: number;
-	created_at: string;
-	username: string;
-}
-export declare type OrganizationMembershipRoles = 'administrator' | 'member';
-export interface ApiKey {
-	id: number;
-	created_at: string;
-	name: string;
-	description: string | null;
-	is_of__actor: { _id: number };
-}
 export interface Application {
 	id: number;
-	created_at: string;
 	app_name: string;
 	slug: string;
 	uuid: string;
-	is_accessible_by_support_until__date: string;
-	is_host: boolean;
-	should_track_latest_release: boolean;
-	is_public: boolean;
-	is_archived: boolean;
-	is_discoverable: boolean;
-	is_stored_at__repository_url: string | null;
-	application_type: NavigationResource<ApplicationType>;
-}
-export interface ApplicationType {
-	id: number;
-	name: string;
-	slug: string;
-	description: string | null;
-	supports_gateway_mode: boolean;
-	supports_multicontainer: boolean;
-	supports_web_url: boolean;
-	is_legacy: boolean;
-	requires_payment: boolean;
-	needs__os_version_range: string | null;
-	maximum_device_count: number | null;
-	is_host_os: boolean;
-}
-export declare type ReleaseStatus =
-	| 'cancelled'
-	| 'error'
-	| 'failed'
-	| 'interrupted'
-	| 'local'
-	| 'running'
-	| 'success'
-	| 'timeout'
-	| null;
-export interface Release {
-	id: number;
-	created_at: string;
-	commit: string;
-	composition: string | null;
-	contract: string | null;
-	status: ReleaseStatus;
-	source: string;
-	build_log: string | null;
-	is_invalidated: boolean;
-	start_timestamp: string;
-	update_timestamp: string | null;
-	end_timestamp: string;
-	release_version: string | null;
 }
 
 export interface DeviceTypeInstructions {
@@ -184,60 +122,4 @@ export interface DeviceType {
 	};
 	/** Holds the latest balenaOS version */
 	logoUrl?: string;
-}
-
-export interface Device {
-	id: number;
-	created_at: string;
-	custom_latitude?: string;
-	custom_longitude?: string;
-	device_name: string;
-	download_progress?: number;
-	ip_address: string | null;
-	public_address: string | null;
-	mac_address: string | null;
-	is_accessible_by_support_until__date: string | null;
-	is_connected_to_vpn: boolean;
-	is_in_local_mode?: boolean;
-	is_locked_until__date: string;
-	is_web_accessible: boolean;
-	is_active: boolean;
-	is_online: boolean;
-	last_connectivity_event: string | null;
-	last_vpn_event: string;
-	latitude?: string;
-	local_id?: string;
-	location: string;
-	longitude?: string;
-	note: string;
-	os_variant?: string;
-	os_version: string | null;
-	provisioning_progress?: number;
-	provisioning_state: string;
-	state?: {
-		key: string;
-		name: string;
-	};
-	status: string;
-	status_sort_index?: number;
-	supervisor_version: string;
-	uuid: string;
-	vpn_address: string | null;
-	api_heartbeat_state: 'online' | 'offline' | 'timeout' | 'unknown';
-	memory_usage: number | null;
-	memory_total: number | null;
-	storage_block_device: string | null;
-	storage_usage: number | null;
-	storage_total: number | null;
-	cpu_usage: number | null;
-	cpu_temp: number | null;
-	cpu_id: string | null;
-	is_undervolted: boolean;
-	overall_progress: number | null;
-	is_of__device_type: NavigationResource<DeviceType>;
-	belongs_to__application: NavigationResource<Application>;
-	belongs_to__user: OptionalNavigationResource<User>;
-	is_running__release: OptionalNavigationResource<Release>;
-	should_be_running__release: OptionalNavigationResource<Release>;
-	is_managed_by__device: OptionalNavigationResource<Device>;
 }

--- a/src/unstable-temp/DownloadImageModal/utils.ts
+++ b/src/unstable-temp/DownloadImageModal/utils.ts
@@ -1,10 +1,5 @@
 import template from 'lodash/template';
-import {
-	DeviceType,
-	OptionalNavigationResource,
-	OsTypesEnum,
-	Device,
-} from './models';
+import { DeviceType, OptionalNavigationResource, OsTypesEnum } from './models';
 import { Dictionary } from '../../common-types';
 
 export const OS_VARIANT_FULL_DISPLAY_TEXT_MAP: Dictionary<string> = {
@@ -51,36 +46,6 @@ export const getOsTypeName = (osTypeSlug: string) => {
 	}
 };
 
-/**
- * @return known return values are 'dev', 'prod' & ''
- */
-export const getOsVariant = (deviceOrVersion: Device | string): string => {
-	if (!deviceOrVersion) {
-		return '';
-	}
-
-	let version;
-	if (typeof deviceOrVersion === 'string') {
-		version = deviceOrVersion;
-	} else {
-		if (deviceOrVersion.os_variant) {
-			return deviceOrVersion.os_variant;
-		}
-
-		version = deviceOrVersion.os_version || '';
-	}
-
-	const versionVariantMatch = version.match(/(prod|dev)/) || [];
-	return versionVariantMatch[1] || '';
-};
-
-export const getOsVariantDisplayText = (
-	deviceOrVariant: Device | string,
-): string => {
-	const variant =
-		typeof deviceOrVariant === 'string'
-			? deviceOrVariant
-			: getOsVariant(deviceOrVariant as Device);
-
+export const getOsVariantDisplayText = (variant: string): string => {
 	return OS_VARIANT_FULL_DISPLAY_TEXT_MAP[variant] || variant;
 };


### PR DESCRIPTION
The `application_type.is_host_os` does not actually exist in v6, and TS started complaining after removing it from the SDK typings. I took an extra moment though and removed almost all unused typings, so that UnstableTempDownloadImageModal only requires the really necessary fields in its props.

Change-type: patch
See: https://github.com/balena-io/balena-sdk/pull/1124
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

<!-- You can remove tags that do not apply. -->
Connects-to: # <!-- waffle convention to track a PR's status through its connected, open issue -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->
Change-type: major|minor|patch <!-- The change type of this PR -->

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
