### PR TITLE
Make getBaseUrl accept full URLs as strings

### DIFF
--- a/src/components/Table/TableRow.tsx
+++ b/src/components/Table/TableRow.tsx
@@ -91,13 +91,22 @@ export class TableRow<T> extends React.PureComponent<TableRowProps<T>, {}> {
 						typeof column.cellAttributes === 'function'
 							? column.cellAttributes(data, get(data, column.field))
 							: column.cellAttributes || {};
+					let url: URL | null;
+					try {
+						url = new URL(href ?? '');
+					} catch (err) {
+						url = null;
+					}
 					return (
 						<a
 							{...attributes}
-							href={href}
 							data-display="table-cell"
+							href={href}
 							data-key={keyAttribute}
-							onClick={this.props.onRowClick}
+							onClick={(props) => {
+								this.props.onRowClick(props);
+							}}
+							target={url ? '_blank' : undefined}
 							{...cellAttributes}
 							key={column.key || (column.field as string)}
 						>

--- a/src/extra/AutoUI/Collection/LensRenderer.tsx
+++ b/src/extra/AutoUI/Collection/LensRenderer.tsx
@@ -181,7 +181,12 @@ export const LensRenderer = <T extends AutoUIBaseResource<T>>({
 			history
 		) {
 			event.preventDefault();
-			history.push?.(autouiContext.getBaseUrl(row));
+			try {
+				const url = new URL(autouiContext.getBaseUrl(row));
+				window.open(url.toString(), '_blank');
+			} catch (err) {
+				history.push?.(autouiContext.getBaseUrl(row));
+			}
 		}
 	};
 

--- a/src/extra/AutoUI/Collection/index.tsx
+++ b/src/extra/AutoUI/Collection/index.tsx
@@ -361,7 +361,12 @@ export const AutoUICollection = <T extends AutoUIBaseResource<T>>({
 							onClick={(e) => {
 								e.preventDefault();
 								if (autouiContext.getBaseUrl && history) {
-									history.push?.(autouiContext.getBaseUrl(entity));
+									try {
+										const url = new URL(autouiContext.getBaseUrl(entity));
+										window.open(url.toString(), '_blank');
+									} catch (err) {
+										history.push?.(autouiContext.getBaseUrl(entity));
+									}
 								}
 							}}
 							hasGetBaseUrl={!!autouiContext.getBaseUrl}


### PR DESCRIPTION
Make getBaseUrl accept full URLs as strings

Change-type: minor
Signed-off-by: Matthew Yarmolinsky <matthew-timothy@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have regenerated screenshots for any affected components with `npm run generate-snapshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
