### PR TITLE
Use styled components instead of classNames in TextWithCopy

### DIFF
--- a/src/components/Avatar/__snapshots__/Avatar.stories.storyshot
+++ b/src/components/Avatar/__snapshots__/Avatar.stories.storyshot
@@ -7,7 +7,7 @@ exports[`Storyshots Core/Avatar Default 1`] = `
   >
     
     <div
-      class="StyledBox-sc-13pk1d4-0 gQBMGO StyledAvatar-sc-1suyamb-1 sc-cuWdqJ ihoHEi"
+      class="StyledBox-sc-13pk1d4-0 gQBMGO StyledAvatar-sc-1suyamb-1 sc-hRxcUd hoOiRc"
     >
       <svg
         aria-hidden="true"
@@ -36,7 +36,7 @@ exports[`Storyshots Core/Avatar Emphasized 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 cNraFD sc-eFuaqX iXQyXF"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 dVVuTe StyledAvatar-sc-1suyamb-1 sc-cuWdqJ ihoHEi"
+      class="StyledBox-sc-13pk1d4-0 dVVuTe StyledAvatar-sc-1suyamb-1 sc-hRxcUd hoOiRc"
     >
       <div
         class="sc-fKFxtB eNMjwF sc-bBXrwG jiBhUN"
@@ -54,7 +54,7 @@ exports[`Storyshots Core/Avatar With First Name 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 cNraFD sc-eFuaqX iXQyXF"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 gQBMGO StyledAvatar-sc-1suyamb-1 sc-cuWdqJ ihoHEi"
+      class="StyledBox-sc-13pk1d4-0 gQBMGO StyledAvatar-sc-1suyamb-1 sc-hRxcUd hoOiRc"
     >
       <div
         class="sc-fKFxtB eNMjwF sc-bBXrwG jiBhUN"
@@ -72,7 +72,7 @@ exports[`Storyshots Core/Avatar With Full Name 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 cNraFD sc-eFuaqX iXQyXF"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 gQBMGO StyledAvatar-sc-1suyamb-1 sc-cuWdqJ ihoHEi"
+      class="StyledBox-sc-13pk1d4-0 gQBMGO StyledAvatar-sc-1suyamb-1 sc-hRxcUd hoOiRc"
     >
       <div
         class="sc-fKFxtB eNMjwF sc-bBXrwG jiBhUN"
@@ -90,7 +90,7 @@ exports[`Storyshots Core/Avatar With Image 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 cNraFD sc-eFuaqX iXQyXF"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 kZHGQl StyledAvatar-sc-1suyamb-1 sc-cuWdqJ ihoHEi"
+      class="StyledBox-sc-13pk1d4-0 kZHGQl StyledAvatar-sc-1suyamb-1 sc-hRxcUd hoOiRc"
     />
     
   </div>
@@ -103,7 +103,7 @@ exports[`Storyshots Core/Avatar With Last Name 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 cNraFD sc-eFuaqX iXQyXF"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 gQBMGO StyledAvatar-sc-1suyamb-1 sc-cuWdqJ ihoHEi"
+      class="StyledBox-sc-13pk1d4-0 gQBMGO StyledAvatar-sc-1suyamb-1 sc-hRxcUd hoOiRc"
     >
       <div
         class="sc-fKFxtB eNMjwF sc-bBXrwG jiBhUN"

--- a/src/components/Breadcrumbs/__snapshots__/Breadcrumbs.stories.storyshot
+++ b/src/components/Breadcrumbs/__snapshots__/Breadcrumbs.stories.storyshot
@@ -18,7 +18,7 @@ exports[`Storyshots Core/Breadcrumbs Default 1`] = `
             class="sc-gKseQn cOdZAq sc-iBPTik kWuhSW sc-hHfuMS bGyzMR"
           >
             <div
-              class="sc-gKseQn cOdZAq sc-iBPTik bqhgIB sc-hHfuMS sc-fTACoA kXuowN dFpGxH"
+              class="sc-gKseQn cOdZAq sc-iBPTik bqhgIB sc-hHfuMS sc-fTNIjK kXuowN trndB"
             />
             <div
               class="sc-gKseQn cOdZAq sc-iBPTik hlsbIF sc-hHfuMS kXuowN"
@@ -60,7 +60,7 @@ exports[`Storyshots Core/Breadcrumbs Default 1`] = `
             class="sc-gKseQn cOdZAq sc-iBPTik kWuhSW sc-hHfuMS bGyzMR"
           >
             <div
-              class="sc-gKseQn cOdZAq sc-iBPTik bqhgIB sc-hHfuMS sc-fTACoA kXuowN dFpGxH"
+              class="sc-gKseQn cOdZAq sc-iBPTik bqhgIB sc-hHfuMS sc-fTNIjK kXuowN trndB"
             />
             <div
               class="sc-gKseQn cOdZAq sc-iBPTik hlsbIF sc-hHfuMS kXuowN"
@@ -102,7 +102,7 @@ exports[`Storyshots Core/Breadcrumbs Default 1`] = `
             class="sc-gKseQn cOdZAq sc-iBPTik kWuhSW sc-hHfuMS bGyzMR"
           >
             <div
-              class="sc-gKseQn cOdZAq sc-iBPTik bqhgIB sc-hHfuMS sc-fTACoA kXuowN kJANmT"
+              class="sc-gKseQn cOdZAq sc-iBPTik bqhgIB sc-hHfuMS sc-fTNIjK kXuowN ccQkLJ"
             />
             <div
               class="sc-gKseQn cOdZAq sc-iBPTik hlsbIF sc-hHfuMS kXuowN"
@@ -172,7 +172,7 @@ exports[`Storyshots Core/Breadcrumbs Wrapped 1`] = `
               class="sc-gKseQn cOdZAq sc-iBPTik kWuhSW sc-hHfuMS bGyzMR"
             >
               <div
-                class="sc-gKseQn cOdZAq sc-iBPTik bqhgIB sc-hHfuMS sc-fTACoA kXuowN dFpGxH"
+                class="sc-gKseQn cOdZAq sc-iBPTik bqhgIB sc-hHfuMS sc-fTNIjK kXuowN trndB"
               />
               <div
                 class="sc-gKseQn cOdZAq sc-iBPTik hlsbIF sc-hHfuMS kXuowN"
@@ -214,7 +214,7 @@ exports[`Storyshots Core/Breadcrumbs Wrapped 1`] = `
               class="sc-gKseQn cOdZAq sc-iBPTik kWuhSW sc-hHfuMS bGyzMR"
             >
               <div
-                class="sc-gKseQn cOdZAq sc-iBPTik bqhgIB sc-hHfuMS sc-fTACoA kXuowN dFpGxH"
+                class="sc-gKseQn cOdZAq sc-iBPTik bqhgIB sc-hHfuMS sc-fTNIjK kXuowN trndB"
               />
               <div
                 class="sc-gKseQn cOdZAq sc-iBPTik hlsbIF sc-hHfuMS kXuowN"
@@ -256,7 +256,7 @@ exports[`Storyshots Core/Breadcrumbs Wrapped 1`] = `
               class="sc-gKseQn cOdZAq sc-iBPTik kWuhSW sc-hHfuMS bGyzMR"
             >
               <div
-                class="sc-gKseQn cOdZAq sc-iBPTik bqhgIB sc-hHfuMS sc-fTACoA kXuowN kJANmT"
+                class="sc-gKseQn cOdZAq sc-iBPTik bqhgIB sc-hHfuMS sc-fTNIjK kXuowN ccQkLJ"
               />
               <div
                 class="sc-gKseQn cOdZAq sc-iBPTik hlsbIF sc-hHfuMS kXuowN"

--- a/src/components/Card/__snapshots__/Card.stories.storyshot
+++ b/src/components/Card/__snapshots__/Card.stories.storyshot
@@ -163,19 +163,19 @@ exports[`Storyshots Core/Card With Rows 1`] = `
               class="sc-iktFfs fGhlyA sc-hiSbEG iXlJCC"
             />
             <span
-              class="sc-fKFxtB eNMjwF sc-iwyWTf kPghqC sc-hYZPxA eicDbK text-with-copy"
+              class="sc-fKFxtB eNMjwF sc-iwyWTf kPghqC sc-hYZPxA kEjrfv"
               title="This value has been copied to your clipboard!"
             >
               <span
-                class="text-with-copy__content"
+                class="sc-cHjwLt kFEMXp"
               >
                 Row with Copy component
               </span>
               <span
-                class="text-with-copy__copy_wrapper"
+                class="sc-gHfsNP dROUvG"
               >
                 <div
-                  class="sc-gKseQn cOdZAq sc-iBPTik bqhgIB text-with-copy__copy"
+                  class="sc-gKseQn cOdZAq sc-iBPTik bqhgIB sc-JAcba kulegd"
                 >
                   <svg
                     aria-hidden="true"

--- a/src/components/Container/__snapshots__/Container.stories.storyshot
+++ b/src/components/Container/__snapshots__/Container.stories.storyshot
@@ -6,7 +6,7 @@ exports[`Storyshots Core/Container Centered Content 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 cNraFD sc-eFuaqX iXQyXF"
   >
     <div
-      class="sc-gKseQn cOdZAq sc-iBPTik jCoLHv sc-dkAqVg elcfge sc-jifHHV juzEvz"
+      class="sc-gKseQn cOdZAq sc-iBPTik jCoLHv sc-bSFUlv ieHjHw sc-jvfqPk bvBrDk"
     >
       <h3
         class="sc-gWHigU hGGoTM sc-cBNeex gsjqDj"
@@ -24,7 +24,7 @@ exports[`Storyshots Core/Container Default 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 cNraFD sc-eFuaqX iXQyXF"
   >
     <div
-      class="sc-gKseQn cOdZAq sc-iBPTik jCoLHv sc-dkAqVg dbZNWR sc-jifHHV juzEvz"
+      class="sc-gKseQn cOdZAq sc-iBPTik jCoLHv sc-bSFUlv fXMplH sc-jvfqPk bvBrDk"
     >
       <h3
         class="sc-gWHigU hGGoTM sc-cBNeex gsjqDj"

--- a/src/components/Filters/__snapshots__/Filters.stories.storyshot
+++ b/src/components/Filters/__snapshots__/Filters.stories.storyshot
@@ -135,7 +135,7 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
           Bulbasaur
         </h2>
         <table
-          class="sc-kGNyvp kUWvOo"
+          class="sc-bxnjHY hdPlUe"
         >
           <tbody>
             <tr>
@@ -225,7 +225,7 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
           Ivysaur
         </h2>
         <table
-          class="sc-kGNyvp kUWvOo"
+          class="sc-bxnjHY hdPlUe"
         >
           <tbody>
             <tr>
@@ -315,7 +315,7 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
           Venusaur
         </h2>
         <table
-          class="sc-kGNyvp kUWvOo"
+          class="sc-bxnjHY hdPlUe"
         >
           <tbody>
             <tr>
@@ -405,7 +405,7 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
           Charmander
         </h2>
         <table
-          class="sc-kGNyvp kUWvOo"
+          class="sc-bxnjHY hdPlUe"
         >
           <tbody>
             <tr>
@@ -495,7 +495,7 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
           Charmeleon
         </h2>
         <table
-          class="sc-kGNyvp kUWvOo"
+          class="sc-bxnjHY hdPlUe"
         >
           <tbody>
             <tr>
@@ -587,7 +587,7 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
           Charizard
         </h2>
         <table
-          class="sc-kGNyvp kUWvOo"
+          class="sc-bxnjHY hdPlUe"
         >
           <tbody>
             <tr>
@@ -706,7 +706,7 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
           Squirtle
         </h2>
         <table
-          class="sc-kGNyvp kUWvOo"
+          class="sc-bxnjHY hdPlUe"
         >
           <tbody>
             <tr>
@@ -825,7 +825,7 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
           Wartortle
         </h2>
         <table
-          class="sc-kGNyvp kUWvOo"
+          class="sc-bxnjHY hdPlUe"
         >
           <tbody>
             <tr>
@@ -915,7 +915,7 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
           Blastoise
         </h2>
         <table
-          class="sc-kGNyvp kUWvOo"
+          class="sc-bxnjHY hdPlUe"
         >
           <tbody>
             <tr>
@@ -1005,7 +1005,7 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
           Caterpie
         </h2>
         <table
-          class="sc-kGNyvp kUWvOo"
+          class="sc-bxnjHY hdPlUe"
         >
           <tbody>
             <tr>
@@ -1095,7 +1095,7 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
           Staryu
         </h2>
         <table
-          class="sc-kGNyvp kUWvOo"
+          class="sc-bxnjHY hdPlUe"
         >
           <tbody>
             <tr>
@@ -1306,7 +1306,7 @@ exports[`Storyshots Core/Filters Compact 1`] = `
           Bulbasaur
         </h2>
         <table
-          class="sc-kGNyvp kUWvOo"
+          class="sc-bxnjHY hdPlUe"
         >
           <tbody>
             <tr>
@@ -1396,7 +1396,7 @@ exports[`Storyshots Core/Filters Compact 1`] = `
           Ivysaur
         </h2>
         <table
-          class="sc-kGNyvp kUWvOo"
+          class="sc-bxnjHY hdPlUe"
         >
           <tbody>
             <tr>
@@ -1486,7 +1486,7 @@ exports[`Storyshots Core/Filters Compact 1`] = `
           Venusaur
         </h2>
         <table
-          class="sc-kGNyvp kUWvOo"
+          class="sc-bxnjHY hdPlUe"
         >
           <tbody>
             <tr>
@@ -1576,7 +1576,7 @@ exports[`Storyshots Core/Filters Compact 1`] = `
           Charmander
         </h2>
         <table
-          class="sc-kGNyvp kUWvOo"
+          class="sc-bxnjHY hdPlUe"
         >
           <tbody>
             <tr>
@@ -1666,7 +1666,7 @@ exports[`Storyshots Core/Filters Compact 1`] = `
           Charmeleon
         </h2>
         <table
-          class="sc-kGNyvp kUWvOo"
+          class="sc-bxnjHY hdPlUe"
         >
           <tbody>
             <tr>
@@ -1758,7 +1758,7 @@ exports[`Storyshots Core/Filters Compact 1`] = `
           Charizard
         </h2>
         <table
-          class="sc-kGNyvp kUWvOo"
+          class="sc-bxnjHY hdPlUe"
         >
           <tbody>
             <tr>
@@ -1877,7 +1877,7 @@ exports[`Storyshots Core/Filters Compact 1`] = `
           Squirtle
         </h2>
         <table
-          class="sc-kGNyvp kUWvOo"
+          class="sc-bxnjHY hdPlUe"
         >
           <tbody>
             <tr>
@@ -1996,7 +1996,7 @@ exports[`Storyshots Core/Filters Compact 1`] = `
           Wartortle
         </h2>
         <table
-          class="sc-kGNyvp kUWvOo"
+          class="sc-bxnjHY hdPlUe"
         >
           <tbody>
             <tr>
@@ -2086,7 +2086,7 @@ exports[`Storyshots Core/Filters Compact 1`] = `
           Blastoise
         </h2>
         <table
-          class="sc-kGNyvp kUWvOo"
+          class="sc-bxnjHY hdPlUe"
         >
           <tbody>
             <tr>
@@ -2176,7 +2176,7 @@ exports[`Storyshots Core/Filters Compact 1`] = `
           Caterpie
         </h2>
         <table
-          class="sc-kGNyvp kUWvOo"
+          class="sc-bxnjHY hdPlUe"
         >
           <tbody>
             <tr>
@@ -2266,7 +2266,7 @@ exports[`Storyshots Core/Filters Compact 1`] = `
           Staryu
         </h2>
         <table
-          class="sc-kGNyvp kUWvOo"
+          class="sc-bxnjHY hdPlUe"
         >
           <tbody>
             <tr>
@@ -2490,7 +2490,7 @@ exports[`Storyshots Core/Filters Default 1`] = `
           Bulbasaur
         </h2>
         <table
-          class="sc-kGNyvp kUWvOo"
+          class="sc-bxnjHY hdPlUe"
         >
           <tbody>
             <tr>
@@ -2580,7 +2580,7 @@ exports[`Storyshots Core/Filters Default 1`] = `
           Ivysaur
         </h2>
         <table
-          class="sc-kGNyvp kUWvOo"
+          class="sc-bxnjHY hdPlUe"
         >
           <tbody>
             <tr>
@@ -2670,7 +2670,7 @@ exports[`Storyshots Core/Filters Default 1`] = `
           Venusaur
         </h2>
         <table
-          class="sc-kGNyvp kUWvOo"
+          class="sc-bxnjHY hdPlUe"
         >
           <tbody>
             <tr>
@@ -2760,7 +2760,7 @@ exports[`Storyshots Core/Filters Default 1`] = `
           Charmander
         </h2>
         <table
-          class="sc-kGNyvp kUWvOo"
+          class="sc-bxnjHY hdPlUe"
         >
           <tbody>
             <tr>
@@ -2850,7 +2850,7 @@ exports[`Storyshots Core/Filters Default 1`] = `
           Charmeleon
         </h2>
         <table
-          class="sc-kGNyvp kUWvOo"
+          class="sc-bxnjHY hdPlUe"
         >
           <tbody>
             <tr>
@@ -2942,7 +2942,7 @@ exports[`Storyshots Core/Filters Default 1`] = `
           Charizard
         </h2>
         <table
-          class="sc-kGNyvp kUWvOo"
+          class="sc-bxnjHY hdPlUe"
         >
           <tbody>
             <tr>
@@ -3061,7 +3061,7 @@ exports[`Storyshots Core/Filters Default 1`] = `
           Squirtle
         </h2>
         <table
-          class="sc-kGNyvp kUWvOo"
+          class="sc-bxnjHY hdPlUe"
         >
           <tbody>
             <tr>
@@ -3180,7 +3180,7 @@ exports[`Storyshots Core/Filters Default 1`] = `
           Wartortle
         </h2>
         <table
-          class="sc-kGNyvp kUWvOo"
+          class="sc-bxnjHY hdPlUe"
         >
           <tbody>
             <tr>
@@ -3270,7 +3270,7 @@ exports[`Storyshots Core/Filters Default 1`] = `
           Blastoise
         </h2>
         <table
-          class="sc-kGNyvp kUWvOo"
+          class="sc-bxnjHY hdPlUe"
         >
           <tbody>
             <tr>
@@ -3360,7 +3360,7 @@ exports[`Storyshots Core/Filters Default 1`] = `
           Caterpie
         </h2>
         <table
-          class="sc-kGNyvp kUWvOo"
+          class="sc-bxnjHY hdPlUe"
         >
           <tbody>
             <tr>
@@ -3450,7 +3450,7 @@ exports[`Storyshots Core/Filters Default 1`] = `
           Staryu
         </h2>
         <table
-          class="sc-kGNyvp kUWvOo"
+          class="sc-bxnjHY hdPlUe"
         >
           <tbody>
             <tr>
@@ -3678,7 +3678,7 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
           Bulbasaur
         </h2>
         <table
-          class="sc-kGNyvp kUWvOo"
+          class="sc-bxnjHY hdPlUe"
         >
           <tbody>
             <tr>
@@ -3768,7 +3768,7 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
           Ivysaur
         </h2>
         <table
-          class="sc-kGNyvp kUWvOo"
+          class="sc-bxnjHY hdPlUe"
         >
           <tbody>
             <tr>
@@ -3858,7 +3858,7 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
           Venusaur
         </h2>
         <table
-          class="sc-kGNyvp kUWvOo"
+          class="sc-bxnjHY hdPlUe"
         >
           <tbody>
             <tr>
@@ -3948,7 +3948,7 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
           Charmander
         </h2>
         <table
-          class="sc-kGNyvp kUWvOo"
+          class="sc-bxnjHY hdPlUe"
         >
           <tbody>
             <tr>
@@ -4038,7 +4038,7 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
           Charmeleon
         </h2>
         <table
-          class="sc-kGNyvp kUWvOo"
+          class="sc-bxnjHY hdPlUe"
         >
           <tbody>
             <tr>
@@ -4130,7 +4130,7 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
           Charizard
         </h2>
         <table
-          class="sc-kGNyvp kUWvOo"
+          class="sc-bxnjHY hdPlUe"
         >
           <tbody>
             <tr>
@@ -4249,7 +4249,7 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
           Squirtle
         </h2>
         <table
-          class="sc-kGNyvp kUWvOo"
+          class="sc-bxnjHY hdPlUe"
         >
           <tbody>
             <tr>
@@ -4368,7 +4368,7 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
           Wartortle
         </h2>
         <table
-          class="sc-kGNyvp kUWvOo"
+          class="sc-bxnjHY hdPlUe"
         >
           <tbody>
             <tr>
@@ -4458,7 +4458,7 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
           Blastoise
         </h2>
         <table
-          class="sc-kGNyvp kUWvOo"
+          class="sc-bxnjHY hdPlUe"
         >
           <tbody>
             <tr>
@@ -4548,7 +4548,7 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
           Caterpie
         </h2>
         <table
-          class="sc-kGNyvp kUWvOo"
+          class="sc-bxnjHY hdPlUe"
         >
           <tbody>
             <tr>
@@ -4638,7 +4638,7 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
           Staryu
         </h2>
         <table
-          class="sc-kGNyvp kUWvOo"
+          class="sc-bxnjHY hdPlUe"
         >
           <tbody>
             <tr>
@@ -4955,7 +4955,7 @@ exports[`Storyshots Core/Filters Render Modes 1`] = `
           Squirtle
         </h2>
         <table
-          class="sc-kGNyvp kUWvOo"
+          class="sc-bxnjHY hdPlUe"
         >
           <tbody>
             <tr>

--- a/src/components/Form/__snapshots__/Form.stories.storyshot
+++ b/src/components/Form/__snapshots__/Form.stories.storyshot
@@ -262,7 +262,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                         id="root_first_seen__description"
                       >
                         <div
-                          class="sc-fKFxtB eNMjwF sc-bBXrwG caFSBy sc-cipXqI ioQWsw"
+                          class="sc-fKFxtB eNMjwF sc-bBXrwG caFSBy sc-jYCGPb cDTTdv"
                         >
                           <div>
                             <p
@@ -305,7 +305,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                         id="root_poke_password__description"
                       >
                         <div
-                          class="sc-fKFxtB eNMjwF sc-bBXrwG caFSBy sc-cipXqI ioQWsw"
+                          class="sc-fKFxtB eNMjwF sc-bBXrwG caFSBy sc-jYCGPb cDTTdv"
                         >
                           <div>
                             <p
@@ -412,7 +412,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                           id="root_tags__description"
                         >
                           <div
-                            class="sc-fKFxtB eNMjwF sc-bBXrwG caFSBy sc-cipXqI ioQWsw"
+                            class="sc-fKFxtB eNMjwF sc-bBXrwG caFSBy sc-jYCGPb cDTTdv"
                           >
                             <div>
                               <p
@@ -744,7 +744,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                         id="root_first_seen__description"
                       >
                         <div
-                          class="sc-fKFxtB eNMjwF sc-bBXrwG caFSBy sc-cipXqI ioQWsw"
+                          class="sc-fKFxtB eNMjwF sc-bBXrwG caFSBy sc-jYCGPb cDTTdv"
                         >
                           <div>
                             <p
@@ -787,7 +787,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                         id="root_poke_password__description"
                       >
                         <div
-                          class="sc-fKFxtB eNMjwF sc-bBXrwG caFSBy sc-cipXqI ioQWsw"
+                          class="sc-fKFxtB eNMjwF sc-bBXrwG caFSBy sc-jYCGPb cDTTdv"
                         >
                           <div>
                             <p
@@ -894,7 +894,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                           id="root_tags__description"
                         >
                           <div
-                            class="sc-fKFxtB eNMjwF sc-bBXrwG caFSBy sc-cipXqI ioQWsw"
+                            class="sc-fKFxtB eNMjwF sc-bBXrwG caFSBy sc-jYCGPb cDTTdv"
                           >
                             <div>
                               <p
@@ -1234,7 +1234,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                         id="root_first_seen__description"
                       >
                         <div
-                          class="sc-fKFxtB eNMjwF sc-bBXrwG caFSBy sc-cipXqI ioQWsw"
+                          class="sc-fKFxtB eNMjwF sc-bBXrwG caFSBy sc-jYCGPb cDTTdv"
                         >
                           <div>
                             <p
@@ -1278,7 +1278,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                         id="root_poke_password__description"
                       >
                         <div
-                          class="sc-fKFxtB eNMjwF sc-bBXrwG caFSBy sc-cipXqI ioQWsw"
+                          class="sc-fKFxtB eNMjwF sc-bBXrwG caFSBy sc-jYCGPb cDTTdv"
                         >
                           <div>
                             <p
@@ -1387,7 +1387,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                           id="root_tags__description"
                         >
                           <div
-                            class="sc-fKFxtB eNMjwF sc-bBXrwG caFSBy sc-cipXqI ioQWsw"
+                            class="sc-fKFxtB eNMjwF sc-bBXrwG caFSBy sc-jYCGPb cDTTdv"
                           >
                             <div>
                               <p
@@ -1719,7 +1719,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                         id="root_first_seen__description"
                       >
                         <div
-                          class="sc-fKFxtB eNMjwF sc-bBXrwG caFSBy sc-cipXqI ioQWsw"
+                          class="sc-fKFxtB eNMjwF sc-bBXrwG caFSBy sc-jYCGPb cDTTdv"
                         >
                           <div>
                             <p
@@ -1762,7 +1762,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                         id="root_poke_password__description"
                       >
                         <div
-                          class="sc-fKFxtB eNMjwF sc-bBXrwG caFSBy sc-cipXqI ioQWsw"
+                          class="sc-fKFxtB eNMjwF sc-bBXrwG caFSBy sc-jYCGPb cDTTdv"
                         >
                           <div>
                             <p
@@ -1869,7 +1869,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                           id="root_tags__description"
                         >
                           <div
-                            class="sc-fKFxtB eNMjwF sc-bBXrwG caFSBy sc-cipXqI ioQWsw"
+                            class="sc-fKFxtB eNMjwF sc-bBXrwG caFSBy sc-jYCGPb cDTTdv"
                           >
                             <div>
                               <p
@@ -2196,7 +2196,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                         id="root_first_seen__description"
                       >
                         <div
-                          class="sc-fKFxtB eNMjwF sc-bBXrwG caFSBy sc-cipXqI ioQWsw"
+                          class="sc-fKFxtB eNMjwF sc-bBXrwG caFSBy sc-jYCGPb cDTTdv"
                         >
                           <div>
                             <p
@@ -2239,7 +2239,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                         id="root_poke_password__description"
                       >
                         <div
-                          class="sc-fKFxtB eNMjwF sc-bBXrwG caFSBy sc-cipXqI ioQWsw"
+                          class="sc-fKFxtB eNMjwF sc-bBXrwG caFSBy sc-jYCGPb cDTTdv"
                         >
                           <div>
                             <p
@@ -2346,7 +2346,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                           id="root_tags__description"
                         >
                           <div
-                            class="sc-fKFxtB eNMjwF sc-bBXrwG caFSBy sc-cipXqI ioQWsw"
+                            class="sc-fKFxtB eNMjwF sc-bBXrwG caFSBy sc-jYCGPb cDTTdv"
                           >
                             <div>
                               <p
@@ -2571,7 +2571,7 @@ exports[`Storyshots Core/Form With Extra Widgets 1`] = `
       class="sc-gKseQn cOdZAq sc-iBPTik dzpbnr"
     >
       <div
-        class="sc-fKFxtB eNMjwF sc-bBXrwG caFSBy sc-cipXqI ioQWsw"
+        class="sc-fKFxtB eNMjwF sc-bBXrwG caFSBy sc-jYCGPb cDTTdv"
       >
         <div>
           <h1
@@ -3373,7 +3373,7 @@ Rendition contains widgets for rendering Markdown and Mermaid text formats that 
                         Markdown
                       </label>
                       <div
-                        class="sc-clhTte gMRvHi"
+                        class="sc-kGNyvp kFYwZx"
                         id="simplemde-editor-1-wrapper"
                       >
                         <textarea
@@ -3665,7 +3665,7 @@ Rendition contains widgets for rendering Markdown and Mermaid text formats that 
                         Captcha
                       </label>
                       <div
-                        class="sc-kJFuxL cQJvrb"
+                        class="sc-bAffKu gdCpkg"
                       />
                     </div>
                   </div>
@@ -3762,7 +3762,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                         id="root_Name"
                       >
                         <div
-                          class="sc-fKFxtB eNMjwF sc-bBXrwG caFSBy sc-cipXqI ioQWsw"
+                          class="sc-fKFxtB eNMjwF sc-bBXrwG caFSBy sc-jYCGPb cDTTdv"
                         >
                           <div>
                             <p
@@ -3972,7 +3972,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                         id="root_first_seen__description"
                       >
                         <div
-                          class="sc-fKFxtB eNMjwF sc-bBXrwG caFSBy sc-cipXqI ioQWsw"
+                          class="sc-fKFxtB eNMjwF sc-bBXrwG caFSBy sc-jYCGPb cDTTdv"
                         >
                           <div>
                             <p
@@ -4015,7 +4015,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                         id="root_poke_password__description"
                       >
                         <div
-                          class="sc-fKFxtB eNMjwF sc-bBXrwG caFSBy sc-cipXqI ioQWsw"
+                          class="sc-fKFxtB eNMjwF sc-bBXrwG caFSBy sc-jYCGPb cDTTdv"
                         >
                           <div>
                             <p
@@ -4146,7 +4146,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                           id="root_tags__description"
                         >
                           <div
-                            class="sc-fKFxtB eNMjwF sc-bBXrwG caFSBy sc-cipXqI ioQWsw"
+                            class="sc-fKFxtB eNMjwF sc-bBXrwG caFSBy sc-jYCGPb cDTTdv"
                           >
                             <div>
                               <p
@@ -4832,7 +4832,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                         id="root_first_seen__description"
                       >
                         <div
-                          class="sc-fKFxtB eNMjwF sc-bBXrwG caFSBy sc-cipXqI ioQWsw"
+                          class="sc-fKFxtB eNMjwF sc-bBXrwG caFSBy sc-jYCGPb cDTTdv"
                         >
                           <div>
                             <p
@@ -4875,7 +4875,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                         id="root_poke_password__description"
                       >
                         <div
-                          class="sc-fKFxtB eNMjwF sc-bBXrwG caFSBy sc-cipXqI ioQWsw"
+                          class="sc-fKFxtB eNMjwF sc-bBXrwG caFSBy sc-jYCGPb cDTTdv"
                         >
                           <div>
                             <p
@@ -5006,7 +5006,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                           id="root_tags__description"
                         >
                           <div
-                            class="sc-fKFxtB eNMjwF sc-bBXrwG caFSBy sc-cipXqI ioQWsw"
+                            class="sc-fKFxtB eNMjwF sc-bBXrwG caFSBy sc-jYCGPb cDTTdv"
                           >
                             <div>
                               <p
@@ -5147,7 +5147,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                             class="sc-gKseQn cOdZAq sc-iBPTik kyOabN sc-hHfuMS hAjhwI sc-biBsmb gKCqzh"
                           >
                             <div
-                              class="sc-fKFxtB eNMjwF sc-bBXrwG caFSBy sc-cipXqI ioQWsw"
+                              class="sc-fKFxtB eNMjwF sc-bBXrwG caFSBy sc-jYCGPb cDTTdv"
                             >
                               <div>
                                 <p
@@ -5377,7 +5377,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                         id="root_first_seen__description"
                       >
                         <div
-                          class="sc-fKFxtB eNMjwF sc-bBXrwG caFSBy sc-cipXqI ioQWsw"
+                          class="sc-fKFxtB eNMjwF sc-bBXrwG caFSBy sc-jYCGPb cDTTdv"
                         >
                           <div>
                             <p
@@ -5420,7 +5420,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                         id="root_poke_password__description"
                       >
                         <div
-                          class="sc-fKFxtB eNMjwF sc-bBXrwG caFSBy sc-cipXqI ioQWsw"
+                          class="sc-fKFxtB eNMjwF sc-bBXrwG caFSBy sc-jYCGPb cDTTdv"
                         >
                           <div>
                             <p
@@ -5551,7 +5551,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                           id="root_tags__description"
                         >
                           <div
-                            class="sc-fKFxtB eNMjwF sc-bBXrwG caFSBy sc-cipXqI ioQWsw"
+                            class="sc-fKFxtB eNMjwF sc-bBXrwG caFSBy sc-jYCGPb cDTTdv"
                           >
                             <div>
                               <p

--- a/src/components/Navbar/__snapshots__/Navbar.stories.storyshot
+++ b/src/components/Navbar/__snapshots__/Navbar.stories.storyshot
@@ -9,7 +9,7 @@ exports[`Storyshots Core/Navbar Default 1`] = `
       class="sc-gKseQn cOdZAq sc-iBPTik icKUIt"
     >
       <div
-        class="sc-gKseQn cOdZAq sc-iBPTik jCoLHv sc-dkAqVg dbZNWR sc-jifHHV juzEvz"
+        class="sc-gKseQn cOdZAq sc-iBPTik jCoLHv sc-bSFUlv fXMplH sc-jvfqPk bvBrDk"
       >
         <div
           class="sc-gKseQn cOdZAq sc-iBPTik bqhgIB sc-hHfuMS hyLyPm"
@@ -18,7 +18,7 @@ exports[`Storyshots Core/Navbar Default 1`] = `
             class="sc-gKseQn cOdZAq sc-iBPTik bqhgIB sc-hHfuMS kXuowN"
           >
             <div
-              class="sc-gKseQn cOdZAq sc-iBPTik bEdFVY sc-hkwmXC klUrZH"
+              class="sc-gKseQn cOdZAq sc-iBPTik bEdFVY sc-edoYdd kCTMpm"
             >
               <a
                 class="sc-eGCaLh ivtBsX sc-ctaXho gJOVRq"
@@ -33,7 +33,7 @@ exports[`Storyshots Core/Navbar Default 1`] = `
               </a>
             </div>
             <div
-              class="sc-gKseQn cOdZAq sc-iBPTik kRHOup sc-bSFUlv dXJrVV"
+              class="sc-gKseQn cOdZAq sc-iBPTik kRHOup sc-jlIlqL KwRiD"
             >
               <svg
                 aria-hidden="true"
@@ -53,7 +53,7 @@ exports[`Storyshots Core/Navbar Default 1`] = `
             </div>
           </div>
           <div
-            class="sc-gKseQn cOdZAq sc-iBPTik fLsURK sc-hHfuMS sc-jvfqPk kXuowN MmqKb"
+            class="sc-gKseQn cOdZAq sc-iBPTik fLsURK sc-hHfuMS sc-iWRHom kXuowN VYDTt"
           >
             <div
               class="sc-gKseQn cOdZAq sc-iBPTik dSEnBp sc-hHfuMS hyLyPm"

--- a/src/components/Notifications/__snapshots__/Notifications.stories.storyshot
+++ b/src/components/Notifications/__snapshots__/Notifications.stories.storyshot
@@ -9,7 +9,7 @@ exports[`Storyshots Core/Notifications Default 1`] = `
       class="sc-gKseQn cOdZAq sc-iBPTik fHoxZW sc-hHfuMS hAjhwI"
     >
       <div
-        class="react-notification-root sc-gHfsNP kGRduT"
+        class="react-notification-root sc-hkwmXC dChClp"
       >
         <div
           class="notification-container-top-left"
@@ -25,7 +25,7 @@ exports[`Storyshots Core/Notifications Default 1`] = `
               class="notification-item n-child"
             >
               <div
-                class="sc-gKseQn cOdZAq sc-iBPTik bqhgIB sc-hHfuMS sc-dmlqKv kXuowN eHSTVh sc-lmoMya dEAGLX sc-JAcba bOMZLA"
+                class="sc-gKseQn cOdZAq sc-iBPTik bqhgIB sc-hHfuMS sc-dmlqKv kXuowN eHSTVh sc-lmoMya dEAGLX sc-jifHHV jsgwuM"
               >
                 
                 <div
@@ -71,7 +71,7 @@ exports[`Storyshots Core/Notifications Default 1`] = `
               class="notification-item n-child"
             >
               <div
-                class="sc-gKseQn cOdZAq sc-iBPTik bqhgIB sc-hHfuMS sc-dmlqKv kXuowN eHSTVh sc-lmoMya dEAGLX sc-JAcba bOMZLA"
+                class="sc-gKseQn cOdZAq sc-iBPTik bqhgIB sc-hHfuMS sc-dmlqKv kXuowN eHSTVh sc-lmoMya dEAGLX sc-jifHHV jsgwuM"
               >
                 
                 <div
@@ -167,7 +167,7 @@ exports[`Storyshots Core/Notifications Positioning 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 cNraFD sc-eFuaqX iXQyXF"
   >
     <div
-      class="react-notification-root sc-gHfsNP kGRduT"
+      class="react-notification-root sc-hkwmXC dChClp"
     >
       <div
         class="notification-container-top-left"
@@ -180,7 +180,7 @@ exports[`Storyshots Core/Notifications Positioning 1`] = `
             class="notification-item n-child"
           >
             <div
-              class="sc-gKseQn cOdZAq sc-iBPTik bqhgIB sc-hHfuMS sc-dmlqKv kXuowN eHSTVh sc-lmoMya dEAGLX sc-JAcba bOMZLA"
+              class="sc-gKseQn cOdZAq sc-iBPTik bqhgIB sc-hHfuMS sc-dmlqKv kXuowN eHSTVh sc-lmoMya dEAGLX sc-jifHHV jsgwuM"
             >
               
               <div
@@ -230,7 +230,7 @@ exports[`Storyshots Core/Notifications Positioning 1`] = `
             class="notification-item n-child"
           >
             <div
-              class="sc-gKseQn cOdZAq sc-iBPTik bqhgIB sc-hHfuMS sc-dmlqKv kXuowN eHSTVh sc-lmoMya dEAGLX sc-JAcba bOMZLA"
+              class="sc-gKseQn cOdZAq sc-iBPTik bqhgIB sc-hHfuMS sc-dmlqKv kXuowN eHSTVh sc-lmoMya dEAGLX sc-jifHHV jsgwuM"
             >
               
               <div
@@ -280,7 +280,7 @@ exports[`Storyshots Core/Notifications Positioning 1`] = `
             class="notification-item n-child"
           >
             <div
-              class="sc-gKseQn cOdZAq sc-iBPTik bqhgIB sc-hHfuMS sc-dmlqKv kXuowN eHSTVh sc-lmoMya dEAGLX sc-JAcba bOMZLA"
+              class="sc-gKseQn cOdZAq sc-iBPTik bqhgIB sc-hHfuMS sc-dmlqKv kXuowN eHSTVh sc-lmoMya dEAGLX sc-jifHHV jsgwuM"
             >
               
               <div
@@ -330,7 +330,7 @@ exports[`Storyshots Core/Notifications Positioning 1`] = `
             class="notification-item n-child"
           >
             <div
-              class="sc-gKseQn cOdZAq sc-iBPTik bqhgIB sc-hHfuMS sc-dmlqKv kXuowN eHSTVh sc-lmoMya dEAGLX sc-JAcba bOMZLA"
+              class="sc-gKseQn cOdZAq sc-iBPTik bqhgIB sc-hHfuMS sc-dmlqKv kXuowN eHSTVh sc-lmoMya dEAGLX sc-jifHHV jsgwuM"
             >
               
               <div
@@ -380,7 +380,7 @@ exports[`Storyshots Core/Notifications Positioning 1`] = `
             class="notification-item n-child"
           >
             <div
-              class="sc-gKseQn cOdZAq sc-iBPTik bqhgIB sc-hHfuMS sc-dmlqKv kXuowN eHSTVh sc-lmoMya dEAGLX sc-JAcba bOMZLA"
+              class="sc-gKseQn cOdZAq sc-iBPTik bqhgIB sc-hHfuMS sc-dmlqKv kXuowN eHSTVh sc-lmoMya dEAGLX sc-jifHHV jsgwuM"
             >
               
               <div
@@ -433,7 +433,7 @@ exports[`Storyshots Core/Notifications Positioning 1`] = `
               class="notification-item n-child"
             >
               <div
-                class="sc-gKseQn cOdZAq sc-iBPTik bqhgIB sc-hHfuMS sc-dmlqKv kXuowN eHSTVh sc-lmoMya dEAGLX sc-JAcba bOMZLA"
+                class="sc-gKseQn cOdZAq sc-iBPTik bqhgIB sc-hHfuMS sc-dmlqKv kXuowN eHSTVh sc-lmoMya dEAGLX sc-jifHHV jsgwuM"
               >
                 
                 <div
@@ -484,7 +484,7 @@ exports[`Storyshots Core/Notifications Positioning 1`] = `
             class="notification-item n-child"
           >
             <div
-              class="sc-gKseQn cOdZAq sc-iBPTik bqhgIB sc-hHfuMS sc-dmlqKv kXuowN eHSTVh sc-lmoMya dEAGLX sc-JAcba bOMZLA"
+              class="sc-gKseQn cOdZAq sc-iBPTik bqhgIB sc-hHfuMS sc-dmlqKv kXuowN eHSTVh sc-lmoMya dEAGLX sc-jifHHV jsgwuM"
             >
               
               <div
@@ -591,7 +591,7 @@ exports[`Storyshots Core/Notifications Types 1`] = `
       class="sc-gKseQn cOdZAq sc-iBPTik fHoxZW sc-hHfuMS hAjhwI"
     >
       <div
-        class="react-notification-root sc-gHfsNP kGRduT"
+        class="react-notification-root sc-hkwmXC dChClp"
       >
         <div
           class="notification-container-top-left"
@@ -607,7 +607,7 @@ exports[`Storyshots Core/Notifications Types 1`] = `
               class="notification-item n-child"
             >
               <div
-                class="sc-gKseQn cOdZAq sc-iBPTik ekHhPE sc-hHfuMS sc-dmlqKv kXuowN iHSEZP sc-lmoMya dEAGLX sc-JAcba bOMZLA"
+                class="sc-gKseQn cOdZAq sc-iBPTik ekHhPE sc-hHfuMS sc-dmlqKv kXuowN iHSEZP sc-lmoMya dEAGLX sc-jifHHV jsgwuM"
               >
                 <div
                   class="sc-fKFxtB eNMjwF sc-bBXrwG eebxHH"
@@ -675,7 +675,7 @@ exports[`Storyshots Core/Notifications Types 1`] = `
               class="notification-item n-child"
             >
               <div
-                class="sc-gKseQn cOdZAq sc-iBPTik gEWEsG sc-hHfuMS sc-dmlqKv kXuowN inWYSQ sc-lmoMya dEAGLX sc-JAcba bOMZLA"
+                class="sc-gKseQn cOdZAq sc-iBPTik gEWEsG sc-hHfuMS sc-dmlqKv kXuowN inWYSQ sc-lmoMya dEAGLX sc-jifHHV jsgwuM"
               >
                 <div
                   class="sc-fKFxtB eNMjwF sc-bBXrwG dUMxoh"
@@ -743,7 +743,7 @@ exports[`Storyshots Core/Notifications Types 1`] = `
               class="notification-item n-child"
             >
               <div
-                class="sc-gKseQn cOdZAq sc-iBPTik eZdrRm sc-hHfuMS sc-dmlqKv kXuowN kFGRDj sc-lmoMya dEAGLX sc-JAcba bOMZLA"
+                class="sc-gKseQn cOdZAq sc-iBPTik eZdrRm sc-hHfuMS sc-dmlqKv kXuowN kFGRDj sc-lmoMya dEAGLX sc-jifHHV jsgwuM"
               >
                 <div
                   class="sc-fKFxtB eNMjwF sc-bBXrwG gekcFt"
@@ -811,7 +811,7 @@ exports[`Storyshots Core/Notifications Types 1`] = `
               class="notification-item n-child"
             >
               <div
-                class="sc-gKseQn cOdZAq sc-iBPTik crZzRb sc-hHfuMS sc-dmlqKv kXuowN bBdqzk sc-lmoMya dEAGLX sc-JAcba bOMZLA"
+                class="sc-gKseQn cOdZAq sc-iBPTik crZzRb sc-hHfuMS sc-dmlqKv kXuowN bBdqzk sc-lmoMya dEAGLX sc-jifHHV jsgwuM"
               >
                 <div
                   class="sc-fKFxtB eNMjwF sc-bBXrwG cYtESA"

--- a/src/components/Tabs/__snapshots__/Tabs.stories.storyshot
+++ b/src/components/Tabs/__snapshots__/Tabs.stories.storyshot
@@ -6,7 +6,7 @@ exports[`Storyshots Core/Tabs Compact 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 cNraFD sc-eFuaqX iXQyXF"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 kSZjsO StyledTabs-sc-a4fwxl-2 keuzHD sc-edoYdd cgpscD sc-jlIlqL iEUOqq"
+      class="StyledBox-sc-13pk1d4-0 kSZjsO StyledTabs-sc-a4fwxl-2 keuzHD sc-hYAvtR bUTIbE sc-hJJRrs ekdgwD"
       role="tablist"
     >
       <div
@@ -137,7 +137,7 @@ exports[`Storyshots Core/Tabs Default 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 cNraFD sc-eFuaqX iXQyXF"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 kSZjsO StyledTabs-sc-a4fwxl-2 keuzHD sc-edoYdd wbWTu sc-jlIlqL iEUOqq"
+      class="StyledBox-sc-13pk1d4-0 kSZjsO StyledTabs-sc-a4fwxl-2 keuzHD sc-hYAvtR ctpoIh sc-hJJRrs ekdgwD"
       role="tablist"
     >
       <div
@@ -217,7 +217,7 @@ exports[`Storyshots Core/Tabs With Long Titles 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 cNraFD sc-eFuaqX iXQyXF"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 kSZjsO StyledTabs-sc-a4fwxl-2 keuzHD sc-edoYdd wbWTu sc-jlIlqL iEUOqq"
+      class="StyledBox-sc-13pk1d4-0 kSZjsO StyledTabs-sc-a4fwxl-2 keuzHD sc-hYAvtR ctpoIh sc-hJJRrs ekdgwD"
       role="tablist"
     >
       <div

--- a/src/components/TextWithCopy/__snapshots__/TextWithCopy.stories.storyshot
+++ b/src/components/TextWithCopy/__snapshots__/TextWithCopy.stories.storyshot
@@ -6,18 +6,18 @@ exports[`Storyshots Core/TextWithCopy Always Show 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 cNraFD sc-eFuaqX iXQyXF"
   >
     <span
-      class="sc-fKFxtB eNMjwF sc-iwyWTf kPghqC sc-hYZPxA eicDbK text-with-copy"
+      class="sc-fKFxtB eNMjwF sc-iwyWTf kPghqC sc-hYZPxA kEjrfv"
     >
       <span
-        class="text-with-copy__content"
+        class="sc-cHjwLt kFEMXp"
       >
         Click the icon
       </span>
       <span
-        class="text-with-copy__copy_wrapper"
+        class="sc-gHfsNP dROUvG"
       >
         <div
-          class="sc-gKseQn cOdZAq sc-iBPTik bqhgIB text-with-copy__copy"
+          class="sc-gKseQn cOdZAq sc-iBPTik bqhgIB sc-JAcba kulegd"
         >
           <svg
             aria-hidden="true"
@@ -47,7 +47,7 @@ exports[`Storyshots Core/TextWithCopy Code 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 cNraFD sc-eFuaqX iXQyXF"
   >
     <span
-      class="sc-fKFxtB eNMjwF sc-iwyWTf kPghqC sc-hYZPxA eJpxlG text-with-copy"
+      class="sc-fKFxtB eNMjwF sc-iwyWTf kPghqC sc-hYZPxA kEjrfv"
       title="This value has been copied to your clipboard!"
     >
       <code
@@ -56,10 +56,10 @@ exports[`Storyshots Core/TextWithCopy Code 1`] = `
         3555432
       </code>
       <span
-        class="text-with-copy__copy_wrapper"
+        class="sc-gHfsNP dROUvG"
       >
         <div
-          class="sc-gKseQn cOdZAq sc-iBPTik bqhgIB text-with-copy__copy"
+          class="sc-gKseQn cOdZAq sc-iBPTik bqhgIB sc-JAcba bCbxch"
         >
           <svg
             aria-hidden="true"
@@ -89,11 +89,11 @@ exports[`Storyshots Core/TextWithCopy Default 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 cNraFD sc-eFuaqX iXQyXF"
   >
     <span
-      class="sc-fKFxtB eNMjwF sc-iwyWTf kPghqC sc-hYZPxA eJpxlG text-with-copy"
+      class="sc-fKFxtB eNMjwF sc-iwyWTf kPghqC sc-hYZPxA kEjrfv"
       title="This value has been copied to your clipboard!"
     >
       <span
-        class="text-with-copy__content"
+        class="sc-cHjwLt kFEMXp"
       >
         <i>
           hover
@@ -105,10 +105,10 @@ exports[`Storyshots Core/TextWithCopy Default 1`] = `
          the icon
       </span>
       <span
-        class="text-with-copy__copy_wrapper"
+        class="sc-gHfsNP dROUvG"
       >
         <div
-          class="sc-gKseQn cOdZAq sc-iBPTik bqhgIB text-with-copy__copy"
+          class="sc-gKseQn cOdZAq sc-iBPTik bqhgIB sc-JAcba bCbxch"
         >
           <svg
             aria-hidden="true"

--- a/src/components/TextWithCopy/index.tsx
+++ b/src/components/TextWithCopy/index.tsx
@@ -13,22 +13,6 @@ const Wrapper = styled(Txt.span)<InternalTextWithCopyProps>`
 	display: inline-block;
 	white-space: ${(props) => (props.code ? 'initial' : 'nowrap')};
 
-	.text-with-copy__content {
-		white-space: normal;
-		word-wrap: break-word;
-		margin-right: ${(props) => px(props.theme.space[1])};
-	}
-
-	& > .text-with-copy__copy_wrapper {
-		display: inline-block;
-	}
-
-	.text-with-copy__copy {
-		cursor: pointer;
-		visibility: ${(props) =>
-			props.showCopyButton === 'always' ? 'visible' : 'hidden'};
-	}
-
 	code {
 		font-family: ${(props) => props.theme.monospace};
 		padding: 2px 4px;
@@ -42,10 +26,25 @@ const Wrapper = styled(Txt.span)<InternalTextWithCopyProps>`
 		margin-right: ${(props) => px(props.theme.space[1])};
 		display: inline-block;
 	}
+`;
 
-	&:hover .text-with-copy__copy {
+const Content = styled.span`
+	white-space: normal;
+	word-wrap: break-word;
+	margin-right: ${(props) => px(props.theme.space[1])};
+`;
+
+const Copy = styled(Box)<{ showCopyButton: 'always' | 'hover' | undefined }>`
+	cursor: pointer;
+	visibility: ${(props) =>
+		props.showCopyButton === 'always' ? 'visible' : 'hidden'};
+	&:hover {
 		visibility: visible;
 	}
+`;
+
+const CopyWrapper = styled.span`
+	display: inline-block;
 `;
 
 const BaseTextWithCopy = ({
@@ -53,29 +52,27 @@ const BaseTextWithCopy = ({
 	code,
 	text,
 	children,
-	...props
+	showCopyButton,
 }: InternalTextWithCopyProps) => {
 	const normalizedText = (text || '').toString().trim();
 	const normalizedCopy = (copy || normalizedText).toString().trim();
 	const contentToRender = children || normalizedText || normalizedCopy;
 
 	return (
-		<Wrapper copy={copy} title={copy} {...props} className="text-with-copy">
-			{!code && (
-				<span className="text-with-copy__content">{contentToRender}</span>
-			)}
+		<Wrapper copy={copy} title={copy}>
+			{!code && <Content>{contentToRender}</Content>}
 
 			{code && <code title={normalizedCopy}>{contentToRender}</code>}
 
-			<span onClick={stopEvent} className="text-with-copy__copy_wrapper">
-				<Box
+			<CopyWrapper onClick={stopEvent}>
+				<Copy
 					tooltip={{ text: 'Copied!', trigger: 'click' }}
 					onClick={() => copyToClipboard(normalizedCopy)}
-					className="text-with-copy__copy"
+					showCopyButton={showCopyButton}
 				>
 					<FontAwesomeIcon icon={faCopy} />
-				</Box>
-			</span>
+				</Copy>
+			</CopyWrapper>
 		</Wrapper>
 	);
 };

--- a/src/extra/AutoUi/__snapshots__/AutoUi.stories.storyshot
+++ b/src/extra/AutoUi/__snapshots__/AutoUi.stories.storyshot
@@ -18,7 +18,7 @@ exports[`Storyshots Extra/AutoUICollection Default 1`] = `
             class="sc-gKseQn cOdZAq sc-iBPTik bqhgIB"
           >
             <div
-              class="sc-gKseQn cOdZAq sc-iBPTik bqhgIB sc-hHfuMS sc-fTNIjK EUECC iqQmmj"
+              class="sc-gKseQn cOdZAq sc-iBPTik bqhgIB sc-hHfuMS sc-hguplt EUECC kDTeZd"
             >
               <div
                 class="sc-gKseQn bkeHkg sc-iBPTik bqhgIB"
@@ -148,7 +148,7 @@ exports[`Storyshots Extra/AutoUICollection Default 1`] = `
                 </div>
               </div>
               <div
-                class="sc-gKseQn cOdZAq sc-iBPTik bqhgIB sc-hHfuMS sc-fTNIjK kXuowN iqQmmj"
+                class="sc-gKseQn cOdZAq sc-iBPTik bqhgIB sc-hHfuMS sc-hguplt kXuowN kDTeZd"
               />
             </div>
             <div

--- a/src/extra/Markdown/__snapshots__/Markdown.stories.storyshot
+++ b/src/extra/Markdown/__snapshots__/Markdown.stories.storyshot
@@ -76,7 +76,7 @@ exports[`Storyshots Extra/Markdown Customized 1`] = `
                         class="sc-gKseQn cOdZAq sc-iBPTik jsUrGU"
                       >
                         <div
-                          class="sc-fKFxtB eNMjwF sc-bBXrwG caFSBy sc-cipXqI ioQWsw"
+                          class="sc-fKFxtB eNMjwF sc-bBXrwG caFSBy sc-jYCGPb cDTTdv"
                         >
                           <div>
                             <h1
@@ -113,7 +113,7 @@ exports[`Storyshots Extra/Markdown Customized 1`] = `
                         class="sc-gKseQn cOdZAq sc-iBPTik jsUrGU"
                       >
                         <div
-                          class="sc-fKFxtB eNMjwF sc-bBXrwG caFSBy sc-cipXqI ioQWsw"
+                          class="sc-fKFxtB eNMjwF sc-bBXrwG caFSBy sc-jYCGPb cDTTdv"
                         >
                           <div>
                             A title
@@ -167,7 +167,7 @@ exports[`Storyshots Extra/Markdown Customized 1`] = `
                         class="sc-gKseQn cOdZAq sc-iBPTik jsUrGU"
                       >
                         <div
-                          class="sc-fKFxtB eNMjwF sc-bBXrwG caFSBy sc-cipXqI ioQWsw"
+                          class="sc-fKFxtB eNMjwF sc-bBXrwG caFSBy sc-jYCGPb cDTTdv"
                         >
                           <div>
                             <h1
@@ -204,7 +204,7 @@ exports[`Storyshots Extra/Markdown Customized 1`] = `
                         class="sc-gKseQn cOdZAq sc-iBPTik jsUrGU"
                       >
                         <div
-                          class="sc-fKFxtB eNMjwF sc-bBXrwG caFSBy sc-cipXqI ioQWsw"
+                          class="sc-fKFxtB eNMjwF sc-bBXrwG caFSBy sc-jYCGPb cDTTdv"
                         >
                           <div>
                             A title
@@ -252,7 +252,7 @@ exports[`Storyshots Extra/Markdown Customized 1`] = `
                         class="sc-gKseQn cOdZAq sc-iBPTik jsUrGU"
                       >
                         <div
-                          class="sc-fKFxtB eNMjwF sc-bBXrwG caFSBy sc-cipXqI ioQWsw"
+                          class="sc-fKFxtB eNMjwF sc-bBXrwG caFSBy sc-jYCGPb cDTTdv"
                         >
                           <div>
                             <h1
@@ -289,7 +289,7 @@ exports[`Storyshots Extra/Markdown Customized 1`] = `
                         class="sc-gKseQn cOdZAq sc-iBPTik jsUrGU"
                       >
                         <div
-                          class="sc-fKFxtB eNMjwF sc-bBXrwG caFSBy sc-cipXqI ioQWsw"
+                          class="sc-fKFxtB eNMjwF sc-bBXrwG caFSBy sc-jYCGPb cDTTdv"
                         >
                           <div>
                             <h1
@@ -320,7 +320,7 @@ exports[`Storyshots Extra/Markdown Default 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 cNraFD sc-eFuaqX iXQyXF"
   >
     <div
-      class="sc-fKFxtB eNMjwF sc-bBXrwG caFSBy sc-cipXqI ioQWsw"
+      class="sc-fKFxtB eNMjwF sc-bBXrwG caFSBy sc-jYCGPb cDTTdv"
     >
       <div>
         <h1
@@ -1126,7 +1126,7 @@ exports[`Storyshots Extra/Markdown With Decorators 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 cNraFD sc-eFuaqX iXQyXF"
   >
     <div
-      class="sc-fKFxtB eNMjwF sc-bBXrwG caFSBy sc-cipXqI ioQWsw"
+      class="sc-fKFxtB eNMjwF sc-bBXrwG caFSBy sc-jYCGPb cDTTdv"
     >
       <div>
         <p

--- a/src/extra/MarkdownEditor/__snapshots__/MarkdownEditor.stories.storyshot
+++ b/src/extra/MarkdownEditor/__snapshots__/MarkdownEditor.stories.storyshot
@@ -6,7 +6,7 @@ exports[`Storyshots Extra/MarkdownEditor Default 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 cNraFD sc-eFuaqX iXQyXF"
   >
     <div
-      class="sc-clhTte gMRvHi"
+      class="sc-kGNyvp kFYwZx"
       id="simplemde-editor-2-wrapper"
     >
       <textarea


### PR DESCRIPTION
Use styled components instead of classNames in TextWithCopy

Resolves: #813 
Change-type: patch
Signed-off-by: Matthew Yarmolinsky <matthew-timothy@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
