### PR TITLE
Add OS issues icon and tooltip in DownloadImageModal

### DIFF
--- a/src/unstable-temp/DownloadImageModal/OsConfiguration.tsx
+++ b/src/unstable-temp/DownloadImageModal/OsConfiguration.tsx
@@ -1,4 +1,3 @@
-// import * as semver from 'balena-semver';
 import partition from 'lodash/partition';
 import * as React from 'react';
 
@@ -26,6 +25,9 @@ import { getOsVariantDisplayText } from './utils';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { IconProp } from '@fortawesome/fontawesome-svg-core';
 import { faFileAlt } from '@fortawesome/free-regular-svg-icons/faFileAlt';
+import { faExclamationTriangle } from '@fortawesome/free-solid-svg-icons/faExclamationTriangle';
+import { useTheme } from '../../hooks/useTheme';
+import { Theme } from '~/theme';
 
 export const DownloadImageLabel = styled.label`
 	display: flex;
@@ -143,6 +145,39 @@ const VariantSelector = ({
 	);
 };
 
+const VersionSelectOption = ({
+	option,
+	theme,
+}: {
+	option: VersionSelectionOptions;
+	theme: Theme;
+}) => (
+	<Flex
+		alignItems="center"
+		py={2}
+		pl={3}
+		tooltip={option.knownIssueList ?? undefined}
+		maxWidth="445px"
+	>
+		<Txt mr={2}>{option.title}</Txt>{' '}
+		{!!option.knownIssueList && (
+			<Box
+				ml={2}
+				tooltip={option.knownIssueList}
+				display="contents"
+				style={{ lineHeight: 'normal' }}
+			>
+				<FontAwesomeIcon
+					color={theme.colors.warning.main}
+					icon={faExclamationTriangle}
+				/>
+				<Txt ml={1} truncate>
+					{option.knownIssueList}
+				</Txt>
+			</Box>
+		)}
+	</Flex>
+);
 export const OsConfiguration = ({
 	deviceTypeOsVersions,
 	compatibleDeviceTypes,
@@ -156,6 +191,7 @@ export const OsConfiguration = ({
 	onSelectedOsTypeChange,
 	docsIcon,
 }: OsConfigurationProps) => {
+	const theme = useTheme();
 	const { t } = useTranslation();
 	const [showAllVersions, setShowAllVersions] = React.useState(false);
 	const [version, setVersion] = React.useState<
@@ -289,13 +325,22 @@ export const OsConfiguration = ({
 								valueKey="value"
 								labelKey="title"
 								emptySearchMessage="No version available for this application type"
-								value={version ?? {}}
+								value={version}
+								valueLabel={
+									version && (
+										<VersionSelectOption option={version} theme={theme} />
+									)
+								}
 								placeholder={'Choose a version...'}
 								onChange={({ option }) => {
 									setVersion(option);
 								}}
 								options={versionSelectionOpts}
-							/>
+							>
+								{(option) => (
+									<VersionSelectOption option={option} theme={theme} />
+								)}
+							</Select>
 						</Box>
 
 						{shouldShowAllVersionsToggle && (

--- a/src/unstable-temp/DownloadImageModal/models.ts
+++ b/src/unstable-temp/DownloadImageModal/models.ts
@@ -58,6 +58,7 @@ export interface OsVersion {
 	variant?: string;
 	formattedVersion: string;
 	isRecommended?: boolean;
+	known_issue_list: string | null;
 }
 export interface OsVersionsByDeviceType {
 	[deviceTypeSlug: string]: OsVersion[];

--- a/src/unstable-temp/DownloadImageModal/versions.ts
+++ b/src/unstable-temp/DownloadImageModal/versions.ts
@@ -9,6 +9,7 @@ export interface VersionSelectionOptions {
 	supportsBuildEditions: boolean;
 	osType: string;
 	line?: string;
+	knownIssueList: string | null;
 	rawVersions: {
 		dev: string | null;
 		prod: string | null;
@@ -28,6 +29,7 @@ export const transformVersions = (
 				supportsBuildEditions: false,
 				osType: v.osType,
 				line: v.line,
+				knownIssueList: v.known_issue_list,
 				rawVersions: {
 					dev: null,
 					prod: v.rawVersion,
@@ -52,6 +54,7 @@ export const transformVersions = (
 				supportsBuildEditions: true,
 				osType: version.osType,
 				line: version.line,
+				knownIssueList: version.known_issue_list,
 				rawVersions: {
 					dev:
 						version.variant === 'dev'
@@ -98,7 +101,6 @@ export const getPreferredVersionOpts = (
 		return Object.values(preferredMultilineOpts);
 	} else {
 		const preferredDefaultOpts: VersionSelectionOptions[] = [];
-
 		for (const option of opts) {
 			if (preferredDefaultOpts.length >= 3) {
 				break;


### PR DESCRIPTION
Change-type: minor
See: https://github.com/balena-io/balena-ui/issues/5091
Signed-off-by: Andrea Rosci <andrear@balena.io>

<img width="1292" alt="Screenshot 2021-10-21 at 15 21 14" src="https://user-images.githubusercontent.com/7238159/138295921-527684fc-58e4-4989-ae59-f2ec8b177424.png">
<img width="1282" alt="Screenshot 2021-10-21 at 15 21 24" src="https://user-images.githubusercontent.com/7238159/138295931-12f8271f-33f3-4587-81dc-4d3f1d49f6a7.png">

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
