### PR TITLE
Add a FileContentContainer component

### DIFF
--- a/src/components/FileContentContainer/FileContentContainer.stories.tsx
+++ b/src/components/FileContentContainer/FileContentContainer.stories.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react';
+import { Meta } from '@storybook/react';
+import { createTemplate, createStory } from '../../stories/utils';
+import { FileContentContainer, FileContentContainerProps } from './';
+
+export default {
+	title: 'Core/FileContentContainer',
+	component: FileContentContainer,
+	decorators: [
+		(Story) => (
+			<div style={{ width: 400, height: 400 }}>
+				<Story />
+			</div>
+		),
+	],
+} as Meta;
+
+const Template =
+	createTemplate<FileContentContainerProps>(FileContentContainer);
+
+// I'll see if this is the best example text to use
+export const Default = createStory<FileContentContainerProps>(Template, {
+	children: `FROM show/some/example/code
+
+    RUN some example formatted code
+    
+    Lorem ipsum dolor sit amet,
+       
+    consectetur adipiscing elit.
+    
+    Nam scelerisque euismod risus at gravida.
+    
+    Pellentesque a nunc semper,
+    
+    ultrices lacus nec, mattis mauris
+
+    `,
+});

--- a/src/components/FileContentContainer/index.tsx
+++ b/src/components/FileContentContainer/index.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+import styled from 'styled-components';
+import { RenditionSystemProps } from '../../common-types';
+
+import asRendition from '../../asRendition';
+// now import some components it builds on
+
+const ComposeContainer = styled.pre`
+	background: none;
+	color: inherit;
+	border: 0;
+	margin: 0;
+	padding: 0;
+	font-size: inherit;
+	white-space: pre-wrap;
+`;
+
+/*const FileContentContainerBase = ()=> {
+    return (
+        <ComposeContainer></ComposeContainer>
+    );
+};*/
+// note: this should be good for now. See how it looks with <Box>
+const FileContentContainerBase = ({
+	children,
+}: InternalContentContainerProps) => {
+	const Body = children;
+	return <ComposeContainer>{Body}</ComposeContainer>;
+};
+
+export interface InternalContentContainerProps {
+	children?: string;
+}
+
+export type FileContentContainerProps = InternalContentContainerProps &
+	RenditionSystemProps;
+
+export const FileContentContainer = asRendition<
+	React.FunctionComponent<FileContentContainerProps>
+>(FileContentContainerBase);


### PR DESCRIPTION
Add FileContentContainer compoment which makes viewing the contents of a file easier. 

Change-type: feat/minor


Connects-to: #1435 
See: https://github.com/balena-io/balena-ui/issues/3497


---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
