### PR TITLE
Lock grommet to 2.18

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "color-hash": "^1.1.1",
     "copy-to-clipboard": "^3.3.1",
     "date-fns": "^2.24.0",
-    "grommet": "^2.16.3",
+    "grommet": "~2.18.0",
     "hast-util-sanitize": "^3.0.2",
     "json-e": "^4.4.1",
     "lodash": "^4.17.21",


### PR DESCRIPTION
Lock grommet to 2.18

Change-type: patch
Signed-off-by: Matthew Yarmolinsky <matthew-timothy@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have regenerated screenshots for any affected components with `npm run generate-snapshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
