### PR TITLE
Filters: Default to contains instead of is when filtering

### DIFF
--- a/src/components/DataTypes/object.tsx
+++ b/src/components/DataTypes/object.tsx
@@ -22,6 +22,12 @@ const getValueLabel = (schema: JSONSchema) => {
 };
 
 export const operators = {
+	key_contains: {
+		getLabel: (s: JSONSchema) => `${getKeyLabel(s)} contains`,
+	},
+	key_not_contains: {
+		getLabel: (s: JSONSchema) => `${getKeyLabel(s)} does not contain`,
+	},
 	is: {
 		getLabel: (_s: JSONSchema) => 'is',
 	},
@@ -30,12 +36,6 @@ export const operators = {
 	},
 	key_is: {
 		getLabel: (s: JSONSchema) => `${getKeyLabel(s)} is`,
-	},
-	key_contains: {
-		getLabel: (s: JSONSchema) => `${getKeyLabel(s)} contains`,
-	},
-	key_not_contains: {
-		getLabel: (s: JSONSchema) => `${getKeyLabel(s)} does not contain`,
 	},
 	key_matches_re: {
 		getLabel: (s: JSONSchema) => `${getKeyLabel(s)} matches RegEx`,

--- a/src/components/DataTypes/string.tsx
+++ b/src/components/DataTypes/string.tsx
@@ -8,17 +8,17 @@ import { Textarea, TextareaProps } from '../Textarea';
 import { getJsonDescription } from './utils';
 
 export const operators = {
-	is: {
-		getLabel: (_s: JSONSchema) => 'is',
-	},
 	contains: {
 		getLabel: (_s: JSONSchema) => 'contains',
 	},
-	full_text_search: {
-		getLabel: (_s: JSONSchema) => 'full text search',
-	},
 	not_contains: {
 		getLabel: (_s: JSONSchema) => 'does not contain',
+	},
+	is: {
+		getLabel: (_s: JSONSchema) => 'is',
+	},
+	full_text_search: {
+		getLabel: (_s: JSONSchema) => 'full text search',
 	},
 	matches_re: {
 		getLabel: (_s: JSONSchema) => 'matches RegEx',


### PR DESCRIPTION
Filters: Default to contains instead of is when filtering

Resolves: #1483 
Change-type: patch
Signed-off-by: Matthew Yarmolinsky <matthew-timothy@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have regenerated screenshots for any affected components with `npm run generate-snapshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
