### PR TITLE
Stop allowing undefined DropDownButton items

### DIFF
--- a/src/components/DropDownButton/index.tsx
+++ b/src/components/DropDownButton/index.tsx
@@ -306,7 +306,7 @@ class BaseDropDownButton extends React.Component<
 
 export interface InternalDropDownButtonProps extends ButtonProps {
 	/** A 2D array. Each child array contains a group of items. Each child array is separated by Dividers */
-	items?: Array<Array<DropdownOption | undefined>>;
+	items?: DropdownOption[][];
 	/** Optionally provide a JSX element that will be displayed inside the main button */
 	label?: string | JSX.Element;
 	/** If true, place a border between each item in the dropdown */


### PR DESCRIPTION
Stop allowing undefined DropDownButton items

Connects-to: https://github.com/balena-io/balena-ui/tree/stop-allowing-undefined-dropdownbutton-items
FD: https://www.flowdock.com/app/rulemotion/resin-frontend/threads/7zeCbXnadFPFdlM0srXfTzlFeVA
Change-type: patch
Signed-off-by: Matthew Yarmolinsky <matthew-timothy@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have regenerated screenshots for any affected components with `npm run generate-snapshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
