### PR TITLE
Adding a hover effect to plain button

### DIFF
--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -151,7 +151,7 @@ const Plain = styled(ButtonBase)`
 		border-radius: 0;
 		${(props) =>
 			getHoverEffectOverride(
-				'none',
+				'#f8f9fd',
 				getColor(props, 'color', 'dark') || props.theme.colors.text.light,
 			)};
 	}


### PR DESCRIPTION
I have added hover effect to the Plain button as specified in issue 3183. 
Here is a screenshot of what the hover effect looks like in the dropdown menu:
![image](https://user-images.githubusercontent.com/8771822/138862228-19ec6f88-4f11-47ed-b235-90c7cb21605f.png)


Connects-to: #1442
See: https://github.com/balena-io/balena-ui/issues/3183
Change-type: minor

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screen shots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`


##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
