### PR TITLE
Fix focus search crashing due to `length` not existing on val

### DIFF
--- a/src/extra/AutoUI/Filters/FocusSearch.tsx
+++ b/src/extra/AutoUI/Filters/FocusSearch.tsx
@@ -64,7 +64,7 @@ export const FocusSearch = <T extends { id: number; [key: string]: any }>({
 		filtered.map((entity) => ({
 			id: entity.id,
 			searchTerms: Object.values(entity).filter(
-				(val) => typeof val === 'number' || val.length > 0,
+				(val) => typeof val === 'number' || val?.length > 0,
 			),
 		})),
 		(entity) => entity.id,


### PR DESCRIPTION
Fix focus search crashing due to `length` not existing on val

Change-type: patch
Signed-off-by: Matthew Yarmolinsky <matthew-timothy@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have regenerated screenshots for any affected components with `npm run generate-snapshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
