### PR TITLE
Add OpaqueLayer component

### DIFF
--- a/src/components/Accordion/__snapshots__/Accordion.stories.storyshot
+++ b/src/components/Accordion/__snapshots__/Accordion.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/Accordion Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 hpSXsQ"

--- a/src/components/Alert/__snapshots__/Alert.stories.storyshot
+++ b/src/components/Alert/__snapshots__/Alert.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/Alert Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd exdBHI sc-iCfMLu bURqap sc-hGPBjI sc-dlVxhl dljPk hpBCna sc-llYSUQ FJxnU"
@@ -49,7 +49,7 @@ exports[`Storyshots Core/Alert Default 1`] = `
 exports[`Storyshots Core/Alert Emphasized 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd exdBHI sc-iCfMLu huiLtj sc-hGPBjI sc-dlVxhl dljPk liQeNu sc-llYSUQ FJxnU"
@@ -95,7 +95,7 @@ exports[`Storyshots Core/Alert Emphasized 1`] = `
 exports[`Storyshots Core/Alert Plaintext 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI dljPk sc-llYSUQ FJxnU"
@@ -132,7 +132,7 @@ exports[`Storyshots Core/Alert Plaintext 1`] = `
 exports[`Storyshots Core/Alert With Link 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd exdBHI sc-iCfMLu bURqap sc-hGPBjI sc-dlVxhl dljPk hpBCna sc-llYSUQ FJxnU"
@@ -185,7 +185,7 @@ exports[`Storyshots Core/Alert With Link 1`] = `
 exports[`Storyshots Core/Alert Without Dismiss 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd exdBHI sc-iCfMLu bURqap sc-hGPBjI sc-dlVxhl dljPk hpBCna sc-llYSUQ FJxnU"
@@ -231,7 +231,7 @@ exports[`Storyshots Core/Alert Without Dismiss 1`] = `
 exports[`Storyshots Core/Alert Without Prefix 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd exdBHI sc-iCfMLu bURqap sc-hGPBjI sc-dlVxhl dljPk hpBCna sc-llYSUQ FJxnU"

