### PR TITLE
Fix dropdowns with no items not hiding onclick

### DIFF
--- a/src/components/DropDownButton/index.tsx
+++ b/src/components/DropDownButton/index.tsx
@@ -250,6 +250,7 @@ class BaseDropDownButton extends React.Component<
 					<MenuBase
 						dropUp={dropUp}
 						alignRight={alignRight}
+						onClick={() => (!items ? this.toggle() : undefined)}
 						maxHeight={px(this.props.listMaxHeight ?? 300)}
 					>
 						{items
@@ -291,13 +292,7 @@ class BaseDropDownButton extends React.Component<
 										return child;
 									}
 									return (
-										<Item
-											px={3}
-											py={1}
-											onClick={() => null}
-											hasActionFn={false}
-											key={i}
-										>
+										<Item px={3} py={1} hasActionFn={false} key={i}>
 											{child}
 										</Item>
 									);


### PR DESCRIPTION
Fix dropdowns with no items not hiding onclick

FD: https://www.flowdock.com/app/rulemotion/resin-frontend/threads/Vkyrt2aJ7lQe5NeU0PgZPlYW1tM
Change-type: patch
Signed-off-by: Matthew Yarmolinsky <matthew-timothy@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have regenerated screenshots for any affected components with `npm run generate-snapshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
