### PR TITLE
Fix download image modal actions tooltips and clicks

### DIFF
--- a/src/components/DropDownButton/index.tsx
+++ b/src/components/DropDownButton/index.tsx
@@ -6,7 +6,7 @@ import styled from 'styled-components';
 import asRendition from '../../asRendition';
 import { RenditionSystemProps } from '../../common-types';
 import { useBreakpoint } from '../../hooks/useBreakpoint';
-import { px } from '../../utils';
+import { px, stopEvent } from '../../utils';
 import { Box } from '../Box';
 import { Button, ButtonProps } from '../Button';
 import { Divider } from '../Divider';
@@ -211,7 +211,6 @@ class BaseDropDownButton extends React.Component<
 			items,
 			...props
 		} = this.props;
-
 		return (
 			<Wrapper
 				className={className}
@@ -238,6 +237,7 @@ class BaseDropDownButton extends React.Component<
 						<Toggle
 							{...props}
 							outline={outline}
+							onMouseEnter={stopEvent}
 							handler={this.toggle}
 							open={this.state.open}
 							items={items}


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Andrea Rosci <andrear@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have regenerated screenshots for any affected components with `npm run generate-snapshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
