### PR TITLE
Map: Stop preventing loading google fonts, since it breaks click events

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,9 +44,9 @@
   },
   "devDependencies": {
     "@balena/lint": "^6.1.1",
-    "@storybook/addon-actions": "^6.3.12",
-    "@storybook/addon-essentials": "^6.3.12",
-    "@storybook/addon-links": "^6.3.12",
+    "@storybook/addon-actions": "~6.3.12",
+    "@storybook/addon-essentials": "~6.3.12",
+    "@storybook/addon-links": "~6.3.12",
     "@storybook/addon-storyshots": "~6.3.12",
     "@storybook/react": "~6.3.12",
     "@testing-library/jest-dom": "^5.14.1",

--- a/src/components/Map/index.tsx
+++ b/src/components/Map/index.tsx
@@ -144,12 +144,7 @@ const BaseMap = <T extends any>({
 	return (
 		<Box height="100%" className={className}>
 			{apiKey && (
-				<LoadScript
-					googleMapsApiKey={apiKey}
-					version="3"
-					language="en"
-					preventGoogleFontsLoading
-				>
+				<LoadScript googleMapsApiKey={apiKey} version="3" language="en">
 					<GoogleMap
 						mapContainerStyle={{
 							height: '100%',


### PR DESCRIPTION
Change-type: patch
See: https://github.com/JustFly1984/react-google-maps-api/issues/2906
See: https://github.com/balena-io/balena-ui/issues/5202
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>