### PR TITLE
Allow user to see list of all affected entities when confirming actions

### DIFF
--- a/src/components/TagManagementModal/CollectionSummary/CollectionSummary.tsx
+++ b/src/components/TagManagementModal/CollectionSummary/CollectionSummary.tsx
@@ -1,75 +1,62 @@
 import * as React from 'react';
-
 import styled from 'styled-components';
-import { Theme } from '../../../index';
-import { Coloring } from '../../../common-types';
-import { Txt } from '../../Txt';
-import { getThemeColoring } from '../../../utils';
-
-import CaretButton from './CaretButton';
+import { Button } from '../../../components/Button';
 
 const Container = styled.div`
 	font-size: 16px;
 	font-weight: normal;
-	color: #b3b6b9;
 `;
 
-const ItemNameHolder = styled(Txt)`
-	font-size: 0.9em;
-	white-space: normal;
-	color: ${(prop) => prop.color || ''};
+const ItemListContainer = styled.div`
+	border: solid 1px;
+	border-radius: 5px;
 `;
 
-interface CollectionSummaryProps extends Coloring {
-	initiallyExpanded?: boolean;
+const ItemList = styled.div`
+	max-height: 100px;
+	overflow-y: auto;
+	margin: 1%;
+`;
+
+interface CollectionSummaryProps {
 	items: string[];
 	itemsType: string;
 	maxVisibleItemCount?: number;
-	itemNameStyle?: React.CSSProperties;
 }
 
-export class CollectionSummary extends React.Component<
-	CollectionSummaryProps,
-	{
-		isExpanded: boolean;
-	}
-> {
-	constructor(props: CollectionSummaryProps) {
-		super(props);
+export const CollectionSummary = (props: CollectionSummaryProps) => {
+	const { items, itemsType, maxVisibleItemCount = 0 } = props;
+	const [showFullList, setShowFullList] = React.useState<boolean>(false);
 
-		this.state = {
-			isExpanded: !!this.props.initiallyExpanded,
-		};
-	}
-
-	public render() {
-		const { items, itemsType, maxVisibleItemCount } = this.props;
-		const itemNameColor = getThemeColoring(Theme, this.props, 'main');
-		return (
-			<Container>
-				{items.length === 1 && <Txt color={itemNameColor}>{items[0]}</Txt>}
-				{items.length > 1 && (
-					<div>
-						<CaretButton
-							isExpanded={this.state.isExpanded}
-							onClick={() =>
-								this.setState({
-									isExpanded: !this.state.isExpanded,
-								})
-							}
-						>
-							<span>{`${items.length} ${itemsType}`}</span>
-						</CaretButton>
-						{this.state.isExpanded && (
-							<ItemNameHolder color={itemNameColor}>
-								{maxVisibleItemCount && items.length > maxVisibleItemCount
-									? `${items.slice(0, maxVisibleItemCount).join(', ')}, ...`
-									: items.join(', ')}
-							</ItemNameHolder>
-						)}
-					</div>
-				)}
-			</Container>
-		);
-	}
-}
+	return (
+		<Container>
+			{!showFullList ? (
+				<>
+					{items.length} {itemsType}
+					{': '}
+					{items.slice(0, maxVisibleItemCount).join(', ')}
+					{items.length > maxVisibleItemCount ? ', ...' : ''}
+				</>
+			) : (
+				<ItemListContainer>
+					<ItemList>
+						{items.map((item) => (
+							<div>{item}</div>
+						))}
+					</ItemList>
+				</ItemListContainer>
+			)}
+			{items.length > maxVisibleItemCount && (
+				<Button
+					plain
+					ml={showFullList ? 0 : 3}
+					onClick={() => {
+						setShowFullList(!showFullList);
+					}}
+				>
+					Show {showFullList ? 'less' : 'all'}
+				</Button>
+			)}
+		</Container>
+	);
+};


### PR DESCRIPTION
Allow user to see list of all affected entities when confirming actions

Change-type: minor
Signed-off-by: Matthew Yarmolinsky <matthew-timothy@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