--- a/src/components/Avatar/__snapshots__/Avatar.stories.storyshot
+++ b/src/components/Avatar/__snapshots__/Avatar.stories.storyshot
@@ -3,11 +3,11 @@
 exports[`Storyshots Core/Avatar Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     
     <div
-      class="StyledBox-sc-13pk1d4-0 hnCSiQ StyledAvatar-sc-1suyamb-1 sc-hRMWxn NGAiA"
+      class="StyledBox-sc-13pk1d4-0 hnCSiQ StyledAvatar-sc-1suyamb-1 sc-fTxOGA jcqvjl"
     >
       <svg
         aria-hidden="true"
@@ -33,10 +33,10 @@ exports[`Storyshots Core/Avatar Default 1`] = `
 exports[`Storyshots Core/Avatar Emphasized 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 jiCZEI StyledAvatar-sc-1suyamb-1 sc-hRMWxn NGAiA"
+      class="StyledBox-sc-13pk1d4-0 jiCZEI StyledAvatar-sc-1suyamb-1 sc-fTxOGA jcqvjl"
     >
       <div
         class="sc-fKVqWL hOcWtv sc-bBHxTw cqZchy"
@@ -51,10 +51,10 @@ exports[`Storyshots Core/Avatar Emphasized 1`] = `
 exports[`Storyshots Core/Avatar With First Name 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hnCSiQ StyledAvatar-sc-1suyamb-1 sc-hRMWxn NGAiA"
+      class="StyledBox-sc-13pk1d4-0 hnCSiQ StyledAvatar-sc-1suyamb-1 sc-fTxOGA jcqvjl"
     >
       <div
         class="sc-fKVqWL hOcWtv sc-bBHxTw cqZchy"
@@ -69,10 +69,10 @@ exports[`Storyshots Core/Avatar With First Name 1`] = `
 exports[`Storyshots Core/Avatar With Full Name 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hnCSiQ StyledAvatar-sc-1suyamb-1 sc-hRMWxn NGAiA"
+      class="StyledBox-sc-13pk1d4-0 hnCSiQ StyledAvatar-sc-1suyamb-1 sc-fTxOGA jcqvjl"
     >
       <div
         class="sc-fKVqWL hOcWtv sc-bBHxTw cqZchy"
@@ -87,10 +87,10 @@ exports[`Storyshots Core/Avatar With Full Name 1`] = `
 exports[`Storyshots Core/Avatar With Image 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hRWFaH StyledAvatar-sc-1suyamb-1 sc-hRMWxn NGAiA"
+      class="StyledBox-sc-13pk1d4-0 hRWFaH StyledAvatar-sc-1suyamb-1 sc-fTxOGA jcqvjl"
     />
     
   </div>
@@ -100,10 +100,10 @@ exports[`Storyshots Core/Avatar With Image 1`] = `
 exports[`Storyshots Core/Avatar With Last Name 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hnCSiQ StyledAvatar-sc-1suyamb-1 sc-hRMWxn NGAiA"
+      class="StyledBox-sc-13pk1d4-0 hnCSiQ StyledAvatar-sc-1suyamb-1 sc-fTxOGA jcqvjl"
     >
       <div
         class="sc-fKVqWL hOcWtv sc-bBHxTw cqZchy"

--- a/src/components/Badge/__snapshots__/Badge.stories.storyshot
+++ b/src/components/Badge/__snapshots__/Badge.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/Badge Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <span
       class="sc-fKVqWL hOcWtv sc-iwjdpV hWOcgl sc-iJKOTD fDCXsG sc-giYglK NZLql"

--- a/src/components/Banner/__snapshots__/Banner.stories.storyshot
+++ b/src/components/Banner/__snapshots__/Banner.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/Banner Primary 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-ezbkAF jrnTxU lmnrNx sc-bYoBSM jnvMPR"

--- a/src/components/Box/__snapshots__/Box.stories.storyshot
+++ b/src/components/Box/__snapshots__/Box.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/Box Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd exdBHI sc-iCfMLu jciJBO"

--- a/src/components/Breadcrumbs/__snapshots__/Breadcrumbs.stories.storyshot
+++ b/src/components/Breadcrumbs/__snapshots__/Breadcrumbs.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/Breadcrumbs Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd exdBHI sc-iCfMLu frGhDt sc-hGPBjI fA-dHZr"
@@ -18,7 +18,7 @@ exports[`Storyshots Core/Breadcrumbs Default 1`] = `
             class="sc-gKclnd exdBHI sc-iCfMLu frGhDt sc-hGPBjI jouXBw"
           >
             <div
-              class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-fTxOGA dljPk beaNYA"
+              class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-BHvUt dljPk fEvoVG"
             />
             <div
               class="sc-gKclnd exdBHI sc-iCfMLu DnkNu sc-hGPBjI dljPk"
@@ -60,7 +60,7 @@ exports[`Storyshots Core/Breadcrumbs Default 1`] = `
             class="sc-gKclnd exdBHI sc-iCfMLu frGhDt sc-hGPBjI jouXBw"
           >
             <div
-              class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-fTxOGA dljPk beaNYA"
+              class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-BHvUt dljPk fEvoVG"
             />
             <div
               class="sc-gKclnd exdBHI sc-iCfMLu DnkNu sc-hGPBjI dljPk"
@@ -102,7 +102,7 @@ exports[`Storyshots Core/Breadcrumbs Default 1`] = `
             class="sc-gKclnd exdBHI sc-iCfMLu frGhDt sc-hGPBjI jouXBw"
           >
             <div
-              class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-fTxOGA dljPk jTCUec"
+              class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-BHvUt dljPk eOEyFa"
             />
             <div
               class="sc-gKclnd exdBHI sc-iCfMLu DnkNu sc-hGPBjI dljPk"
@@ -154,7 +154,7 @@ exports[`Storyshots Core/Breadcrumbs Default 1`] = `
 exports[`Storyshots Core/Breadcrumbs Wrapped 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd exdBHI sc-iCfMLu cZjQcD sc-hGPBjI dljPk"
@@ -172,7 +172,7 @@ exports[`Storyshots Core/Breadcrumbs Wrapped 1`] = `
               class="sc-gKclnd exdBHI sc-iCfMLu frGhDt sc-hGPBjI jouXBw"
             >
               <div
-                class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-fTxOGA dljPk beaNYA"
+                class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-BHvUt dljPk fEvoVG"
               />
               <div
                 class="sc-gKclnd exdBHI sc-iCfMLu DnkNu sc-hGPBjI dljPk"
@@ -214,7 +214,7 @@ exports[`Storyshots Core/Breadcrumbs Wrapped 1`] = `
               class="sc-gKclnd exdBHI sc-iCfMLu frGhDt sc-hGPBjI jouXBw"
             >
               <div
-                class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-fTxOGA dljPk beaNYA"
+                class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-BHvUt dljPk fEvoVG"
               />
               <div
                 class="sc-gKclnd exdBHI sc-iCfMLu DnkNu sc-hGPBjI dljPk"
@@ -256,7 +256,7 @@ exports[`Storyshots Core/Breadcrumbs Wrapped 1`] = `
               class="sc-gKclnd exdBHI sc-iCfMLu frGhDt sc-hGPBjI jouXBw"
             >
               <div
-                class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-fTxOGA dljPk jTCUec"
+                class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-BHvUt dljPk eOEyFa"
               />
               <div
                 class="sc-gKclnd exdBHI sc-iCfMLu DnkNu sc-hGPBjI dljPk"

--- a/src/components/Button/__snapshots__/Button.stories.storyshot
+++ b/src/components/Button/__snapshots__/Button.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/Button Active 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <button
       class="StyledButton-sc-323bzc-0 eFzidw sc-bqiRlB sc-ksdxgE edofBN dJfWty sc-dJjYzT cGuTUx"
@@ -18,7 +18,7 @@ exports[`Storyshots Core/Button Active 1`] = `
 exports[`Storyshots Core/Button Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <button
       class="StyledButton-sc-323bzc-0 dEhBwt sc-bqiRlB sc-hBUSln edofBN jaIwDv sc-dJjYzT cGuTUx"
@@ -33,7 +33,7 @@ exports[`Storyshots Core/Button Default 1`] = `
 exports[`Storyshots Core/Button Disabled 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <button
       class="StyledButton-sc-323bzc-0 djIyDn sc-bqiRlB sc-hBUSln edofBN jaIwDv sc-dJjYzT cGuTUx"
@@ -49,7 +49,7 @@ exports[`Storyshots Core/Button Disabled 1`] = `
 exports[`Storyshots Core/Button Icon Only 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <button
       class="StyledButton-sc-323bzc-0 hclgal sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx"
@@ -78,7 +78,7 @@ exports[`Storyshots Core/Button Icon Only 1`] = `
 exports[`Storyshots Core/Button Link 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <a
       class="StyledButton-sc-323bzc-0 dEhBwt sc-bqiRlB sc-hBUSln edofBN jaIwDv sc-dJjYzT cGuTUx"
@@ -93,7 +93,7 @@ exports[`Storyshots Core/Button Link 1`] = `
 exports[`Storyshots Core/Button Outlined 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <button
       class="StyledButton-sc-323bzc-0 dEhBwt sc-bqiRlB sc-hBUSln edofBN jaIwDv sc-dJjYzT cGuTUx"
@@ -108,7 +108,7 @@ exports[`Storyshots Core/Button Outlined 1`] = `
 exports[`Storyshots Core/Button Plain 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <button
       class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx"
@@ -123,7 +123,7 @@ exports[`Storyshots Core/Button Plain 1`] = `
 exports[`Storyshots Core/Button Primary 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <button
       class="StyledButton-sc-323bzc-0 cLGAaT sc-bqiRlB sc-ksdxgE edofBN gWXKEC sc-dJjYzT cGuTUx"
@@ -138,7 +138,7 @@ exports[`Storyshots Core/Button Primary 1`] = `
 exports[`Storyshots Core/Button Underlined 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <button
       class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt sc-ieecCq edofBN hOYLYz feeXzs sc-dJjYzT cGuTUx"
@@ -153,7 +153,7 @@ exports[`Storyshots Core/Button Underlined 1`] = `
 exports[`Storyshots Core/Button With Confirmation 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <button
       class="StyledButton-sc-323bzc-0 ehgFzb sc-bqiRlB sc-ksdxgE edofBN eMbKsS sc-dJjYzT cGuTUx"
@@ -168,7 +168,7 @@ exports[`Storyshots Core/Button With Confirmation 1`] = `
 exports[`Storyshots Core/Button With Icon 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <button
       class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx"

--- a/src/components/ButtonGroup/__snapshots__/ButtonGroup.stories.storyshot
+++ b/src/components/ButtonGroup/__snapshots__/ButtonGroup.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/ButtonGroup Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-kLwhqv dljPk bzMIBI"
@@ -34,7 +34,7 @@ exports[`Storyshots Core/ButtonGroup Default 1`] = `
 exports[`Storyshots Core/ButtonGroup Group Select 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-kLwhqv dljPk dfsSxc"
@@ -66,7 +66,7 @@ exports[`Storyshots Core/ButtonGroup Group Select 1`] = `
 exports[`Storyshots Core/ButtonGroup With Icon Button 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-kLwhqv dljPk bzMIBI"

--- a/src/components/Card/__snapshots__/Card.stories.storyshot
+++ b/src/components/Card/__snapshots__/Card.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/Card Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       style="width: 400px; height: 400px;"
@@ -31,7 +31,7 @@ exports[`Storyshots Core/Card Default 1`] = `
 exports[`Storyshots Core/Card Small 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       style="width: 400px; height: 400px;"
@@ -59,7 +59,7 @@ exports[`Storyshots Core/Card Small 1`] = `
 exports[`Storyshots Core/Card With Header 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       style="width: 400px; height: 400px;"
@@ -105,7 +105,7 @@ exports[`Storyshots Core/Card With Header 1`] = `
 exports[`Storyshots Core/Card With Rows 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       style="width: 400px; height: 400px;"
@@ -163,19 +163,19 @@ exports[`Storyshots Core/Card With Rows 1`] = `
               class="sc-ikJyIC fyVnc sc-hiCibw fhBOc"
             />
             <span
-              class="sc-fKVqWL hOcWtv sc-iwjdpV iXrUAY sc-hZpJaK djDbBF"
+              class="sc-fKVqWL hOcWtv sc-iwjdpV iXrUAY sc-cHzqoD bBDeUQ"
               title="This value has been copied to your clipboard!"
             >
               <span
-                class="sc-cHzqoD cBlKfa"
+                class="sc-JkixQ dLBRgg"
               >
                 Row with Copy component
               </span>
               <span
-                class="sc-gGPzkF fxnEtP"
+                class="sc-dkQkyq brNuSp"
               >
                 <div
-                  class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-JkixQ gfDyTp"
+                  class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-gGPzkF jGlSeL"
                 >
                   <svg
                     aria-hidden="true"

--- a/src/components/Checkbox/__snapshots__/Checkbox.stories.storyshot
+++ b/src/components/Checkbox/__snapshots__/Checkbox.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/Checkbox Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-dPiLbb krGoUJ sc-bBHHxi doLBYL"
@@ -31,7 +31,7 @@ exports[`Storyshots Core/Checkbox Default 1`] = `
 exports[`Storyshots Core/Checkbox Disabled 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-dPiLbb krGoUJ sc-bBHHxi doLBYL"
@@ -66,7 +66,7 @@ exports[`Storyshots Core/Checkbox Disabled 1`] = `
 exports[`Storyshots Core/Checkbox Reversed Label 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-dPiLbb krGoUJ sc-bBHHxi doLBYL"
@@ -97,7 +97,7 @@ exports[`Storyshots Core/Checkbox Reversed Label 1`] = `
 exports[`Storyshots Core/Checkbox Toggle 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-dPiLbb krGoUJ sc-bBHHxi doLBYL"
@@ -132,7 +132,7 @@ exports[`Storyshots Core/Checkbox Toggle 1`] = `
 exports[`Storyshots Core/Checkbox With Label 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-dPiLbb krGoUJ sc-bBHHxi doLBYL"

--- a/src/components/Container/__snapshots__/Container.stories.storyshot
+++ b/src/components/Container/__snapshots__/Container.stories.storyshot
@@ -3,10 +3,10 @@
 exports[`Storyshots Core/Container Centered Content 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
-      class="sc-gKclnd exdBHI sc-iCfMLu cGgNNs sc-bSqaIl bUfmbW sc-jvvksu bDmWVF"
+      class="sc-gKclnd exdBHI sc-iCfMLu cGgNNs sc-jvvksu iZWZbd sc-edERGn kyDWed"
     >
       <h3
         class="sc-gWXbKe gGPSCF sc-cCcXHH hYTSJh"
@@ -21,10 +21,10 @@ exports[`Storyshots Core/Container Centered Content 1`] = `
 exports[`Storyshots Core/Container Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
-      class="sc-gKclnd exdBHI sc-iCfMLu cGgNNs sc-bSqaIl KbNKZ sc-jvvksu bDmWVF"
+      class="sc-gKclnd exdBHI sc-iCfMLu cGgNNs sc-jvvksu rvCKa sc-edERGn kyDWed"
     >
       <h3
         class="sc-gWXbKe gGPSCF sc-cCcXHH hYTSJh"

--- a/src/components/Copy/__snapshots__/Copy.stories.storyshot
+++ b/src/components/Copy/__snapshots__/Copy.stories.storyshot
@@ -3,22 +3,22 @@
 exports[`Storyshots Core/Copy Always Show 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-AjmGg ceYMaG iAHxUc"
     >
       <div
-        class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-fyrocj dljPk jxvgud"
+        class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-iWVNaa dljPk YIrmE"
       >
         <div
           class="sc-gKclnd iQIogj sc-iCfMLu frGhDt sc-hGPBjI kBwkZQ"
         >
           <div
-            class="sc-iqVWFU hIAseQ"
+            class="sc-eWfVMQ gmreIg"
           >
             <div
-              class="sc-eWfVMQ kmJZgg sc-jKTccl fWCWlF"
+              class="sc-kTLmzF kNwxgk sc-bUbRBg hsvIRe"
             >
               <div
                 data-display="table-head"
@@ -109,7 +109,7 @@ exports[`Storyshots Core/Copy Always Show 1`] = `
 exports[`Storyshots Core/Copy Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-AjmGg ceYMaG iAHxUc"
@@ -146,7 +146,7 @@ exports[`Storyshots Core/Copy Default 1`] = `
 exports[`Storyshots Core/Copy Icon Only 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd exdBHI sc-iCfMLu fBDGQC"
@@ -183,7 +183,7 @@ exports[`Storyshots Core/Copy Icon Only 1`] = `
 exports[`Storyshots Core/Copy With Tag 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-AjmGg ceYMaG iAHxUc"

--- a/src/components/DataGrid/__snapshots__/DataGrid.stories.storyshot
+++ b/src/components/DataGrid/__snapshots__/DataGrid.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/DataGrid Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-FNXRL cmfiKl"

--- a/src/components/Divider/__snapshots__/Divider.stories.storyshot
+++ b/src/components/Divider/__snapshots__/Divider.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/Divider Dashed 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <hr
       class="sc-ikJyIC fpaKKe sc-hiCibw fhBOc"
@@ -16,7 +16,7 @@ exports[`Storyshots Core/Divider Dashed 1`] = `
 exports[`Storyshots Core/Divider Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <hr
       class="sc-ikJyIC fyVnc sc-hiCibw fhBOc"
@@ -28,7 +28,7 @@ exports[`Storyshots Core/Divider Default 1`] = `
 exports[`Storyshots Core/Divider With Custom Color 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <hr
       class="sc-ikJyIC kUYIpl sc-hiCibw eBsIAg"
@@ -41,7 +41,7 @@ exports[`Storyshots Core/Divider With Custom Color 1`] = `
 exports[`Storyshots Core/Divider With Text Content 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd exdBHI sc-iCfMLu frGhDt sc-hGPBjI dGJbEs sc-hiCibw fhBOc"

--- a/src/components/DropDownButton/__snapshots__/DropDownButton.stories.storyshot
+++ b/src/components/DropDownButton/__snapshots__/DropDownButton.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/DropDownButton Bordered List 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-jOxtWs iRYYIV sc-bTfYFJ isjOxD"
@@ -44,7 +44,7 @@ exports[`Storyshots Core/DropDownButton Bordered List 1`] = `
 exports[`Storyshots Core/DropDownButton Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-jOxtWs iRYYIV sc-bTfYFJ isjOxD"
@@ -85,7 +85,7 @@ exports[`Storyshots Core/DropDownButton Default 1`] = `
 exports[`Storyshots Core/DropDownButton Drop Up 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd exdBHI sc-iCfMLu gdlmhk"
@@ -130,7 +130,7 @@ exports[`Storyshots Core/DropDownButton Drop Up 1`] = `
 exports[`Storyshots Core/DropDownButton Icon Only 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-jOxtWs iRYYIV sc-bTfYFJ isjOxD"
@@ -164,7 +164,7 @@ exports[`Storyshots Core/DropDownButton Icon Only 1`] = `
 exports[`Storyshots Core/DropDownButton Joined 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-jOxtWs iRYYIV sc-bTfYFJ isjOxD"
@@ -206,7 +206,7 @@ exports[`Storyshots Core/DropDownButton Joined 1`] = `
 exports[`Storyshots Core/DropDownButton No List Formatting 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-jOxtWs iRYYIV sc-bTfYFJ isjOxD"
@@ -246,7 +246,7 @@ exports[`Storyshots Core/DropDownButton No List Formatting 1`] = `
 exports[`Storyshots Core/DropDownButton With Primary Button 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-jOxtWs iRYYIV sc-bTfYFJ isjOxD"

--- a/src/components/Filters/__snapshots__/Filters.stories.storyshot
+++ b/src/components/Filters/__snapshots__/Filters.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/Filters Button Props 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div>
       <div
@@ -135,7 +135,7 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
           Bulbasaur
         </h2>
         <table
-          class="sc-bxDdli garddY"
+          class="sc-jWaEpP ffLJvK"
         >
           <tbody>
             <tr>
@@ -225,7 +225,7 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
           Ivysaur
         </h2>
         <table
-          class="sc-bxDdli garddY"
+          class="sc-jWaEpP ffLJvK"
         >
           <tbody>
             <tr>
@@ -315,7 +315,7 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
           Venusaur
         </h2>
         <table
-          class="sc-bxDdli garddY"
+          class="sc-jWaEpP ffLJvK"
         >
           <tbody>
             <tr>
@@ -405,7 +405,7 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
           Charmander
         </h2>
         <table
-          class="sc-bxDdli garddY"
+          class="sc-jWaEpP ffLJvK"
         >
           <tbody>
             <tr>
@@ -495,7 +495,7 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
           Charmeleon
         </h2>
         <table
-          class="sc-bxDdli garddY"
+          class="sc-jWaEpP ffLJvK"
         >
           <tbody>
             <tr>
@@ -587,7 +587,7 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
           Charizard
         </h2>
         <table
-          class="sc-bxDdli garddY"
+          class="sc-jWaEpP ffLJvK"
         >
           <tbody>
             <tr>
@@ -706,7 +706,7 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
           Squirtle
         </h2>
         <table
-          class="sc-bxDdli garddY"
+          class="sc-jWaEpP ffLJvK"
         >
           <tbody>
             <tr>
@@ -825,7 +825,7 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
           Wartortle
         </h2>
         <table
-          class="sc-bxDdli garddY"
+          class="sc-jWaEpP ffLJvK"
         >
           <tbody>
             <tr>
@@ -915,7 +915,7 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
           Blastoise
         </h2>
         <table
-          class="sc-bxDdli garddY"
+          class="sc-jWaEpP ffLJvK"
         >
           <tbody>
             <tr>
@@ -1005,7 +1005,7 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
           Caterpie
         </h2>
         <table
-          class="sc-bxDdli garddY"
+          class="sc-jWaEpP ffLJvK"
         >
           <tbody>
             <tr>
@@ -1095,7 +1095,7 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
           Staryu
         </h2>
         <table
-          class="sc-bxDdli garddY"
+          class="sc-jWaEpP ffLJvK"
         >
           <tbody>
             <tr>
@@ -1188,7 +1188,7 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
 exports[`Storyshots Core/Filters Compact 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div>
       <div
@@ -1306,7 +1306,7 @@ exports[`Storyshots Core/Filters Compact 1`] = `
           Bulbasaur
         </h2>
         <table
-          class="sc-bxDdli garddY"
+          class="sc-jWaEpP ffLJvK"
         >
           <tbody>
             <tr>
@@ -1396,7 +1396,7 @@ exports[`Storyshots Core/Filters Compact 1`] = `
           Ivysaur
         </h2>
         <table
-          class="sc-bxDdli garddY"
+          class="sc-jWaEpP ffLJvK"
         >
           <tbody>
             <tr>
@@ -1486,7 +1486,7 @@ exports[`Storyshots Core/Filters Compact 1`] = `
           Venusaur
         </h2>
         <table
-          class="sc-bxDdli garddY"
+          class="sc-jWaEpP ffLJvK"
         >
           <tbody>
             <tr>
@@ -1576,7 +1576,7 @@ exports[`Storyshots Core/Filters Compact 1`] = `
           Charmander
         </h2>
         <table
-          class="sc-bxDdli garddY"
+          class="sc-jWaEpP ffLJvK"
         >
           <tbody>
             <tr>
@@ -1666,7 +1666,7 @@ exports[`Storyshots Core/Filters Compact 1`] = `
           Charmeleon
         </h2>
         <table
-          class="sc-bxDdli garddY"
+          class="sc-jWaEpP ffLJvK"
         >
           <tbody>
             <tr>
@@ -1758,7 +1758,7 @@ exports[`Storyshots Core/Filters Compact 1`] = `
           Charizard
         </h2>
         <table
-          class="sc-bxDdli garddY"
+          class="sc-jWaEpP ffLJvK"
         >
           <tbody>
             <tr>
@@ -1877,7 +1877,7 @@ exports[`Storyshots Core/Filters Compact 1`] = `
           Squirtle
         </h2>
         <table
-          class="sc-bxDdli garddY"
+          class="sc-jWaEpP ffLJvK"
         >
           <tbody>
             <tr>
@@ -1996,7 +1996,7 @@ exports[`Storyshots Core/Filters Compact 1`] = `
           Wartortle
         </h2>
         <table
-          class="sc-bxDdli garddY"
+          class="sc-jWaEpP ffLJvK"
         >
           <tbody>
             <tr>
@@ -2086,7 +2086,7 @@ exports[`Storyshots Core/Filters Compact 1`] = `
           Blastoise
         </h2>
         <table
-          class="sc-bxDdli garddY"
+          class="sc-jWaEpP ffLJvK"
         >
           <tbody>
             <tr>
@@ -2176,7 +2176,7 @@ exports[`Storyshots Core/Filters Compact 1`] = `
           Caterpie
         </h2>
         <table
-          class="sc-bxDdli garddY"
+          class="sc-jWaEpP ffLJvK"
         >
           <tbody>
             <tr>
@@ -2266,7 +2266,7 @@ exports[`Storyshots Core/Filters Compact 1`] = `
           Staryu
         </h2>
         <table
-          class="sc-bxDdli garddY"
+          class="sc-jWaEpP ffLJvK"
         >
           <tbody>
             <tr>
@@ -2359,7 +2359,7 @@ exports[`Storyshots Core/Filters Compact 1`] = `
 exports[`Storyshots Core/Filters Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div>
       <div
@@ -2490,7 +2490,7 @@ exports[`Storyshots Core/Filters Default 1`] = `
           Bulbasaur
         </h2>
         <table
-          class="sc-bxDdli garddY"
+          class="sc-jWaEpP ffLJvK"
         >
           <tbody>
             <tr>
@@ -2580,7 +2580,7 @@ exports[`Storyshots Core/Filters Default 1`] = `
           Ivysaur
         </h2>
         <table
-          class="sc-bxDdli garddY"
+          class="sc-jWaEpP ffLJvK"
         >
           <tbody>
             <tr>
@@ -2670,7 +2670,7 @@ exports[`Storyshots Core/Filters Default 1`] = `
           Venusaur
         </h2>
         <table
-          class="sc-bxDdli garddY"
+          class="sc-jWaEpP ffLJvK"
         >
           <tbody>
             <tr>
@@ -2760,7 +2760,7 @@ exports[`Storyshots Core/Filters Default 1`] = `
           Charmander
         </h2>
         <table
-          class="sc-bxDdli garddY"
+          class="sc-jWaEpP ffLJvK"
         >
           <tbody>
             <tr>
@@ -2850,7 +2850,7 @@ exports[`Storyshots Core/Filters Default 1`] = `
           Charmeleon
         </h2>
         <table
-          class="sc-bxDdli garddY"
+          class="sc-jWaEpP ffLJvK"
         >
           <tbody>
             <tr>
@@ -2942,7 +2942,7 @@ exports[`Storyshots Core/Filters Default 1`] = `
           Charizard
         </h2>
         <table
-          class="sc-bxDdli garddY"
+          class="sc-jWaEpP ffLJvK"
         >
           <tbody>
             <tr>
@@ -3061,7 +3061,7 @@ exports[`Storyshots Core/Filters Default 1`] = `
           Squirtle
         </h2>
         <table
-          class="sc-bxDdli garddY"
+          class="sc-jWaEpP ffLJvK"
         >
           <tbody>
             <tr>
@@ -3180,7 +3180,7 @@ exports[`Storyshots Core/Filters Default 1`] = `
           Wartortle
         </h2>
         <table
-          class="sc-bxDdli garddY"
+          class="sc-jWaEpP ffLJvK"
         >
           <tbody>
             <tr>
@@ -3270,7 +3270,7 @@ exports[`Storyshots Core/Filters Default 1`] = `
           Blastoise
         </h2>
         <table
-          class="sc-bxDdli garddY"
+          class="sc-jWaEpP ffLJvK"
         >
           <tbody>
             <tr>
@@ -3360,7 +3360,7 @@ exports[`Storyshots Core/Filters Default 1`] = `
           Caterpie
         </h2>
         <table
-          class="sc-bxDdli garddY"
+          class="sc-jWaEpP ffLJvK"
         >
           <tbody>
             <tr>
@@ -3450,7 +3450,7 @@ exports[`Storyshots Core/Filters Default 1`] = `
           Staryu
         </h2>
         <table
-          class="sc-bxDdli garddY"
+          class="sc-jWaEpP ffLJvK"
         >
           <tbody>
             <tr>
@@ -3543,7 +3543,7 @@ exports[`Storyshots Core/Filters Default 1`] = `
 exports[`Storyshots Core/Filters Disabled 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div>
       <div
@@ -3678,7 +3678,7 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
           Bulbasaur
         </h2>
         <table
-          class="sc-bxDdli garddY"
+          class="sc-jWaEpP ffLJvK"
         >
           <tbody>
             <tr>
@@ -3768,7 +3768,7 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
           Ivysaur
         </h2>
         <table
-          class="sc-bxDdli garddY"
+          class="sc-jWaEpP ffLJvK"
         >
           <tbody>
             <tr>
@@ -3858,7 +3858,7 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
           Venusaur
         </h2>
         <table
-          class="sc-bxDdli garddY"
+          class="sc-jWaEpP ffLJvK"
         >
           <tbody>
             <tr>
@@ -3948,7 +3948,7 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
           Charmander
         </h2>
         <table
-          class="sc-bxDdli garddY"
+          class="sc-jWaEpP ffLJvK"
         >
           <tbody>
             <tr>
@@ -4038,7 +4038,7 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
           Charmeleon
         </h2>
         <table
-          class="sc-bxDdli garddY"
+          class="sc-jWaEpP ffLJvK"
         >
           <tbody>
             <tr>
@@ -4130,7 +4130,7 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
           Charizard
         </h2>
         <table
-          class="sc-bxDdli garddY"
+          class="sc-jWaEpP ffLJvK"
         >
           <tbody>
             <tr>
@@ -4249,7 +4249,7 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
           Squirtle
         </h2>
         <table
-          class="sc-bxDdli garddY"
+          class="sc-jWaEpP ffLJvK"
         >
           <tbody>
             <tr>
@@ -4368,7 +4368,7 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
           Wartortle
         </h2>
         <table
-          class="sc-bxDdli garddY"
+          class="sc-jWaEpP ffLJvK"
         >
           <tbody>
             <tr>
@@ -4458,7 +4458,7 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
           Blastoise
         </h2>
         <table
-          class="sc-bxDdli garddY"
+          class="sc-jWaEpP ffLJvK"
         >
           <tbody>
             <tr>
@@ -4548,7 +4548,7 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
           Caterpie
         </h2>
         <table
-          class="sc-bxDdli garddY"
+          class="sc-jWaEpP ffLJvK"
         >
           <tbody>
             <tr>
@@ -4638,7 +4638,7 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
           Staryu
         </h2>
         <table
-          class="sc-bxDdli garddY"
+          class="sc-jWaEpP ffLJvK"
         >
           <tbody>
             <tr>
@@ -4731,7 +4731,7 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
 exports[`Storyshots Core/Filters Render Modes 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div>
       <div
@@ -4955,7 +4955,7 @@ exports[`Storyshots Core/Filters Render Modes 1`] = `
           Squirtle
         </h2>
         <table
-          class="sc-bxDdli garddY"
+          class="sc-jWaEpP ffLJvK"
         >
           <tbody>
             <tr>

--- a/src/components/Fixed/__snapshots__/Fixed.stories.storyshot
+++ b/src/components/Fixed/__snapshots__/Fixed.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/Fixed Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-fWCJzd gAtjXZ sc-dvQaRk cPKyqy"

--- a/src/components/Flex/__snapshots__/Flex.stories.storyshot
+++ b/src/components/Flex/__snapshots__/Flex.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/Flex Column Direction 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI kBwkZQ"
@@ -28,7 +28,7 @@ exports[`Storyshots Core/Flex Column Direction 1`] = `
 exports[`Storyshots Core/Flex Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI dljPk"
@@ -53,7 +53,7 @@ exports[`Storyshots Core/Flex Default 1`] = `
 exports[`Storyshots Core/Flex Flex On Children 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI hCkpHX"
@@ -86,7 +86,7 @@ exports[`Storyshots Core/Flex Flex On Children 1`] = `
 exports[`Storyshots Core/Flex Justified 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI kZhRrI"
@@ -111,7 +111,7 @@ exports[`Storyshots Core/Flex Justified 1`] = `
 exports[`Storyshots Core/Flex Wrap 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI hCkpHX"

--- a/src/components/Form/__snapshots__/Form.stories.storyshot
+++ b/src/components/Form/__snapshots__/Form.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/Form Custom Submit Text 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI dljPk"
@@ -262,7 +262,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                         id="root_first_seen__description"
                       >
                         <div
-                          class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh sc-jYmNlR kVdGQG"
+                          class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh sc-bxDdli debCz"
                         >
                           <div>
                             <p
@@ -305,7 +305,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                         id="root_poke_password__description"
                       >
                         <div
-                          class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh sc-jYmNlR kVdGQG"
+                          class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh sc-bxDdli debCz"
                         >
                           <div>
                             <p
@@ -412,7 +412,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                           id="root_tags__description"
                         >
                           <div
-                            class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh sc-jYmNlR kVdGQG"
+                            class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh sc-bxDdli debCz"
                           >
                             <div>
                               <p
@@ -485,7 +485,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
 exports[`Storyshots Core/Form Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI dljPk"
@@ -744,7 +744,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                         id="root_first_seen__description"
                       >
                         <div
-                          class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh sc-jYmNlR kVdGQG"
+                          class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh sc-bxDdli debCz"
                         >
                           <div>
                             <p
@@ -787,7 +787,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                         id="root_poke_password__description"
                       >
                         <div
-                          class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh sc-jYmNlR kVdGQG"
+                          class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh sc-bxDdli debCz"
                         >
                           <div>
                             <p
@@ -894,7 +894,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                           id="root_tags__description"
                         >
                           <div
-                            class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh sc-jYmNlR kVdGQG"
+                            class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh sc-bxDdli debCz"
                           >
                             <div>
                               <p
@@ -967,7 +967,7 @@ exports[`Storyshots Core/Form Default 1`] = `
 exports[`Storyshots Core/Form Disabled 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI dljPk"
@@ -1234,7 +1234,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                         id="root_first_seen__description"
                       >
                         <div
-                          class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh sc-jYmNlR kVdGQG"
+                          class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh sc-bxDdli debCz"
                         >
                           <div>
                             <p
@@ -1278,7 +1278,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                         id="root_poke_password__description"
                       >
                         <div
-                          class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh sc-jYmNlR kVdGQG"
+                          class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh sc-bxDdli debCz"
                         >
                           <div>
                             <p
@@ -1387,7 +1387,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                           id="root_tags__description"
                         >
                           <div
-                            class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh sc-jYmNlR kVdGQG"
+                            class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh sc-bxDdli debCz"
                           >
                             <div>
                               <p
@@ -1460,7 +1460,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
 exports[`Storyshots Core/Form Hidden Submit 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI dljPk"
@@ -1719,7 +1719,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                         id="root_first_seen__description"
                       >
                         <div
-                          class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh sc-jYmNlR kVdGQG"
+                          class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh sc-bxDdli debCz"
                         >
                           <div>
                             <p
@@ -1762,7 +1762,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                         id="root_poke_password__description"
                       >
                         <div
-                          class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh sc-jYmNlR kVdGQG"
+                          class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh sc-bxDdli debCz"
                         >
                           <div>
                             <p
@@ -1869,7 +1869,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                           id="root_tags__description"
                         >
                           <div
-                            class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh sc-jYmNlR kVdGQG"
+                            class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh sc-bxDdli debCz"
                           >
                             <div>
                               <p
@@ -1937,7 +1937,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
 exports[`Storyshots Core/Form Secondary Action 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI dljPk"
@@ -2196,7 +2196,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                         id="root_first_seen__description"
                       >
                         <div
-                          class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh sc-jYmNlR kVdGQG"
+                          class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh sc-bxDdli debCz"
                         >
                           <div>
                             <p
@@ -2239,7 +2239,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                         id="root_poke_password__description"
                       >
                         <div
-                          class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh sc-jYmNlR kVdGQG"
+                          class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh sc-bxDdli debCz"
                         >
                           <div>
                             <p
@@ -2346,7 +2346,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                           id="root_tags__description"
                         >
                           <div
-                            class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh sc-jYmNlR kVdGQG"
+                            class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh sc-bxDdli debCz"
                           >
                             <div>
                               <p
@@ -2425,7 +2425,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
 exports[`Storyshots Core/Form With Dependants 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI dljPk"
@@ -2565,13 +2565,13 @@ exports[`Storyshots Core/Form With Dependants 1`] = `
 exports[`Storyshots Core/Form With Extra Widgets 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd exdBHI sc-iCfMLu cibyyY"
     >
       <div
-        class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh sc-jYmNlR kVdGQG"
+        class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh sc-bxDdli debCz"
       >
         <div>
           <h1
@@ -3373,7 +3373,7 @@ Rendition contains widgets for rendering Markdown and Mermaid text formats that 
                         Markdown
                       </label>
                       <div
-                        class="sc-kHdrYz gZnkdE"
+                        class="sc-bzPmhk cDgJoI"
                         id="simplemde-editor-1-wrapper"
                       >
                         <textarea
@@ -3665,7 +3665,7 @@ Rendition contains widgets for rendering Markdown and Mermaid text formats that 
                         Captcha
                       </label>
                       <div
-                        class="sc-bzPmhk itZpOx"
+                        class="sc-jYmNlR bqMpKp"
                       />
                     </div>
                   </div>
@@ -3700,7 +3700,7 @@ Rendition contains widgets for rendering Markdown and Mermaid text formats that 
 exports[`Storyshots Core/Form With Help Text 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI dljPk"
@@ -3762,7 +3762,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                         id="root_Name"
                       >
                         <div
-                          class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh sc-jYmNlR kVdGQG"
+                          class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh sc-bxDdli debCz"
                         >
                           <div>
                             <p
@@ -3972,7 +3972,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                         id="root_first_seen__description"
                       >
                         <div
-                          class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh sc-jYmNlR kVdGQG"
+                          class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh sc-bxDdli debCz"
                         >
                           <div>
                             <p
@@ -4015,7 +4015,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                         id="root_poke_password__description"
                       >
                         <div
-                          class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh sc-jYmNlR kVdGQG"
+                          class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh sc-bxDdli debCz"
                         >
                           <div>
                             <p
@@ -4146,7 +4146,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                           id="root_tags__description"
                         >
                           <div
-                            class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh sc-jYmNlR kVdGQG"
+                            class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh sc-bxDdli debCz"
                           >
                             <div>
                               <p
@@ -4219,7 +4219,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
 exports[`Storyshots Core/Form With Pattern Properties 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI dljPk"
@@ -4340,7 +4340,7 @@ exports[`Storyshots Core/Form With Pattern Properties 1`] = `
 exports[`Storyshots Core/Form With Titles 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI dljPk"
@@ -4580,7 +4580,7 @@ exports[`Storyshots Core/Form With Titles 1`] = `
 exports[`Storyshots Core/Form With Ui Schema 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI dljPk"
@@ -4832,7 +4832,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                         id="root_first_seen__description"
                       >
                         <div
-                          class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh sc-jYmNlR kVdGQG"
+                          class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh sc-bxDdli debCz"
                         >
                           <div>
                             <p
@@ -4875,7 +4875,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                         id="root_poke_password__description"
                       >
                         <div
-                          class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh sc-jYmNlR kVdGQG"
+                          class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh sc-bxDdli debCz"
                         >
                           <div>
                             <p
@@ -5006,7 +5006,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                           id="root_tags__description"
                         >
                           <div
-                            class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh sc-jYmNlR kVdGQG"
+                            class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh sc-bxDdli debCz"
                           >
                             <div>
                               <p
@@ -5079,7 +5079,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
 exports[`Storyshots Core/Form With Warning 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI dljPk"
@@ -5147,7 +5147,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                             class="sc-gKclnd exdBHI sc-iCfMLu jxAqTi sc-hGPBjI hhYUbN sc-bilyIR kdyjCP"
                           >
                             <div
-                              class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh sc-jYmNlR kVdGQG"
+                              class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh sc-bxDdli debCz"
                             >
                               <div>
                                 <p
@@ -5377,7 +5377,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                         id="root_first_seen__description"
                       >
                         <div
-                          class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh sc-jYmNlR kVdGQG"
+                          class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh sc-bxDdli debCz"
                         >
                           <div>
                             <p
@@ -5420,7 +5420,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                         id="root_poke_password__description"
                       >
                         <div
-                          class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh sc-jYmNlR kVdGQG"
+                          class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh sc-bxDdli debCz"
                         >
                           <div>
                             <p
@@ -5551,7 +5551,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                           id="root_tags__description"
                         >
                           <div
-                            class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh sc-jYmNlR kVdGQG"
+                            class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh sc-bxDdli debCz"
                           >
                             <div>
                               <p

--- a/src/components/Heading/__snapshots__/Heading.stories.storyshot
+++ b/src/components/Heading/__snapshots__/Heading.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/Heading Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <h3
       class="sc-gWXbKe gGPSCF sc-cCcXHH hYTSJh"
@@ -17,7 +17,7 @@ exports[`Storyshots Core/Heading Default 1`] = `
 exports[`Storyshots Core/Heading H 1 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <h1
       class="sc-gWXbKe gGPSCF sc-cidDSM koDaHu"
@@ -31,7 +31,7 @@ exports[`Storyshots Core/Heading H 1 1`] = `
 exports[`Storyshots Core/Heading H 2 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <h2
       class="sc-gWXbKe gGPSCF sc-jcFjpl bPpIzB"
@@ -45,7 +45,7 @@ exports[`Storyshots Core/Heading H 2 1`] = `
 exports[`Storyshots Core/Heading H 3 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <h3
       class="sc-gWXbKe gGPSCF sc-caiLqq iWWVnC"
@@ -59,7 +59,7 @@ exports[`Storyshots Core/Heading H 3 1`] = `
 exports[`Storyshots Core/Heading H 4 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <h4
       class="sc-gWXbKe kMRLBA sc-iUKqMP iZohKd"
@@ -73,7 +73,7 @@ exports[`Storyshots Core/Heading H 4 1`] = `
 exports[`Storyshots Core/Heading H 5 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <h5
       class="sc-gWXbKe kMRLBA sc-iAKWXU guhlxZ"

--- a/src/components/HighlightedName/__snapshots__/HighlightedName.stories.storyshot
+++ b/src/components/HighlightedName/__snapshots__/HighlightedName.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/HighlightedName Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <span
       class="sc-fKVqWL hOcWtv sc-iwjdpV csrXjq sc-GEbAx cVEuIT sc-gsNilK dlEAUa"
@@ -17,7 +17,7 @@ exports[`Storyshots Core/HighlightedName Default 1`] = `
 exports[`Storyshots Core/HighlightedName With Custom Colors 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <span
       class="sc-fKVqWL hOcWtv sc-iwjdpV vGMJF sc-GEbAx cVEuIT sc-gsNilK dhNLzR"

--- a/src/components/Img/__snapshots__/Img.stories.storyshot
+++ b/src/components/Img/__snapshots__/Img.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/Img Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <img
       class="sc-bXTejn foFpYE"
@@ -16,7 +16,7 @@ exports[`Storyshots Core/Img Default 1`] = `
 exports[`Storyshots Core/Img With Fallback 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <img
       class="sc-bXTejn foFpYE"

--- a/src/components/Input/__snapshots__/Input.stories.storyshot
+++ b/src/components/Input/__snapshots__/Input.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/Input Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 jqwtzG"
@@ -21,7 +21,7 @@ exports[`Storyshots Core/Input Default 1`] = `
 exports[`Storyshots Core/Input Emphasized 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 jqwtzG"
@@ -39,7 +39,7 @@ exports[`Storyshots Core/Input Emphasized 1`] = `
 exports[`Storyshots Core/Input Monospace 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 jqwtzG"
@@ -57,7 +57,7 @@ exports[`Storyshots Core/Input Monospace 1`] = `
 exports[`Storyshots Core/Input With Placeholder 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 jqwtzG"

--- a/src/components/Link/__snapshots__/Link.stories.storyshot
+++ b/src/components/Link/__snapshots__/Link.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/Link Blank Target 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <a
       class="sc-eGRUor fekqPY sc-ctqQKy fghAZv"
@@ -21,7 +21,7 @@ exports[`Storyshots Core/Link Blank Target 1`] = `
 exports[`Storyshots Core/Link Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <a
       class="sc-eGRUor fekqPY sc-ctqQKy fghAZv"
@@ -37,7 +37,7 @@ exports[`Storyshots Core/Link Default 1`] = `
 exports[`Storyshots Core/Link Disabled 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <a
       class="sc-eGRUor hVTeuo sc-ctqQKy fghAZv"

--- a/src/components/List/__snapshots__/List.stories.storyshot
+++ b/src/components/List/__snapshots__/List.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/List Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <ul
       class="sc-dFtzxp sc-gIDmLj eTnbjW eTAwSV sc-evcjhq bmbhlJ"
@@ -52,7 +52,7 @@ exports[`Storyshots Core/List Default 1`] = `
 exports[`Storyshots Core/List Ordered 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <ol
       class="sc-dFtzxp sc-brSvTw eTnbjW iUbKCC sc-evcjhq bmbhlJ"

--- a/src/components/Map/__snapshots__/Map.stories.storyshot
+++ b/src/components/Map/__snapshots__/Map.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/Map Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       style="height: 600px;"

--- a/src/components/Modal/__snapshots__/Modal.stories.storyshot
+++ b/src/components/Modal/__snapshots__/Modal.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/Modal Custom Action 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd exdBHI sc-iCfMLu jciJBO"
@@ -22,7 +22,7 @@ exports[`Storyshots Core/Modal Custom Action 1`] = `
 exports[`Storyshots Core/Modal Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd exdBHI sc-iCfMLu jciJBO"
@@ -41,7 +41,7 @@ exports[`Storyshots Core/Modal Default 1`] = `
 exports[`Storyshots Core/Modal Nested 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd exdBHI sc-iCfMLu jciJBO"
@@ -60,7 +60,7 @@ exports[`Storyshots Core/Modal Nested 1`] = `
 exports[`Storyshots Core/Modal No Cancel 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd exdBHI sc-iCfMLu jciJBO"
@@ -79,7 +79,7 @@ exports[`Storyshots Core/Modal No Cancel 1`] = `
 exports[`Storyshots Core/Modal With Custom Width 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd exdBHI sc-iCfMLu jciJBO"
@@ -98,7 +98,7 @@ exports[`Storyshots Core/Modal With Custom Width 1`] = `
 exports[`Storyshots Core/Modal With Customized Buttons 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd exdBHI sc-iCfMLu jciJBO"
@@ -117,7 +117,7 @@ exports[`Storyshots Core/Modal With Customized Buttons 1`] = `
 exports[`Storyshots Core/Modal With Multielement Title 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd exdBHI sc-iCfMLu jciJBO"
@@ -136,7 +136,7 @@ exports[`Storyshots Core/Modal With Multielement Title 1`] = `
 exports[`Storyshots Core/Modal With Overflowing Content 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd exdBHI sc-iCfMLu jciJBO"
@@ -155,7 +155,7 @@ exports[`Storyshots Core/Modal With Overflowing Content 1`] = `
 exports[`Storyshots Core/Modal With Title Details 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd exdBHI sc-iCfMLu jciJBO"
@@ -174,7 +174,7 @@ exports[`Storyshots Core/Modal With Title Details 1`] = `
 exports[`Storyshots Core/Modal With Tooltip 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd exdBHI sc-iCfMLu jciJBO"

--- a/src/components/Navbar/__snapshots__/Navbar.stories.storyshot
+++ b/src/components/Navbar/__snapshots__/Navbar.stories.storyshot
@@ -3,13 +3,13 @@
 exports[`Storyshots Core/Navbar Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd exdBHI sc-iCfMLu kisQim"
     >
       <div
-        class="sc-gKclnd exdBHI sc-iCfMLu cGgNNs sc-bSqaIl KbNKZ sc-jvvksu bDmWVF"
+        class="sc-gKclnd exdBHI sc-iCfMLu cGgNNs sc-jvvksu rvCKa sc-edERGn kyDWed"
       >
         <div
           class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI fcICqX"
@@ -18,7 +18,7 @@ exports[`Storyshots Core/Navbar Default 1`] = `
             class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI dljPk"
           >
             <div
-              class="sc-gKclnd exdBHI sc-iCfMLu mkOAX sc-edERGn bKSvKY"
+              class="sc-gKclnd exdBHI sc-iCfMLu mkOAX sc-jlsrNB cWFfXI"
             >
               <a
                 class="sc-eGRUor eisEdB sc-ctqQKy jEA-DWI"
@@ -33,7 +33,7 @@ exports[`Storyshots Core/Navbar Default 1`] = `
               </a>
             </div>
             <div
-              class="sc-gKclnd exdBHI sc-iCfMLu kSWvTu sc-jlsrNB hynsUc"
+              class="sc-gKclnd exdBHI sc-iCfMLu kSWvTu sc-iWBNLc ifndUK"
             >
               <svg
                 aria-hidden="true"
@@ -53,7 +53,7 @@ exports[`Storyshots Core/Navbar Default 1`] = `
             </div>
           </div>
           <div
-            class="sc-gKclnd exdBHI sc-iCfMLu hdtGKh sc-hGPBjI sc-iWBNLc dljPk hjYDnQ"
+            class="sc-gKclnd exdBHI sc-iCfMLu hdtGKh sc-hGPBjI sc-hYQoXb dljPk fFovzs"
           >
             <div
               class="sc-gKclnd exdBHI sc-iCfMLu iEFwjy sc-hGPBjI fcICqX"

--- a/src/components/Notifications/__snapshots__/Notifications.stories.storyshot
+++ b/src/components/Notifications/__snapshots__/Notifications.stories.storyshot
@@ -3,13 +3,13 @@
 exports[`Storyshots Core/Notifications Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd exdBHI sc-iCfMLu nKarx sc-hGPBjI hhYUbN"
     >
       <div
-        class="react-notification-root sc-hkgtus dZVxiT"
+        class="react-notification-root sc-bSqaIl fvRzvB"
       >
         <div
           class="notification-container-top-left"
@@ -25,7 +25,7 @@ exports[`Storyshots Core/Notifications Default 1`] = `
               class="notification-item n-child"
             >
               <div
-                class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-dlVxhl dljPk kNGFbM sc-llYSUQ FJxnU sc-jivBlf fMnGVo"
+                class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-dlVxhl dljPk kNGFbM sc-llYSUQ FJxnU sc-hkgtus bTexjT"
               >
                 
                 <div
@@ -71,7 +71,7 @@ exports[`Storyshots Core/Notifications Default 1`] = `
               class="notification-item n-child"
             >
               <div
-                class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-dlVxhl dljPk kNGFbM sc-llYSUQ FJxnU sc-jivBlf fMnGVo"
+                class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-dlVxhl dljPk kNGFbM sc-llYSUQ FJxnU sc-hkgtus bTexjT"
               >
                 
                 <div
@@ -164,10 +164,10 @@ exports[`Storyshots Core/Notifications Default 1`] = `
 exports[`Storyshots Core/Notifications Positioning 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
-      class="react-notification-root sc-hkgtus dZVxiT"
+      class="react-notification-root sc-bSqaIl fvRzvB"
     >
       <div
         class="notification-container-top-left"
@@ -180,7 +180,7 @@ exports[`Storyshots Core/Notifications Positioning 1`] = `
             class="notification-item n-child"
           >
             <div
-              class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-dlVxhl dljPk kNGFbM sc-llYSUQ FJxnU sc-jivBlf fMnGVo"
+              class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-dlVxhl dljPk kNGFbM sc-llYSUQ FJxnU sc-hkgtus bTexjT"
             >
               
               <div
@@ -230,7 +230,7 @@ exports[`Storyshots Core/Notifications Positioning 1`] = `
             class="notification-item n-child"
           >
             <div
-              class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-dlVxhl dljPk kNGFbM sc-llYSUQ FJxnU sc-jivBlf fMnGVo"
+              class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-dlVxhl dljPk kNGFbM sc-llYSUQ FJxnU sc-hkgtus bTexjT"
             >
               
               <div
@@ -280,7 +280,7 @@ exports[`Storyshots Core/Notifications Positioning 1`] = `
             class="notification-item n-child"
           >
             <div
-              class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-dlVxhl dljPk kNGFbM sc-llYSUQ FJxnU sc-jivBlf fMnGVo"
+              class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-dlVxhl dljPk kNGFbM sc-llYSUQ FJxnU sc-hkgtus bTexjT"
             >
               
               <div
@@ -330,7 +330,7 @@ exports[`Storyshots Core/Notifications Positioning 1`] = `
             class="notification-item n-child"
           >
             <div
-              class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-dlVxhl dljPk kNGFbM sc-llYSUQ FJxnU sc-jivBlf fMnGVo"
+              class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-dlVxhl dljPk kNGFbM sc-llYSUQ FJxnU sc-hkgtus bTexjT"
             >
               
               <div
@@ -380,7 +380,7 @@ exports[`Storyshots Core/Notifications Positioning 1`] = `
             class="notification-item n-child"
           >
             <div
-              class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-dlVxhl dljPk kNGFbM sc-llYSUQ FJxnU sc-jivBlf fMnGVo"
+              class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-dlVxhl dljPk kNGFbM sc-llYSUQ FJxnU sc-hkgtus bTexjT"
             >
               
               <div
@@ -433,7 +433,7 @@ exports[`Storyshots Core/Notifications Positioning 1`] = `
               class="notification-item n-child"
             >
               <div
-                class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-dlVxhl dljPk kNGFbM sc-llYSUQ FJxnU sc-jivBlf fMnGVo"
+                class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-dlVxhl dljPk kNGFbM sc-llYSUQ FJxnU sc-hkgtus bTexjT"
               >
                 
                 <div
@@ -484,7 +484,7 @@ exports[`Storyshots Core/Notifications Positioning 1`] = `
             class="notification-item n-child"
           >
             <div
-              class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-dlVxhl dljPk kNGFbM sc-llYSUQ FJxnU sc-jivBlf fMnGVo"
+              class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-dlVxhl dljPk kNGFbM sc-llYSUQ FJxnU sc-hkgtus bTexjT"
             >
               
               <div
@@ -585,13 +585,13 @@ exports[`Storyshots Core/Notifications Positioning 1`] = `
 exports[`Storyshots Core/Notifications Types 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd exdBHI sc-iCfMLu nKarx sc-hGPBjI hhYUbN"
     >
       <div
-        class="react-notification-root sc-hkgtus dZVxiT"
+        class="react-notification-root sc-bSqaIl fvRzvB"
       >
         <div
           class="notification-container-top-left"
@@ -607,7 +607,7 @@ exports[`Storyshots Core/Notifications Types 1`] = `
               class="notification-item n-child"
             >
               <div
-                class="sc-gKclnd exdBHI sc-iCfMLu huiLtj sc-hGPBjI sc-dlVxhl dljPk nMzZG sc-llYSUQ FJxnU sc-jivBlf fMnGVo"
+                class="sc-gKclnd exdBHI sc-iCfMLu huiLtj sc-hGPBjI sc-dlVxhl dljPk nMzZG sc-llYSUQ FJxnU sc-hkgtus bTexjT"
               >
                 <div
                   class="sc-fKVqWL hOcWtv sc-bBHxTw eYXqkg"
@@ -675,7 +675,7 @@ exports[`Storyshots Core/Notifications Types 1`] = `
               class="notification-item n-child"
             >
               <div
-                class="sc-gKclnd exdBHI sc-iCfMLu eKXQBJ sc-hGPBjI sc-dlVxhl dljPk hYjsLV sc-llYSUQ FJxnU sc-jivBlf fMnGVo"
+                class="sc-gKclnd exdBHI sc-iCfMLu eKXQBJ sc-hGPBjI sc-dlVxhl dljPk hYjsLV sc-llYSUQ FJxnU sc-hkgtus bTexjT"
               >
                 <div
                   class="sc-fKVqWL hOcWtv sc-bBHxTw ckwMS"
@@ -743,7 +743,7 @@ exports[`Storyshots Core/Notifications Types 1`] = `
               class="notification-item n-child"
             >
               <div
-                class="sc-gKclnd exdBHI sc-iCfMLu bURqap sc-hGPBjI sc-dlVxhl dljPk cynbHW sc-llYSUQ FJxnU sc-jivBlf fMnGVo"
+                class="sc-gKclnd exdBHI sc-iCfMLu bURqap sc-hGPBjI sc-dlVxhl dljPk cynbHW sc-llYSUQ FJxnU sc-hkgtus bTexjT"
               >
                 <div
                   class="sc-fKVqWL hOcWtv sc-bBHxTw bkFZrq"
@@ -811,7 +811,7 @@ exports[`Storyshots Core/Notifications Types 1`] = `
               class="notification-item n-child"
             >
               <div
-                class="sc-gKclnd exdBHI sc-iCfMLu bqJAXg sc-hGPBjI sc-dlVxhl dljPk fImdLd sc-llYSUQ FJxnU sc-jivBlf fMnGVo"
+                class="sc-gKclnd exdBHI sc-iCfMLu bqJAXg sc-hGPBjI sc-dlVxhl dljPk fImdLd sc-llYSUQ FJxnU sc-hkgtus bTexjT"
               >
                 <div
                   class="sc-fKVqWL hOcWtv sc-bBHxTw hFmZAP"

--- a/src/components/Pager/__snapshots__/Pager.stories.storyshot
+++ b/src/components/Pager/__snapshots__/Pager.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/Pager Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI dLlxyS"

--- a/src/components/Popover/__snapshots__/Popover.stories.storyshot
+++ b/src/components/Popover/__snapshots__/Popover.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/Popover Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd exdBHI sc-iCfMLu fBDGQC"

--- a/src/components/ProgressBar/__snapshots__/ProgressBar.stories.storyshot
+++ b/src/components/ProgressBar/__snapshots__/ProgressBar.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/ProgressBar Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-XxNYO gNUYFN sc-ilfuhL gPrLKN"
@@ -35,7 +35,7 @@ exports[`Storyshots Core/ProgressBar Default 1`] = `
 exports[`Storyshots Core/ProgressBar Different Color 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-XxNYO gNUYFN sc-ilfuhL gPrLKN"
@@ -68,7 +68,7 @@ exports[`Storyshots Core/ProgressBar Different Color 1`] = `
 exports[`Storyshots Core/ProgressBar Emphasized 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-XxNYO kdGSto sc-ilfuhL gPrLKN"

--- a/src/components/RadioButton/__snapshots__/RadioButton.stories.storyshot
+++ b/src/components/RadioButton/__snapshots__/RadioButton.stories.storyshot
@@ -3,10 +3,10 @@
 exports[`Storyshots Core/RadioButton Checked 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
-      class="sc-gyElHZ bKDQex sc-gjNHFA bySJqW"
+      class="sc-gjNHFA cTVbHk sc-fmciRz FNnoD"
     >
       <label
         class="StyledRadioButton__StyledRadioButtonContainer-sc-g1f6ld-0 jGWwCF"
@@ -50,10 +50,10 @@ exports[`Storyshots Core/RadioButton Checked 1`] = `
 exports[`Storyshots Core/RadioButton Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
-      class="sc-gyElHZ kHOant sc-gjNHFA bySJqW"
+      class="sc-gjNHFA eVZCMM sc-fmciRz FNnoD"
     >
       <label
         class="StyledRadioButton__StyledRadioButtonContainer-sc-g1f6ld-0 jGWwCF"
@@ -84,10 +84,10 @@ exports[`Storyshots Core/RadioButton Default 1`] = `
 exports[`Storyshots Core/RadioButton Disabled 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
-      class="sc-gyElHZ kHOant sc-gjNHFA bySJqW"
+      class="sc-gjNHFA eVZCMM sc-fmciRz FNnoD"
     >
       <label
         class="StyledRadioButton__StyledRadioButtonContainer-sc-g1f6ld-0 bgseKw"

--- a/src/components/RadioButtonGroup/__snapshots__/RadioButtonGroup.stories.storyshot
+++ b/src/components/RadioButtonGroup/__snapshots__/RadioButtonGroup.stories.storyshot
@@ -3,10 +3,10 @@
 exports[`Storyshots Core/RadioButtonGroup Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hpSXsQ sc-fmciRz kXGmpi sc-eXlEPa bHRPf"
+      class="StyledBox-sc-13pk1d4-0 hpSXsQ sc-eXlEPa hsRDoW sc-iFMAIt dpeeck"
       role="radiogroup"
     >
       <label
@@ -83,10 +83,10 @@ exports[`Storyshots Core/RadioButtonGroup Default 1`] = `
 exports[`Storyshots Core/RadioButtonGroup With Expanded Options 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hpSXsQ sc-fmciRz LoyIm sc-eXlEPa bHRPf"
+      class="StyledBox-sc-13pk1d4-0 hpSXsQ sc-eXlEPa iomdZS sc-iFMAIt dpeeck"
       role="radiogroup"
     >
       <label

--- a/src/components/Rating/__snapshots__/Rating.stories.storyshot
+++ b/src/components/Rating/__snapshots__/Rating.stories.storyshot
@@ -3,10 +3,10 @@
 exports[`Storyshots Core/Rating Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
-      class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI dljPk sc-fmBCVi hkNjIb"
+      class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI dljPk sc-lkgTHX gZiCSy"
     >
       <svg
         aria-hidden="true"

--- a/src/components/Search/__snapshots__/Search.stories.storyshot
+++ b/src/components/Search/__snapshots__/Search.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/Search Dark 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-khQegj dljPk ffXoGL sc-hUpaCq igPhtM"
@@ -36,7 +36,7 @@ exports[`Storyshots Core/Search Dark 1`] = `
 exports[`Storyshots Core/Search Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-khQegj dljPk ffXoGL sc-hUpaCq igPhtM"
@@ -68,7 +68,7 @@ exports[`Storyshots Core/Search Default 1`] = `
 exports[`Storyshots Core/Search Disabled 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-khQegj dljPk ffXoGL sc-hUpaCq igPhtM"
@@ -101,7 +101,7 @@ exports[`Storyshots Core/Search Disabled 1`] = `
 exports[`Storyshots Core/Search With Placeholder 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-khQegj dljPk ffXoGL sc-hUpaCq igPhtM"

--- a/src/components/Select/__snapshots__/Select.stories.storyshot
+++ b/src/components/Select/__snapshots__/Select.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/Select Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-eJwWfJ ixbnwP sc-nVkyK dbmSBX"
@@ -59,7 +59,7 @@ exports[`Storyshots Core/Select Default 1`] = `
 exports[`Storyshots Core/Select Emphasized 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-eJwWfJ ixbnwP sc-nVkyK dbmSBX"
@@ -115,7 +115,7 @@ exports[`Storyshots Core/Select Emphasized 1`] = `
 exports[`Storyshots Core/Select Invalid 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-eJwWfJ kAnPF sc-nVkyK dbmSBX"
@@ -171,7 +171,7 @@ exports[`Storyshots Core/Select Invalid 1`] = `
 exports[`Storyshots Core/Select Object Options 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-eJwWfJ ixbnwP sc-nVkyK dbmSBX"
@@ -227,7 +227,7 @@ exports[`Storyshots Core/Select Object Options 1`] = `
 exports[`Storyshots Core/Select With Custom Option 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-eJwWfJ ixbnwP sc-nVkyK dbmSBX"
@@ -283,7 +283,7 @@ exports[`Storyshots Core/Select With Custom Option 1`] = `
 exports[`Storyshots Core/Select With Placeholder 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-eJwWfJ ixbnwP sc-nVkyK dbmSBX"

--- a/src/components/Spinner/__snapshots__/Spinner.stories.storyshot
+++ b/src/components/Spinner/__snapshots__/Spinner.stories.storyshot
@@ -3,13 +3,13 @@
 exports[`Storyshots Core/Spinner Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
-      class="sc-gKclnd exdBHI sc-iCfMLu dqOFRa sc-hGPBjI dIoSYo sc-cbTzjv bxHvyV"
+      class="sc-gKclnd exdBHI sc-iCfMLu dqOFRa sc-hGPBjI dIoSYo sc-hjGZqJ iGsnMG"
     >
       <div
-        class="sc-lkgTHX iTiSHO"
+        class="sc-jlRLRk fkKuWz"
       />
     </div>
   </div>
@@ -19,13 +19,13 @@ exports[`Storyshots Core/Spinner Default 1`] = `
 exports[`Storyshots Core/Spinner Emphasized 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
-      class="sc-gKclnd exdBHI sc-iCfMLu dqOFRa sc-hGPBjI jrnTxU sc-cbTzjv bxHvyV"
+      class="sc-gKclnd exdBHI sc-iCfMLu dqOFRa sc-hGPBjI jrnTxU sc-hjGZqJ iGsnMG"
     >
       <div
-        class="sc-lkgTHX crcbRs"
+        class="sc-jlRLRk fbeEUJ"
       />
     </div>
   </div>
@@ -35,19 +35,19 @@ exports[`Storyshots Core/Spinner Emphasized 1`] = `
 exports[`Storyshots Core/Spinner With Children 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
-      class="sc-jlRLRk fKFzkH sc-cbTzjv bxHvyV"
+      class="sc-dUbtfd kuvLYf sc-hjGZqJ iGsnMG"
     >
       <div
-        class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-dUbtfd duIhFM dRqjPA"
+        class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-htJRVC duIhFM yMIng"
       >
         <div
           class="sc-gKclnd exdBHI sc-iCfMLu dqOFRa sc-hGPBjI dIoSYo"
         >
           <div
-            class="sc-lkgTHX iTiSHO"
+            class="sc-jlRLRk fkKuWz"
           />
           <div
             class="sc-fKVqWL hOcWtv sc-bBHxTw fbMhcE"
@@ -57,7 +57,7 @@ exports[`Storyshots Core/Spinner With Children 1`] = `
         </div>
       </div>
       <div
-        class="sc-htJRVC fmoRMP"
+        class="sc-cbTzjv jwWtfF"
       >
         <div
           class="sc-gKclnd exdBHI sc-iCfMLu eWtVmG"
@@ -74,13 +74,13 @@ exports[`Storyshots Core/Spinner With Children 1`] = `
 exports[`Storyshots Core/Spinner With Component Label 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
-      class="sc-gKclnd exdBHI sc-iCfMLu dqOFRa sc-hGPBjI dIoSYo sc-cbTzjv bxHvyV"
+      class="sc-gKclnd exdBHI sc-iCfMLu dqOFRa sc-hGPBjI dIoSYo sc-hjGZqJ iGsnMG"
     >
       <div
-        class="sc-lkgTHX iTiSHO"
+        class="sc-jlRLRk fkKuWz"
       />
       <div
         class="sc-fKVqWL hOcWtv sc-bBHxTw fbMhcE"
@@ -106,13 +106,13 @@ exports[`Storyshots Core/Spinner With Component Label 1`] = `
 exports[`Storyshots Core/Spinner With Label 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
-      class="sc-gKclnd exdBHI sc-iCfMLu dqOFRa sc-hGPBjI dIoSYo sc-cbTzjv bxHvyV"
+      class="sc-gKclnd exdBHI sc-iCfMLu dqOFRa sc-hGPBjI dIoSYo sc-hjGZqJ iGsnMG"
     >
       <div
-        class="sc-lkgTHX iTiSHO"
+        class="sc-jlRLRk fkKuWz"
       />
       <div
         class="sc-fKVqWL hOcWtv sc-bBHxTw fbMhcE"

--- a/src/components/StatsBar/__snapshots__/StatsBar.stories.storyshot
+++ b/src/components/StatsBar/__snapshots__/StatsBar.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/StatsBar Cpu Temp 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd iQIogj sc-iCfMLu gZewII sc-hGPBjI kBwkZQ"
@@ -93,7 +93,7 @@ exports[`Storyshots Core/StatsBar Cpu Temp 1`] = `
 exports[`Storyshots Core/StatsBar Cpu Usage 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd iQIogj sc-iCfMLu gZewII sc-hGPBjI kBwkZQ"
@@ -271,7 +271,7 @@ exports[`Storyshots Core/StatsBar Cpu Usage 1`] = `
 exports[`Storyshots Core/StatsBar Memory 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd iQIogj sc-iCfMLu gZewII sc-hGPBjI kBwkZQ"
@@ -371,7 +371,7 @@ exports[`Storyshots Core/StatsBar Memory 1`] = `
 exports[`Storyshots Core/StatsBar Storage 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd iQIogj sc-iCfMLu gZewII sc-hGPBjI kBwkZQ"

--- a/src/components/Steps/__snapshots__/Steps.stories.storyshot
+++ b/src/components/Steps/__snapshots__/Steps.stories.storyshot
@@ -3,10 +3,10 @@
 exports[`Storyshots Core/Steps Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
-      class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-dlVxhl cjvOmv hzmnYo sc-fIosxK fZWHgK"
+      class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-dlVxhl cjvOmv hzmnYo sc-gyElHZ SKrzf"
     >
       <div
         class="sc-gKclnd exdBHI sc-iCfMLu hIaPaF sc-hGPBjI leVHSn"
@@ -18,7 +18,7 @@ exports[`Storyshots Core/Steps Default 1`] = `
             class="sc-gKclnd exdBHI sc-iCfMLu bHKpGZ sc-hGPBjI dIoSYo"
           >
             <div
-              class="sc-gKclnd exdBHI sc-iCfMLu iiCCZX sc-hGPBjI sc-hjGZqJ dljPk eBvRjh"
+              class="sc-gKclnd exdBHI sc-iCfMLu iiCCZX sc-hGPBjI sc-gUQvok dljPk jeOSmU"
             >
               <svg
                 aria-hidden="true"
@@ -76,7 +76,7 @@ exports[`Storyshots Core/Steps Default 1`] = `
             class="sc-gKclnd exdBHI sc-iCfMLu bHKpGZ sc-hGPBjI dIoSYo"
           >
             <div
-              class="sc-gKclnd exdBHI sc-iCfMLu iiCCZX sc-hGPBjI sc-hjGZqJ dljPk eBvRjh"
+              class="sc-gKclnd exdBHI sc-iCfMLu iiCCZX sc-hGPBjI sc-gUQvok dljPk jeOSmU"
             >
               <svg
                 aria-hidden="true"
@@ -134,7 +134,7 @@ exports[`Storyshots Core/Steps Default 1`] = `
             class="sc-gKclnd exdBHI sc-iCfMLu bHKpGZ sc-hGPBjI dIoSYo"
           >
             <div
-              class="sc-gKclnd exdBHI sc-iCfMLu iiCCZX sc-hGPBjI sc-hjGZqJ dljPk eBvRjh"
+              class="sc-gKclnd exdBHI sc-iCfMLu iiCCZX sc-hGPBjI sc-gUQvok dljPk jeOSmU"
             >
               <svg
                 aria-hidden="true"
@@ -168,10 +168,10 @@ exports[`Storyshots Core/Steps Default 1`] = `
 exports[`Storyshots Core/Steps Ordered 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
-      class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-dlVxhl cjvOmv hzmnYo sc-fIosxK fZWHgK"
+      class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-dlVxhl cjvOmv hzmnYo sc-gyElHZ SKrzf"
     >
       <div
         class="sc-gKclnd exdBHI sc-iCfMLu hIaPaF sc-hGPBjI leVHSn"
@@ -183,7 +183,7 @@ exports[`Storyshots Core/Steps Ordered 1`] = `
             class="sc-gKclnd exdBHI sc-iCfMLu bHKpGZ sc-hGPBjI dIoSYo"
           >
             <div
-              class="sc-gKclnd exdBHI sc-iCfMLu iiCCZX sc-hGPBjI sc-hjGZqJ dljPk eBvRjh"
+              class="sc-gKclnd exdBHI sc-iCfMLu iiCCZX sc-hGPBjI sc-gUQvok dljPk jeOSmU"
             >
               <svg
                 aria-hidden="true"
@@ -241,7 +241,7 @@ exports[`Storyshots Core/Steps Ordered 1`] = `
             class="sc-gKclnd exdBHI sc-iCfMLu bHKpGZ sc-hGPBjI dIoSYo"
           >
             <div
-              class="sc-gKclnd exdBHI sc-iCfMLu fSpifk sc-hGPBjI sc-hjGZqJ dljPk eBvRjh fa-layers"
+              class="sc-gKclnd exdBHI sc-iCfMLu fSpifk sc-hGPBjI sc-gUQvok dljPk jeOSmU fa-layers"
             >
               <svg
                 aria-hidden="true"
@@ -259,7 +259,7 @@ exports[`Storyshots Core/Steps Ordered 1`] = `
                 />
               </svg>
               <div
-                class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh sc-gUQvok bRurA-D fa-layers-text fa-inverse"
+                class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh sc-fXeWAj gsRwdN fa-layers-text fa-inverse"
               >
                 2
               </div>
@@ -304,13 +304,13 @@ exports[`Storyshots Core/Steps Ordered 1`] = `
             class="sc-gKclnd exdBHI sc-iCfMLu bHKpGZ sc-hGPBjI dIoSYo"
           >
             <div
-              class="sc-gKclnd exdBHI sc-iCfMLu OLnYO sc-hGPBjI sc-hjGZqJ dljPk eBvRjh fa-layers"
+              class="sc-gKclnd exdBHI sc-iCfMLu OLnYO sc-hGPBjI sc-gUQvok dljPk jeOSmU fa-layers"
             >
               <div
-                class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-fXeWAj fdHgqj"
+                class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-fIosxK ejOsSE"
               />
               <div
-                class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh sc-gUQvok bRurA-D fa-layers-text"
+                class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh sc-fXeWAj gsRwdN fa-layers-text"
               >
                 3
               </div>
@@ -331,10 +331,10 @@ exports[`Storyshots Core/Steps Ordered 1`] = `
 exports[`Storyshots Core/Steps With Custom Title 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
-      class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-dlVxhl cjvOmv hzmnYo sc-fIosxK fZWHgK"
+      class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-dlVxhl cjvOmv hzmnYo sc-gyElHZ SKrzf"
     >
       <div
         class="sc-gKclnd exdBHI sc-iCfMLu kLYVQt sc-hGPBjI duIhFM"
@@ -374,7 +374,7 @@ exports[`Storyshots Core/Steps With Custom Title 1`] = `
             class="sc-gKclnd exdBHI sc-iCfMLu bHKpGZ sc-hGPBjI dIoSYo"
           >
             <div
-              class="sc-gKclnd exdBHI sc-iCfMLu iiCCZX sc-hGPBjI sc-hjGZqJ dljPk eBvRjh"
+              class="sc-gKclnd exdBHI sc-iCfMLu iiCCZX sc-hGPBjI sc-gUQvok dljPk jeOSmU"
             >
               <svg
                 aria-hidden="true"
@@ -432,7 +432,7 @@ exports[`Storyshots Core/Steps With Custom Title 1`] = `
             class="sc-gKclnd exdBHI sc-iCfMLu bHKpGZ sc-hGPBjI dIoSYo"
           >
             <div
-              class="sc-gKclnd exdBHI sc-iCfMLu iiCCZX sc-hGPBjI sc-hjGZqJ dljPk eBvRjh"
+              class="sc-gKclnd exdBHI sc-iCfMLu iiCCZX sc-hGPBjI sc-gUQvok dljPk jeOSmU"
             >
               <svg
                 aria-hidden="true"
@@ -490,7 +490,7 @@ exports[`Storyshots Core/Steps With Custom Title 1`] = `
             class="sc-gKclnd exdBHI sc-iCfMLu bHKpGZ sc-hGPBjI dIoSYo"
           >
             <div
-              class="sc-gKclnd exdBHI sc-iCfMLu iiCCZX sc-hGPBjI sc-hjGZqJ dljPk eBvRjh"
+              class="sc-gKclnd exdBHI sc-iCfMLu iiCCZX sc-hGPBjI sc-gUQvok dljPk jeOSmU"
             >
               <svg
                 aria-hidden="true"
@@ -524,10 +524,10 @@ exports[`Storyshots Core/Steps With Custom Title 1`] = `
 exports[`Storyshots Core/Steps Without Borders 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
-      class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-dlVxhl cjvOmv guOJZv sc-fIosxK fZWHgK"
+      class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-dlVxhl cjvOmv guOJZv sc-gyElHZ SKrzf"
     >
       <div
         class="sc-gKclnd exdBHI sc-iCfMLu hIaPaF sc-hGPBjI leVHSn"
@@ -539,7 +539,7 @@ exports[`Storyshots Core/Steps Without Borders 1`] = `
             class="sc-gKclnd exdBHI sc-iCfMLu bHKpGZ sc-hGPBjI dIoSYo"
           >
             <div
-              class="sc-gKclnd exdBHI sc-iCfMLu iiCCZX sc-hGPBjI sc-hjGZqJ dljPk eBvRjh"
+              class="sc-gKclnd exdBHI sc-iCfMLu iiCCZX sc-hGPBjI sc-gUQvok dljPk jeOSmU"
             >
               <svg
                 aria-hidden="true"
@@ -598,7 +598,7 @@ exports[`Storyshots Core/Steps Without Borders 1`] = `
             class="sc-gKclnd exdBHI sc-iCfMLu bHKpGZ sc-hGPBjI dIoSYo"
           >
             <div
-              class="sc-gKclnd exdBHI sc-iCfMLu OLnYO sc-hGPBjI sc-hjGZqJ dljPk eBvRjh"
+              class="sc-gKclnd exdBHI sc-iCfMLu OLnYO sc-hGPBjI sc-gUQvok dljPk jeOSmU"
             >
               <svg
                 aria-hidden="true"

--- a/src/components/SurroundingOverlay/SurroundingOverlay.stories.tsx
+++ b/src/components/SurroundingOverlay/SurroundingOverlay.stories.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { Meta } from '@storybook/react';
+import { createTemplate, createStory } from '../../stories/utils';
+import { SurroundingOverlay, SurroundingOverlayProps, PartialDomRect } from '.';
+import { Input } from '../Input';
+
+const SurroundingOverlayDemo = (props: SurroundingOverlayProps) => {
+	const [rect, setRect] = React.useState<PartialDomRect | null>(null);
+	return (
+		<>
+			<SurroundingOverlay rect={rect} {...props} />
+			<Input
+				mb={4}
+				type="text"
+				onFocus={(e) => setRect(e.target.getBoundingClientRect())}
+				onBlur={() => setRect(null)}
+			/>
+			<Input
+				mb={4}
+				type="text"
+				onFocus={(e) => setRect(e.target.getBoundingClientRect())}
+				onBlur={() => setRect(null)}
+			/>
+			<Input
+				type="datetime-local"
+				onFocus={(e) => setRect(e.target.getBoundingClientRect())}
+				onBlur={() => setRect(null)}
+			/>
+		</>
+	);
+};
+
+export default {
+	title: 'Core/SurroundingOverlay',
+	component: SurroundingOverlay,
+} as Meta;
+
+const Template = createTemplate<SurroundingOverlayProps>(
+	SurroundingOverlayDemo,
+);
+
+export const Default = createStory<SurroundingOverlayProps>(Template, {});
+
+export const WithDifferentColor = createStory<SurroundingOverlayProps>(
+	Template,
+	{
+		layerColor: 'black',
+		padding: 5,
+	},
+);

--- a/src/components/SurroundingOverlay/__snapshots__/SurroundingOverlay.stories.storyshot
+++ b/src/components/SurroundingOverlay/__snapshots__/SurroundingOverlay.stories.storyshot
@@ -1,0 +1,79 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storyshots Core/SurroundingOverlay Default 1`] = `
+<div>
+  <div
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
+  >
+    <div
+      class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 jqwtzG"
+    >
+      <input
+        autocomplete="off"
+        class="StyledTextInput-sc-1x30a0s-0 bMIWHa sc-jgrJph jaaZuO sc-gSQFLo jzuYuc"
+        type="text"
+        value=""
+      />
+    </div>
+    <div
+      class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 jqwtzG"
+    >
+      <input
+        autocomplete="off"
+        class="StyledTextInput-sc-1x30a0s-0 bMIWHa sc-jgrJph jaaZuO sc-gSQFLo jzuYuc"
+        type="text"
+        value=""
+      />
+    </div>
+    <div
+      class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 jqwtzG"
+    >
+      <input
+        autocomplete="off"
+        class="StyledTextInput-sc-1x30a0s-0 bMIWHa sc-jgrJph jaaZuO sc-gSQFLo kimdWC"
+        type="datetime-local"
+        value=""
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Core/SurroundingOverlay With Different Color 1`] = `
+<div>
+  <div
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
+  >
+    <div
+      class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 jqwtzG"
+    >
+      <input
+        autocomplete="off"
+        class="StyledTextInput-sc-1x30a0s-0 bMIWHa sc-jgrJph jaaZuO sc-gSQFLo jzuYuc"
+        type="text"
+        value=""
+      />
+    </div>
+    <div
+      class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 jqwtzG"
+    >
+      <input
+        autocomplete="off"
+        class="StyledTextInput-sc-1x30a0s-0 bMIWHa sc-jgrJph jaaZuO sc-gSQFLo jzuYuc"
+        type="text"
+        value=""
+      />
+    </div>
+    <div
+      class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 jqwtzG"
+    >
+      <input
+        autocomplete="off"
+        class="StyledTextInput-sc-1x30a0s-0 bMIWHa sc-jgrJph jaaZuO sc-gSQFLo kimdWC"
+        type="datetime-local"
+        value=""
+      />
+    </div>
+  </div>
+</div>
+`;

--- a/src/components/SurroundingOverlay/index.tsx
+++ b/src/components/SurroundingOverlay/index.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import styled from 'styled-components';
+
+interface LayerProps {
+	top?: number;
+	bottom?: number;
+	left?: number;
+	right?: number;
+	height?: number;
+	layerColor?: string;
+	opacity?: number;
+}
+
+const Layer = styled.div<LayerProps>`
+	position: absolute;
+	z-index: 20;
+	${(props) => `
+		opacity: ${props.opacity ?? 0.5};
+    background: ${props.layerColor || 'white'};
+    top: ${props.top || 0}px;
+    bottom: ${props.bottom || 0}px;
+    left: ${props.left || 0}px;
+    right: ${props.right || 0}px;
+    height: ${props.height != null ? props.height + 'px' : 'auto'};
+  `}
+`;
+
+export type PartialDomRect = Partial<Omit<DOMRect, 'toJSON'>>;
+
+export const getBoundingContainerRect = (
+	element: EventTarget & HTMLDivElement,
+): PartialDomRect | null => {
+	if (!element) {
+		return null;
+	}
+	const parent = (element.offsetParent as HTMLElement) ?? document.body;
+	const top = element.offsetTop + parent.offsetTop;
+	const left = element.offsetLeft + parent.offsetLeft;
+	const height = element.clientHeight;
+	return {
+		top,
+		bottom: top + height,
+		left,
+		right: left + element.clientWidth,
+		height,
+		width: element.clientWidth,
+		x: top,
+		y: left,
+	};
+};
+
+export interface SurroundingOverlayProps {
+	rect: PartialDomRect | null;
+	layerColor?: string;
+	padding?: number;
+	opacity?: number;
+}
+
+export const SurroundingOverlay = ({
+	rect,
+	layerColor,
+	padding = 0,
+	opacity,
+}: SurroundingOverlayProps) => {
+	if (!rect) {
+		return null;
+	}
+
+	const top = rect.top ?? 0;
+	const left = rect.left ?? 0;
+	const height = rect.height ?? 0;
+	const width = rect.width ?? 0;
+
+	const topDistance = top + height + padding;
+	const lateralLayersTop = Math.max(top - padding, 0);
+	const lateralLayersRight = left + width + padding;
+	const lateralLayersHeight = topDistance - lateralLayersTop;
+
+	const layers = {
+		topLayer: {
+			height: lateralLayersTop,
+		},
+		bottomLayer: {
+			top: topDistance,
+		},
+		rightLayer: {
+			top: lateralLayersTop,
+			left: lateralLayersRight,
+			height: lateralLayersHeight,
+		},
+		leftLayer: {
+			top: lateralLayersTop,
+			right: lateralLayersRight,
+			height: lateralLayersHeight,
+		},
+	};
+
+	return (
+		<>
+			{Object.values(layers).map((layerProps, index) => (
+				<Layer
+					key={index}
+					{...layerProps}
+					layerColor={layerColor}
+					opacity={opacity}
+				/>
+			))}
+		</>
+	);
+};

--- a/src/components/SurroundingOverlay/spec.tsx
+++ b/src/components/SurroundingOverlay/spec.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import { mount } from 'enzyme';
+import { SurroundingOverlay, Provider } from '../..';
+
+describe('SurroundingOverlay component', () => {
+	it('should render the SurroundingOverlay', () => {
+		const rect = {
+			top: 0,
+			left: 0,
+			bottom: 0,
+			right: 0,
+			x: 0,
+			y: 0,
+			height: undefined,
+			width: 800,
+		};
+		const component = mount(
+			<Provider>
+				<SurroundingOverlay rect={rect} />
+			</Provider>,
+		);
+		expect(component.find(SurroundingOverlay).children()).toHaveLength(4);
+	});
+	it('should not render the SurroundingOverlay', () => {
+		const rect = null;
+		const component = mount(
+			<Provider>
+				<SurroundingOverlay rect={rect} />
+			</Provider>,
+		);
+		expect(component.find(SurroundingOverlay).children()).toHaveLength(0);
+	});
+});

--- a/src/components/Table/__snapshots__/Table.stories.storyshot
+++ b/src/components/Table/__snapshots__/Table.stories.storyshot
@@ -3,19 +3,19 @@
 exports[`Storyshots Core/Table Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
-      class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-fyrocj dljPk jxvgud"
+      class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-iWVNaa dljPk YIrmE"
     >
       <div
         class="sc-gKclnd iQIogj sc-iCfMLu frGhDt sc-hGPBjI kBwkZQ"
       >
         <div
-          class="sc-iqVWFU hIAseQ"
+          class="sc-eWfVMQ gmreIg"
         >
           <div
-            class="sc-eWfVMQ kmJZgg sc-jKTccl fWCWlF"
+            class="sc-kTLmzF kNwxgk sc-bUbRBg hsvIRe"
           >
             <div
               data-display="table-head"
@@ -27,7 +27,7 @@ exports[`Storyshots Core/Table Default 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-kTLmzF eezwuu"
+                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-dwsnSq hZFOwY"
                     data-field="Name"
                     type="button"
                   >
@@ -55,7 +55,7 @@ exports[`Storyshots Core/Table Default 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-kTLmzF eezwuu"
+                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-dwsnSq hZFOwY"
                     data-field="pokedex_number"
                     type="button"
                   >
@@ -83,7 +83,7 @@ exports[`Storyshots Core/Table Default 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-kTLmzF eezwuu"
+                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-dwsnSq hZFOwY"
                     data-field="Category"
                     type="button"
                   >
@@ -111,7 +111,7 @@ exports[`Storyshots Core/Table Default 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-kTLmzF eezwuu"
+                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-dwsnSq hZFOwY"
                     data-field="first_seen"
                     type="button"
                   >
@@ -506,19 +506,19 @@ exports[`Storyshots Core/Table Default 1`] = `
 exports[`Storyshots Core/Table Sorted 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
-      class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-fyrocj dljPk jxvgud"
+      class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-iWVNaa dljPk YIrmE"
     >
       <div
         class="sc-gKclnd iQIogj sc-iCfMLu frGhDt sc-hGPBjI kBwkZQ"
       >
         <div
-          class="sc-iqVWFU hIAseQ"
+          class="sc-eWfVMQ gmreIg"
         >
           <div
-            class="sc-eWfVMQ kmJZgg sc-jKTccl fWCWlF"
+            class="sc-kTLmzF kNwxgk sc-bUbRBg hsvIRe"
           >
             <div
               data-display="table-head"
@@ -530,7 +530,7 @@ exports[`Storyshots Core/Table Sorted 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 dxCrOx sc-bqiRlB sc-bkkeKt edofBN hOrbaG sc-dJjYzT cGuTUx sc-kTLmzF eezwuu"
+                    class="StyledButton-sc-323bzc-0 dxCrOx sc-bqiRlB sc-bkkeKt edofBN hOrbaG sc-dJjYzT cGuTUx sc-dwsnSq hZFOwY"
                     data-field="Name"
                     type="button"
                   >
@@ -558,7 +558,7 @@ exports[`Storyshots Core/Table Sorted 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-kTLmzF eezwuu"
+                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-dwsnSq hZFOwY"
                     data-field="pokedex_number"
                     type="button"
                   >
@@ -586,7 +586,7 @@ exports[`Storyshots Core/Table Sorted 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-kTLmzF eezwuu"
+                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-dwsnSq hZFOwY"
                     data-field="Category"
                     type="button"
                   >
@@ -614,7 +614,7 @@ exports[`Storyshots Core/Table Sorted 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-kTLmzF eezwuu"
+                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-dwsnSq hZFOwY"
                     data-field="first_seen"
                     type="button"
                   >
@@ -1009,19 +1009,19 @@ exports[`Storyshots Core/Table Sorted 1`] = `
 exports[`Storyshots Core/Table With Anchor Rows 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
-      class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-fyrocj dljPk jxvgud"
+      class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-iWVNaa dljPk YIrmE"
     >
       <div
         class="sc-gKclnd iQIogj sc-iCfMLu frGhDt sc-hGPBjI kBwkZQ"
       >
         <div
-          class="sc-iqVWFU hIAseQ"
+          class="sc-eWfVMQ gmreIg"
         >
           <div
-            class="sc-eWfVMQ jIMImu sc-jKTccl fWCWlF"
+            class="sc-kTLmzF gNkruy sc-bUbRBg hsvIRe"
           >
             <div
               data-display="table-head"
@@ -1033,7 +1033,7 @@ exports[`Storyshots Core/Table With Anchor Rows 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-kTLmzF eezwuu"
+                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-dwsnSq hZFOwY"
                     data-field="Name"
                     type="button"
                   >
@@ -1061,7 +1061,7 @@ exports[`Storyshots Core/Table With Anchor Rows 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-kTLmzF eezwuu"
+                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-dwsnSq hZFOwY"
                     data-field="pokedex_number"
                     type="button"
                   >
@@ -1089,7 +1089,7 @@ exports[`Storyshots Core/Table With Anchor Rows 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-kTLmzF eezwuu"
+                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-dwsnSq hZFOwY"
                     data-field="Category"
                     type="button"
                   >
@@ -1117,7 +1117,7 @@ exports[`Storyshots Core/Table With Anchor Rows 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-kTLmzF eezwuu"
+                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-dwsnSq hZFOwY"
                     data-field="first_seen"
                     type="button"
                   >
@@ -1600,19 +1600,19 @@ exports[`Storyshots Core/Table With Anchor Rows 1`] = `
 exports[`Storyshots Core/Table With Checkboxes 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
-      class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-fyrocj dljPk jxvgud"
+      class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-iWVNaa dljPk YIrmE"
     >
       <div
         class="sc-gKclnd iQIogj sc-iCfMLu frGhDt sc-hGPBjI kBwkZQ"
       >
         <div
-          class="sc-iqVWFU hIAseQ"
+          class="sc-eWfVMQ gmreIg"
         >
           <div
-            class="sc-eWfVMQ xUXjS sc-jKTccl cKEcNg"
+            class="sc-kTLmzF beZem sc-bUbRBg bnwCgX"
           >
             <div
               data-display="table-head"
@@ -1621,7 +1621,7 @@ exports[`Storyshots Core/Table With Checkboxes 1`] = `
                 data-display="table-row"
               >
                 <div
-                  class="sc-iFMAIt bKXgtf"
+                  class="sc-iqVWFU cmiHhz"
                   data-display="table-cell"
                 >
                   <div
@@ -1648,7 +1648,7 @@ exports[`Storyshots Core/Table With Checkboxes 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-kTLmzF eezwuu"
+                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-dwsnSq hZFOwY"
                     data-field="Name"
                     type="button"
                   >
@@ -1676,7 +1676,7 @@ exports[`Storyshots Core/Table With Checkboxes 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-kTLmzF eezwuu"
+                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-dwsnSq hZFOwY"
                     data-field="pokedex_number"
                     type="button"
                   >
@@ -1704,7 +1704,7 @@ exports[`Storyshots Core/Table With Checkboxes 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-kTLmzF eezwuu"
+                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-dwsnSq hZFOwY"
                     data-field="Category"
                     type="button"
                   >
@@ -1732,7 +1732,7 @@ exports[`Storyshots Core/Table With Checkboxes 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-kTLmzF eezwuu"
+                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-dwsnSq hZFOwY"
                     data-field="first_seen"
                     type="button"
                   >
@@ -1767,7 +1767,7 @@ exports[`Storyshots Core/Table With Checkboxes 1`] = `
                 data-highlight="true"
               >
                 <div
-                  class="sc-iFMAIt bKXgtf"
+                  class="sc-iqVWFU cmiHhz"
                   data-display="table-cell"
                 >
                   <div
@@ -1834,7 +1834,7 @@ exports[`Storyshots Core/Table With Checkboxes 1`] = `
                 data-highlight="true"
               >
                 <div
-                  class="sc-iFMAIt bKXgtf"
+                  class="sc-iqVWFU cmiHhz"
                   data-display="table-cell"
                 >
                   <div
@@ -1901,7 +1901,7 @@ exports[`Storyshots Core/Table With Checkboxes 1`] = `
                 data-highlight="true"
               >
                 <div
-                  class="sc-iFMAIt bKXgtf"
+                  class="sc-iqVWFU cmiHhz"
                   data-display="table-cell"
                 >
                   <div
@@ -1968,7 +1968,7 @@ exports[`Storyshots Core/Table With Checkboxes 1`] = `
                 data-highlight="false"
               >
                 <div
-                  class="sc-iFMAIt bKXgtf"
+                  class="sc-iqVWFU cmiHhz"
                   data-display="table-cell"
                 >
                   <div
@@ -2023,7 +2023,7 @@ exports[`Storyshots Core/Table With Checkboxes 1`] = `
                 data-highlight="false"
               >
                 <div
-                  class="sc-iFMAIt bKXgtf"
+                  class="sc-iqVWFU cmiHhz"
                   data-display="table-cell"
                 >
                   <div
@@ -2086,7 +2086,7 @@ exports[`Storyshots Core/Table With Checkboxes 1`] = `
                 data-highlight="false"
               >
                 <div
-                  class="sc-iFMAIt bKXgtf"
+                  class="sc-iqVWFU cmiHhz"
                   data-display="table-cell"
                 >
                   <div
@@ -2149,7 +2149,7 @@ exports[`Storyshots Core/Table With Checkboxes 1`] = `
                 data-highlight="false"
               >
                 <div
-                  class="sc-iFMAIt bKXgtf"
+                  class="sc-iqVWFU cmiHhz"
                   data-display="table-cell"
                 >
                   <div
@@ -2212,7 +2212,7 @@ exports[`Storyshots Core/Table With Checkboxes 1`] = `
                 data-highlight="false"
               >
                 <div
-                  class="sc-iFMAIt bKXgtf"
+                  class="sc-iqVWFU cmiHhz"
                   data-display="table-cell"
                 >
                   <div
@@ -2267,7 +2267,7 @@ exports[`Storyshots Core/Table With Checkboxes 1`] = `
                 data-highlight="false"
               >
                 <div
-                  class="sc-iFMAIt bKXgtf"
+                  class="sc-iqVWFU cmiHhz"
                   data-display="table-cell"
                 >
                   <div
@@ -2322,7 +2322,7 @@ exports[`Storyshots Core/Table With Checkboxes 1`] = `
                 data-highlight="false"
               >
                 <div
-                  class="sc-iFMAIt bKXgtf"
+                  class="sc-iqVWFU cmiHhz"
                   data-display="table-cell"
                 >
                   <div
@@ -2377,7 +2377,7 @@ exports[`Storyshots Core/Table With Checkboxes 1`] = `
                 data-highlight="false"
               >
                 <div
-                  class="sc-iFMAIt bKXgtf"
+                  class="sc-iqVWFU cmiHhz"
                   data-display="table-cell"
                 >
                   <div
@@ -2438,19 +2438,19 @@ exports[`Storyshots Core/Table With Checkboxes 1`] = `
 exports[`Storyshots Core/Table With Conditional Row Classes 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
-      class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-fyrocj dljPk jxvgud"
+      class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-iWVNaa dljPk YIrmE"
     >
       <div
         class="sc-gKclnd iQIogj sc-iCfMLu frGhDt sc-hGPBjI kBwkZQ"
       >
         <div
-          class="sc-iqVWFU hIAseQ"
+          class="sc-eWfVMQ gmreIg"
         >
           <div
-            class="sc-eWfVMQ kmJZgg sc-jKTccl fWCWlF"
+            class="sc-kTLmzF kNwxgk sc-bUbRBg hsvIRe"
           >
             <div
               data-display="table-head"
@@ -2462,7 +2462,7 @@ exports[`Storyshots Core/Table With Conditional Row Classes 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-kTLmzF eezwuu"
+                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-dwsnSq hZFOwY"
                     data-field="Name"
                     type="button"
                   >
@@ -2490,7 +2490,7 @@ exports[`Storyshots Core/Table With Conditional Row Classes 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-kTLmzF eezwuu"
+                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-dwsnSq hZFOwY"
                     data-field="pokedex_number"
                     type="button"
                   >
@@ -2518,7 +2518,7 @@ exports[`Storyshots Core/Table With Conditional Row Classes 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-kTLmzF eezwuu"
+                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-dwsnSq hZFOwY"
                     data-field="Category"
                     type="button"
                   >
@@ -2546,7 +2546,7 @@ exports[`Storyshots Core/Table With Conditional Row Classes 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-kTLmzF eezwuu"
+                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-dwsnSq hZFOwY"
                     data-field="first_seen"
                     type="button"
                   >
@@ -2941,19 +2941,19 @@ exports[`Storyshots Core/Table With Conditional Row Classes 1`] = `
 exports[`Storyshots Core/Table With Custom Columns 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
-      class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-fyrocj dljPk jxvgud"
+      class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-iWVNaa dljPk YIrmE"
     >
       <div
         class="sc-gKclnd iQIogj sc-iCfMLu frGhDt sc-hGPBjI kBwkZQ"
       >
         <div
-          class="sc-iqVWFU hIAseQ"
+          class="sc-eWfVMQ gmreIg"
         >
           <div
-            class="sc-eWfVMQ kmJZgg sc-jKTccl jBYHQx"
+            class="sc-kTLmzF kNwxgk sc-bUbRBg hEZFOe"
           >
             <div
               data-display="table-head"
@@ -2965,7 +2965,7 @@ exports[`Storyshots Core/Table With Custom Columns 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-kTLmzF eezwuu"
+                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-dwsnSq hZFOwY"
                     data-field="Name"
                     type="button"
                   >
@@ -2993,7 +2993,7 @@ exports[`Storyshots Core/Table With Custom Columns 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-kTLmzF eezwuu"
+                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-dwsnSq hZFOwY"
                     data-field="pokedex_number"
                     type="button"
                   >
@@ -3021,7 +3021,7 @@ exports[`Storyshots Core/Table With Custom Columns 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-kTLmzF eezwuu"
+                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-dwsnSq hZFOwY"
                     data-field="Category"
                     type="button"
                   >
@@ -3049,7 +3049,7 @@ exports[`Storyshots Core/Table With Custom Columns 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-kTLmzF eezwuu"
+                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-dwsnSq hZFOwY"
                     data-field="first_seen"
                     type="button"
                   >
@@ -3437,7 +3437,7 @@ exports[`Storyshots Core/Table With Custom Columns 1`] = `
         </div>
       </div>
       <div
-        class="sc-iWVNaa ibsBWj"
+        class="sc-jKTccl fizxqw"
       >
         <div
           class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-jOxtWs iRYYIV sc-bTfYFJ isjOxD"
@@ -3454,7 +3454,7 @@ exports[`Storyshots Core/Table With Custom Columns 1`] = `
               >
                 <svg
                   aria-hidden="true"
-                  class="svg-inline--fa fa-cog fa-w-16 sc-dwsnSq eHVipD"
+                  class="svg-inline--fa fa-cog fa-w-16 sc-jtXEFf jMRJqw"
                   data-icon="cog"
                   data-prefix="fas"
                   focusable="false"
@@ -3495,19 +3495,19 @@ exports[`Storyshots Core/Table With Custom Columns 1`] = `
 exports[`Storyshots Core/Table With Highlighted Rows 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
-      class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-fyrocj dljPk jxvgud"
+      class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-iWVNaa dljPk YIrmE"
     >
       <div
         class="sc-gKclnd iQIogj sc-iCfMLu frGhDt sc-hGPBjI kBwkZQ"
       >
         <div
-          class="sc-iqVWFU hIAseQ"
+          class="sc-eWfVMQ gmreIg"
         >
           <div
-            class="sc-eWfVMQ kmJZgg sc-jKTccl fWCWlF"
+            class="sc-kTLmzF kNwxgk sc-bUbRBg hsvIRe"
           >
             <div
               data-display="table-head"
@@ -3519,7 +3519,7 @@ exports[`Storyshots Core/Table With Highlighted Rows 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-kTLmzF eezwuu"
+                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-dwsnSq hZFOwY"
                     data-field="Name"
                     type="button"
                   >
@@ -3547,7 +3547,7 @@ exports[`Storyshots Core/Table With Highlighted Rows 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-kTLmzF eezwuu"
+                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-dwsnSq hZFOwY"
                     data-field="pokedex_number"
                     type="button"
                   >
@@ -3575,7 +3575,7 @@ exports[`Storyshots Core/Table With Highlighted Rows 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-kTLmzF eezwuu"
+                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-dwsnSq hZFOwY"
                     data-field="Category"
                     type="button"
                   >
@@ -3603,7 +3603,7 @@ exports[`Storyshots Core/Table With Highlighted Rows 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-kTLmzF eezwuu"
+                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-dwsnSq hZFOwY"
                     data-field="first_seen"
                     type="button"
                   >
@@ -3998,10 +3998,10 @@ exports[`Storyshots Core/Table With Highlighted Rows 1`] = `
 exports[`Storyshots Core/Table With Pager 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
-      class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-fyrocj dljPk jxvgud"
+      class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-iWVNaa dljPk YIrmE"
     >
       <div
         class="sc-gKclnd iQIogj sc-iCfMLu frGhDt sc-hGPBjI kBwkZQ"
@@ -4074,10 +4074,10 @@ exports[`Storyshots Core/Table With Pager 1`] = `
           </div>
         </div>
         <div
-          class="sc-iqVWFU hIAseQ"
+          class="sc-eWfVMQ gmreIg"
         >
           <div
-            class="sc-eWfVMQ kmJZgg sc-jKTccl fWCWlF"
+            class="sc-kTLmzF kNwxgk sc-bUbRBg hsvIRe"
           >
             <div
               data-display="table-head"
@@ -4089,7 +4089,7 @@ exports[`Storyshots Core/Table With Pager 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-kTLmzF eezwuu"
+                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-dwsnSq hZFOwY"
                     data-field="Name"
                     type="button"
                   >
@@ -4117,7 +4117,7 @@ exports[`Storyshots Core/Table With Pager 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-kTLmzF eezwuu"
+                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-dwsnSq hZFOwY"
                     data-field="pokedex_number"
                     type="button"
                   >
@@ -4145,7 +4145,7 @@ exports[`Storyshots Core/Table With Pager 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-kTLmzF eezwuu"
+                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-dwsnSq hZFOwY"
                     data-field="Category"
                     type="button"
                   >
@@ -4173,7 +4173,7 @@ exports[`Storyshots Core/Table With Pager 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-kTLmzF eezwuu"
+                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-dwsnSq hZFOwY"
                     data-field="first_seen"
                     type="button"
                   >
@@ -4371,19 +4371,19 @@ exports[`Storyshots Core/Table With Pager 1`] = `
 exports[`Storyshots Core/Table With Prefix 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
-      class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-fyrocj dljPk jxvgud"
+      class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-iWVNaa dljPk YIrmE"
     >
       <div
         class="sc-gKclnd iQIogj sc-iCfMLu frGhDt sc-hGPBjI kBwkZQ"
       >
         <div
-          class="sc-iqVWFU hIAseQ"
+          class="sc-eWfVMQ gmreIg"
         >
           <div
-            class="sc-eWfVMQ kmJZgg sc-jKTccl fWCWlF"
+            class="sc-kTLmzF kNwxgk sc-bUbRBg hsvIRe"
           >
             <div
               data-display="table-head"
@@ -4395,7 +4395,7 @@ exports[`Storyshots Core/Table With Prefix 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-kTLmzF eezwuu"
+                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-dwsnSq hZFOwY"
                     data-field="Name"
                     type="button"
                   >
@@ -4423,7 +4423,7 @@ exports[`Storyshots Core/Table With Prefix 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-kTLmzF eezwuu"
+                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-dwsnSq hZFOwY"
                     data-field="pokedex_number"
                     type="button"
                   >
@@ -4451,7 +4451,7 @@ exports[`Storyshots Core/Table With Prefix 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-kTLmzF eezwuu"
+                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-dwsnSq hZFOwY"
                     data-field="Category"
                     type="button"
                   >
@@ -4479,7 +4479,7 @@ exports[`Storyshots Core/Table With Prefix 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-kTLmzF eezwuu"
+                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-dwsnSq hZFOwY"
                     data-field="first_seen"
                     type="button"
                   >
@@ -4896,19 +4896,19 @@ exports[`Storyshots Core/Table With Prefix 1`] = `
 exports[`Storyshots Core/Table With Row Click 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
-      class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-fyrocj dljPk jxvgud"
+      class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-iWVNaa dljPk YIrmE"
     >
       <div
         class="sc-gKclnd iQIogj sc-iCfMLu frGhDt sc-hGPBjI kBwkZQ"
       >
         <div
-          class="sc-iqVWFU hIAseQ"
+          class="sc-eWfVMQ gmreIg"
         >
           <div
-            class="sc-eWfVMQ jIMImu sc-jKTccl fWCWlF"
+            class="sc-kTLmzF gNkruy sc-bUbRBg hsvIRe"
           >
             <div
               data-display="table-head"
@@ -4920,7 +4920,7 @@ exports[`Storyshots Core/Table With Row Click 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-kTLmzF eezwuu"
+                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-dwsnSq hZFOwY"
                     data-field="Name"
                     type="button"
                   >
@@ -4948,7 +4948,7 @@ exports[`Storyshots Core/Table With Row Click 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-kTLmzF eezwuu"
+                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-dwsnSq hZFOwY"
                     data-field="pokedex_number"
                     type="button"
                   >
@@ -4976,7 +4976,7 @@ exports[`Storyshots Core/Table With Row Click 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-kTLmzF eezwuu"
+                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-dwsnSq hZFOwY"
                     data-field="Category"
                     type="button"
                   >
@@ -5004,7 +5004,7 @@ exports[`Storyshots Core/Table With Row Click 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-kTLmzF eezwuu"
+                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-dwsnSq hZFOwY"
                     data-field="first_seen"
                     type="button"
                   >

--- a/src/components/Tabs/__snapshots__/Tabs.stories.storyshot
+++ b/src/components/Tabs/__snapshots__/Tabs.stories.storyshot
@@ -3,10 +3,10 @@
 exports[`Storyshots Core/Tabs Compact 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hpSXsQ StyledTabs-sc-a4fwxl-2 dhCfhN sc-hYQoXb ityjhj sc-hJZKUC cnvZUb"
+      class="StyledBox-sc-13pk1d4-0 hpSXsQ StyledTabs-sc-a4fwxl-2 dhCfhN sc-hJZKUC egvftP sc-ewSTlh fLwsxr"
       role="tablist"
     >
       <div
@@ -134,10 +134,10 @@ exports[`Storyshots Core/Tabs Compact 1`] = `
 exports[`Storyshots Core/Tabs Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hpSXsQ StyledTabs-sc-a4fwxl-2 dhCfhN sc-hYQoXb jNUPAa sc-hJZKUC cnvZUb"
+      class="StyledBox-sc-13pk1d4-0 hpSXsQ StyledTabs-sc-a4fwxl-2 dhCfhN sc-hJZKUC iBYnhm sc-ewSTlh fLwsxr"
       role="tablist"
     >
       <div
@@ -214,10 +214,10 @@ exports[`Storyshots Core/Tabs Default 1`] = `
 exports[`Storyshots Core/Tabs With Long Titles 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hpSXsQ StyledTabs-sc-a4fwxl-2 dhCfhN sc-hYQoXb jNUPAa sc-hJZKUC cnvZUb"
+      class="StyledBox-sc-13pk1d4-0 hpSXsQ StyledTabs-sc-a4fwxl-2 dhCfhN sc-hJZKUC iBYnhm sc-ewSTlh fLwsxr"
       role="tablist"
     >
       <div

--- a/src/components/Tag/__snapshots__/Tag.stories.storyshot
+++ b/src/components/Tag/__snapshots__/Tag.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/Tag Clickable 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI dljPk sc-Galmp bbmiOB"
@@ -35,7 +35,7 @@ exports[`Storyshots Core/Tag Clickable 1`] = `
 exports[`Storyshots Core/Tag Closable 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI dljPk sc-Galmp bbmiOB"
@@ -82,7 +82,7 @@ exports[`Storyshots Core/Tag Closable 1`] = `
 exports[`Storyshots Core/Tag Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI dljPk sc-Galmp bbmiOB"
@@ -109,7 +109,7 @@ exports[`Storyshots Core/Tag Default 1`] = `
 exports[`Storyshots Core/Tag Empty 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI dljPk sc-Galmp bbmiOB"
@@ -131,7 +131,7 @@ exports[`Storyshots Core/Tag Empty 1`] = `
 exports[`Storyshots Core/Tag Multiple Values 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI dljPk sc-Galmp bbmiOB"
@@ -173,7 +173,7 @@ exports[`Storyshots Core/Tag Multiple Values 1`] = `
 exports[`Storyshots Core/Tag Only Name 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI dljPk sc-Galmp bbmiOB"
@@ -195,7 +195,7 @@ exports[`Storyshots Core/Tag Only Name 1`] = `
 exports[`Storyshots Core/Tag Only Value 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI dljPk sc-Galmp bbmiOB"
@@ -217,7 +217,7 @@ exports[`Storyshots Core/Tag Only Value 1`] = `
 exports[`Storyshots Core/Tag Overflow 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI dljPk sc-Galmp bbmiOB"

--- a/src/components/TagManagementModal/__snapshots__/TagManagementModal.stories.storyshot
+++ b/src/components/TagManagementModal/__snapshots__/TagManagementModal.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/TagManagementModal Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <button
       class="StyledButton-sc-323bzc-0 cLGAaT sc-bqiRlB sc-ksdxgE edofBN gWXKEC sc-dJjYzT cGuTUx"

--- a/src/components/Terminal/__snapshots__/Terminal.stories.storyshot
+++ b/src/components/Terminal/__snapshots__/Terminal.stories.storyshot
@@ -3,16 +3,16 @@
 exports[`Storyshots Core/Terminal Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       style="height: 500px;"
     >
       <div
-        class="sc-gKclnd iQIogj sc-iCfMLu kHEsbk sc-hGPBjI sc-tAExr dljPk hmJAJR"
+        class="sc-gKclnd iQIogj sc-iCfMLu kHEsbk sc-hGPBjI sc-dSfdvi dljPk gGSnrt"
       >
         <div
-          class="sc-gKclnd iQIogj sc-iCfMLu jciJBO sc-hGPBjI sc-dSfdvi kBwkZQ bSHcyo"
+          class="sc-gKclnd iQIogj sc-iCfMLu jciJBO sc-hGPBjI sc-hZpJaK kBwkZQ eooaHY"
         />
       </div>
     </div>
@@ -23,16 +23,16 @@ exports[`Storyshots Core/Terminal Default 1`] = `
 exports[`Storyshots Core/Terminal Noninteractive Terminal 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       style="height: 500px;"
     >
       <div
-        class="sc-gKclnd iQIogj sc-iCfMLu kHEsbk sc-hGPBjI sc-tAExr dljPk hmJAJR"
+        class="sc-gKclnd iQIogj sc-iCfMLu kHEsbk sc-hGPBjI sc-dSfdvi dljPk gGSnrt"
       >
         <div
-          class="sc-gKclnd iQIogj sc-iCfMLu jciJBO sc-hGPBjI sc-dSfdvi kBwkZQ bSHcyo"
+          class="sc-gKclnd iQIogj sc-iCfMLu jciJBO sc-hGPBjI sc-hZpJaK kBwkZQ eooaHY"
         />
       </div>
     </div>

--- a/src/components/TextWithCopy/__snapshots__/TextWithCopy.stories.storyshot
+++ b/src/components/TextWithCopy/__snapshots__/TextWithCopy.stories.storyshot
@@ -3,21 +3,21 @@
 exports[`Storyshots Core/TextWithCopy Always Show 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <span
-      class="sc-fKVqWL hOcWtv sc-iwjdpV iXrUAY sc-hZpJaK djDbBF"
+      class="sc-fKVqWL hOcWtv sc-iwjdpV iXrUAY sc-cHzqoD bBDeUQ"
     >
       <span
-        class="sc-cHzqoD cBlKfa"
+        class="sc-JkixQ dLBRgg"
       >
         Click the icon
       </span>
       <span
-        class="sc-gGPzkF fxnEtP"
+        class="sc-dkQkyq brNuSp"
       >
         <div
-          class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-JkixQ gfDyTp"
+          class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-gGPzkF jGlSeL"
         >
           <svg
             aria-hidden="true"
@@ -44,10 +44,10 @@ exports[`Storyshots Core/TextWithCopy Always Show 1`] = `
 exports[`Storyshots Core/TextWithCopy Code 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <span
-      class="sc-fKVqWL hOcWtv sc-iwjdpV iXrUAY sc-hZpJaK djDbBF"
+      class="sc-fKVqWL hOcWtv sc-iwjdpV iXrUAY sc-cHzqoD bBDeUQ"
       title="This value has been copied to your clipboard!"
     >
       <code
@@ -56,10 +56,10 @@ exports[`Storyshots Core/TextWithCopy Code 1`] = `
         3555432
       </code>
       <span
-        class="sc-gGPzkF fxnEtP"
+        class="sc-dkQkyq brNuSp"
       >
         <div
-          class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-JkixQ jvhfll"
+          class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-gGPzkF ecWwir"
         >
           <svg
             aria-hidden="true"
@@ -86,14 +86,14 @@ exports[`Storyshots Core/TextWithCopy Code 1`] = `
 exports[`Storyshots Core/TextWithCopy Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <span
-      class="sc-fKVqWL hOcWtv sc-iwjdpV iXrUAY sc-hZpJaK djDbBF"
+      class="sc-fKVqWL hOcWtv sc-iwjdpV iXrUAY sc-cHzqoD bBDeUQ"
       title="This value has been copied to your clipboard!"
     >
       <span
-        class="sc-cHzqoD cBlKfa"
+        class="sc-JkixQ dLBRgg"
       >
         <i>
           hover
@@ -105,10 +105,10 @@ exports[`Storyshots Core/TextWithCopy Default 1`] = `
          the icon
       </span>
       <span
-        class="sc-gGPzkF fxnEtP"
+        class="sc-dkQkyq brNuSp"
       >
         <div
-          class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-JkixQ jvhfll"
+          class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-gGPzkF ecWwir"
         >
           <svg
             aria-hidden="true"

--- a/src/components/Textarea/__snapshots__/Textarea.stories.storyshot
+++ b/src/components/Textarea/__snapshots__/Textarea.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/Textarea Auto Rows 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <textarea
       class="StyledTextArea-sc-17i3mwp-0 cUKiYJ sc-lbhJGD fBtFQY sc-iNGGcK iIzCpx"
@@ -15,7 +15,7 @@ exports[`Storyshots Core/Textarea Auto Rows 1`] = `
 exports[`Storyshots Core/Textarea Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <textarea
       class="StyledTextArea-sc-17i3mwp-0 cUKiYJ sc-lbhJGD fBtFQY sc-iNGGcK iIzCpx"
@@ -27,7 +27,7 @@ exports[`Storyshots Core/Textarea Default 1`] = `
 exports[`Storyshots Core/Textarea Disabled 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <textarea
       class="StyledTextArea-sc-17i3mwp-0 kLJdsH sc-lbhJGD bBKjjH sc-iNGGcK iIzCpx"
@@ -40,7 +40,7 @@ exports[`Storyshots Core/Textarea Disabled 1`] = `
 exports[`Storyshots Core/Textarea Min Max Rows 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <textarea
       class="StyledTextArea-sc-17i3mwp-0 cUKiYJ sc-lbhJGD fBtFQY sc-iNGGcK iIzCpx"
@@ -53,7 +53,7 @@ exports[`Storyshots Core/Textarea Min Max Rows 1`] = `
 exports[`Storyshots Core/Textarea Monospace 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <textarea
       class="StyledTextArea-sc-17i3mwp-0 cUKiYJ sc-lbhJGD dnDOa-d sc-iNGGcK iIzCpx"
@@ -66,7 +66,7 @@ exports[`Storyshots Core/Textarea Monospace 1`] = `
 exports[`Storyshots Core/Textarea Read Only 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <textarea
       class="StyledTextArea-sc-17i3mwp-0 cUKiYJ sc-lbhJGD fBtFQY sc-iNGGcK iIzCpx"
@@ -79,7 +79,7 @@ exports[`Storyshots Core/Textarea Read Only 1`] = `
 exports[`Storyshots Core/Textarea With Placeholder 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <textarea
       class="StyledTextArea-sc-17i3mwp-0 cUKiYJ sc-lbhJGD fBtFQY sc-iNGGcK iIzCpx"

--- a/src/components/Txt/__snapshots__/Txt.stories.storyshot
+++ b/src/components/Txt/__snapshots__/Txt.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/Txt Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh"
@@ -17,7 +17,7 @@ exports[`Storyshots Core/Txt Default 1`] = `
 exports[`Storyshots Core/Txt In Color 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-fKVqWL hOcWtv sc-bBHxTw iKlBqn"
@@ -31,7 +31,7 @@ exports[`Storyshots Core/Txt In Color 1`] = `
 exports[`Storyshots Core/Txt Span Component 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <span
       class="sc-fKVqWL gNOvvf sc-iwjdpV iXrUAY"
@@ -45,7 +45,7 @@ exports[`Storyshots Core/Txt Span Component 1`] = `
 exports[`Storyshots Core/Txt Styled 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-fKVqWL gPCQRh sc-bBHxTw bFNBkh"

--- a/src/extra/AutoUi/__snapshots__/AutoUi.stories.storyshot
+++ b/src/extra/AutoUi/__snapshots__/AutoUi.stories.storyshot
@@ -3,22 +3,22 @@
 exports[`Storyshots Extra/AutoUICollection Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd exdBHI sc-iCfMLu gALdNb sc-hGPBjI kBwkZQ"
     >
       <div
-        class="sc-jlRLRk fKFzkH sc-cbTzjv bxHvyV"
+        class="sc-dUbtfd kuvLYf sc-hjGZqJ iGsnMG"
       >
         <div
-          class="sc-htJRVC flhMOk"
+          class="sc-cbTzjv lhvXCi"
         >
           <div
             class="sc-gKclnd exdBHI sc-iCfMLu jciJBO"
           >
             <div
-              class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-hgKiOD fReLan dBmNCP"
+              class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-fivaXQ fReLan bsTZts"
             >
               <div
                 class="sc-gKclnd kCaRJe sc-iCfMLu jciJBO"
@@ -148,7 +148,7 @@ exports[`Storyshots Extra/AutoUICollection Default 1`] = `
                 </div>
               </div>
               <div
-                class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-hgKiOD dljPk dBmNCP"
+                class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-fivaXQ dljPk bsTZts"
               />
             </div>
             <div
@@ -160,16 +160,16 @@ exports[`Storyshots Extra/AutoUICollection Default 1`] = `
             </div>
           </div>
           <div
-            class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-fyrocj dljPk jxvgud"
+            class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-iWVNaa dljPk YIrmE"
           >
             <div
               class="sc-gKclnd iQIogj sc-iCfMLu frGhDt sc-hGPBjI kBwkZQ"
             >
               <div
-                class="sc-iqVWFU hIAseQ"
+                class="sc-eWfVMQ gmreIg"
               >
                 <div
-                  class="sc-eWfVMQ jIMImu sc-jKTccl jBYHQx"
+                  class="sc-kTLmzF gNkruy sc-bUbRBg hEZFOe"
                 >
                   <div
                     data-display="table-head"
@@ -181,7 +181,7 @@ exports[`Storyshots Extra/AutoUICollection Default 1`] = `
                         data-display="table-cell"
                       >
                         <button
-                          class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-kTLmzF eezwuu"
+                          class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-dwsnSq hZFOwY"
                           data-field="title"
                           type="button"
                         >
@@ -209,7 +209,7 @@ exports[`Storyshots Extra/AutoUICollection Default 1`] = `
                         data-display="table-cell"
                       >
                         <button
-                          class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-kTLmzF eezwuu"
+                          class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-dwsnSq hZFOwY"
                           data-field="description"
                           type="button"
                         >
@@ -237,7 +237,7 @@ exports[`Storyshots Extra/AutoUICollection Default 1`] = `
                         data-display="table-cell"
                       >
                         <button
-                          class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-kTLmzF eezwuu"
+                          class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-dwsnSq hZFOwY"
                           data-field="public_key"
                           type="button"
                         >
@@ -265,7 +265,7 @@ exports[`Storyshots Extra/AutoUICollection Default 1`] = `
                         data-display="table-cell"
                       >
                         <button
-                          class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-kTLmzF eezwuu"
+                          class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-dwsnSq hZFOwY"
                           data-field="fingerprint"
                           type="button"
                         >
@@ -605,7 +605,7 @@ exports[`Storyshots Extra/AutoUICollection Default 1`] = `
               </div>
             </div>
             <div
-              class="sc-iWVNaa ibsBWj"
+              class="sc-jKTccl fizxqw"
             >
               <div
                 class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-jOxtWs iRYYIV sc-bTfYFJ isjOxD"
@@ -622,7 +622,7 @@ exports[`Storyshots Extra/AutoUICollection Default 1`] = `
                     >
                       <svg
                         aria-hidden="true"
-                        class="svg-inline--fa fa-cog fa-w-16 sc-dwsnSq eHVipD"
+                        class="svg-inline--fa fa-cog fa-w-16 sc-jtXEFf jMRJqw"
                         data-icon="cog"
                         data-prefix="fas"
                         focusable="false"

--- a/src/extra/Markdown/__snapshots__/Markdown.stories.storyshot
+++ b/src/extra/Markdown/__snapshots__/Markdown.stories.storyshot
@@ -3,19 +3,19 @@
 exports[`Storyshots Extra/Markdown Customized 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
-      class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-fyrocj dljPk jxvgud"
+      class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-iWVNaa dljPk YIrmE"
     >
       <div
         class="sc-gKclnd iQIogj sc-iCfMLu frGhDt sc-hGPBjI kBwkZQ"
       >
         <div
-          class="sc-iqVWFU hIAseQ"
+          class="sc-eWfVMQ gmreIg"
         >
           <div
-            class="sc-eWfVMQ kmJZgg sc-jKTccl fWCWlF"
+            class="sc-kTLmzF kNwxgk sc-bUbRBg hsvIRe"
           >
             <div
               data-display="table-head"
@@ -76,7 +76,7 @@ exports[`Storyshots Extra/Markdown Customized 1`] = `
                         class="sc-gKclnd exdBHI sc-iCfMLu gHPssH"
                       >
                         <div
-                          class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh sc-jYmNlR kVdGQG"
+                          class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh sc-bxDdli debCz"
                         >
                           <div>
                             <h1
@@ -113,7 +113,7 @@ exports[`Storyshots Extra/Markdown Customized 1`] = `
                         class="sc-gKclnd exdBHI sc-iCfMLu gHPssH"
                       >
                         <div
-                          class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh sc-jYmNlR kVdGQG"
+                          class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh sc-bxDdli debCz"
                         >
                           <div>
                             A title
@@ -167,7 +167,7 @@ exports[`Storyshots Extra/Markdown Customized 1`] = `
                         class="sc-gKclnd exdBHI sc-iCfMLu gHPssH"
                       >
                         <div
-                          class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh sc-jYmNlR kVdGQG"
+                          class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh sc-bxDdli debCz"
                         >
                           <div>
                             <h1
@@ -204,7 +204,7 @@ exports[`Storyshots Extra/Markdown Customized 1`] = `
                         class="sc-gKclnd exdBHI sc-iCfMLu gHPssH"
                       >
                         <div
-                          class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh sc-jYmNlR kVdGQG"
+                          class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh sc-bxDdli debCz"
                         >
                           <div>
                             A title
@@ -252,7 +252,7 @@ exports[`Storyshots Extra/Markdown Customized 1`] = `
                         class="sc-gKclnd exdBHI sc-iCfMLu gHPssH"
                       >
                         <div
-                          class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh sc-jYmNlR kVdGQG"
+                          class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh sc-bxDdli debCz"
                         >
                           <div>
                             <h1
@@ -289,7 +289,7 @@ exports[`Storyshots Extra/Markdown Customized 1`] = `
                         class="sc-gKclnd exdBHI sc-iCfMLu gHPssH"
                       >
                         <div
-                          class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh sc-jYmNlR kVdGQG"
+                          class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh sc-bxDdli debCz"
                         >
                           <div>
                             <h1
@@ -317,10 +317,10 @@ exports[`Storyshots Extra/Markdown Customized 1`] = `
 exports[`Storyshots Extra/Markdown Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
-      class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh sc-jYmNlR kVdGQG"
+      class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh sc-bxDdli debCz"
     >
       <div>
         <h1
@@ -1123,10 +1123,10 @@ const foo = () =&gt; {
 exports[`Storyshots Extra/Markdown With Decorators 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
-      class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh sc-jYmNlR kVdGQG"
+      class="sc-fKVqWL hOcWtv sc-bBHxTw bFNBkh sc-bxDdli debCz"
     >
       <div>
         <p

--- a/src/extra/MarkdownEditor/__snapshots__/MarkdownEditor.stories.storyshot
+++ b/src/extra/MarkdownEditor/__snapshots__/MarkdownEditor.stories.storyshot
@@ -3,10 +3,10 @@
 exports[`Storyshots Extra/MarkdownEditor Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
-      class="sc-kHdrYz gZnkdE"
+      class="sc-bzPmhk cDgJoI"
       id="simplemde-editor-2-wrapper"
     >
       <textarea

--- a/src/extra/Mermaid/__snapshots__/Mermaid.stories.storyshot
+++ b/src/extra/Mermaid/__snapshots__/Mermaid.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Extra/Mermaid Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-eFegNN gAaKNc"
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fmBCVi dwxdYI"
   >
     <div
       class="sc-gKclnd exdBHI sc-iCfMLu jciJBO"

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,12 @@ export {
 } from './components/HighlightedName';
 export { Input, InputProps } from './components/Input';
 export { Modal, ModalProps } from './components/Modal';
+export {
+	SurroundingOverlay,
+	SurroundingOverlayProps,
+	PartialDomRect,
+	getBoundingContainerRect,
+} from './components/SurroundingOverlay';
 export { Pager, PagerProps } from './components/Pager';
 export { ProgressBar, ProgressBarProps } from './components/ProgressBar';
 export { Provider } from './components/Provider';


### PR DESCRIPTION
Change-type: minor
Signed-off-by: Andrea Rosci <andrear@balena.io>

Add a component that set a layer with opacity around the selected element


<img width="1836" alt="Screenshot 2021-10-26 at 14 59 09" src="https://user-images.githubusercontent.com/7238159/138883977-21c875a6-249e-4135-894f-e499f962f6e1.png">
<img width="1829" alt="Screenshot 2021-10-26 at 14 59 19" src="https://user-images.githubusercontent.com/7238159/138883987-ececcc2a-2bd6-4339-9f18-0621c370d2eb.png">

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have regenerated screenshots for any affected components with `npm run generate-screenshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
