### PR TITLE
DownloadImageModal: Add support for invariant OS releases

### DIFF
--- a/src/unstable-temp/DownloadImageModal/DownloadImageModal.tsx
+++ b/src/unstable-temp/DownloadImageModal/DownloadImageModal.tsx
@@ -6,7 +6,6 @@ import { ApplicationInstructions } from './ApplicationInstructions';
 import { ImageForm, ModalAction } from './ImageForm';
 import isEmpty from 'lodash/isEmpty';
 import noop from 'lodash/noop';
-import find from 'lodash/find';
 import uniq from 'lodash/uniq';
 import {
 	OsVersionsByDeviceType,
@@ -133,6 +132,7 @@ export const UnstableTempDownloadImageModal = ({
 	const { t } = useTranslation();
 	const [deviceType, setDeviceType] = React.useState(initialDeviceType);
 	const [rawVersion, setRawVersion] = React.useState<string | null>(null);
+	const [developmentMode, setDevelopmentMode] = React.useState(false);
 	const [osVersions, setOsVersions] = React.useState<OsVersionsByDeviceType>(
 		initialOsVersions ?? {},
 	);
@@ -207,32 +207,6 @@ export const UnstableTempDownloadImageModal = ({
 		getSupportedOsTypes(application.id, deviceType?.slug).then(setOsTypes);
 	}, [deviceType?.slug, application.id]);
 
-	const templateData = {
-		dockerImage:
-			rawVersion && deviceType
-				? getDockerArtifact(deviceType.slug, stripVersionBuild(rawVersion))
-				: '',
-	};
-
-	const handleSelectedDeviceTypeChange = React.useCallback(
-		(dt: DeviceType) => {
-			if (deviceType?.slug === dt.slug) {
-				return;
-			}
-
-			const selectedDeviceType = find(compatibleDeviceTypes, {
-				slug: dt.slug,
-			});
-
-			if (!selectedDeviceType) {
-				return;
-			}
-
-			setDeviceType(selectedDeviceType);
-		},
-		[compatibleDeviceTypes, deviceType],
-	);
-
 	if (!deviceType) {
 		return null;
 	}
@@ -279,6 +253,7 @@ export const UnstableTempDownloadImageModal = ({
 										releaseId={releaseId}
 										downloadUrl={downloadUrl}
 										rawVersion={rawVersion}
+										developmentMode={developmentMode}
 										modalActions={modalActions}
 										authToken={authToken}
 										{...(downloadConfig && {
@@ -297,10 +272,9 @@ export const UnstableTempDownloadImageModal = ({
 												deviceTypeOsVersions={osVersions}
 												osTypes={osTypes}
 												isInitialDefault={isInitialDefault}
-												onSelectedDeviceTypeChange={
-													handleSelectedDeviceTypeChange
-												}
+												onSelectedDeviceTypeChange={setDeviceType}
 												onSelectedVersionChange={setRawVersion}
+												onSelectedDevelopmentMode={setDevelopmentMode}
 												onSelectedOsTypeChange={setOsType}
 												hasEsrVersions={
 													deviceTypeHasEsr[deviceType.slug] ?? false
@@ -316,8 +290,15 @@ export const UnstableTempDownloadImageModal = ({
 				</Box>
 				<Box flex={1} ml={[0, 0, 0, 3]} mt={[3, 0, 0, 0]}>
 					<ApplicationInstructions
-						templateData={templateData}
 						deviceType={deviceType}
+						templateData={{
+							dockerImage: rawVersion
+								? getDockerArtifact(
+										deviceType.slug,
+										stripVersionBuild(rawVersion),
+								  )
+								: '',
+						}}
 					/>
 				</Box>
 			</Flex>

--- a/src/unstable-temp/DownloadImageModal/DownloadImageModal.tsx
+++ b/src/unstable-temp/DownloadImageModal/DownloadImageModal.tsx
@@ -260,8 +260,15 @@ export const UnstableTempDownloadImageModal = ({
 										modalActions={modalActions}
 										authToken={authToken}
 										{...(downloadConfig && {
-											downloadConfig: (model) =>
-												downloadConfig(deviceType, rawVersion, model),
+											downloadConfig: ({
+												appId,
+												releaseId,
+												deviceType: _deviceTypeSlug,
+												version,
+												...model
+											}) =>
+												// TODO: Change this to be passing the whole model
+												downloadConfig(deviceType, version, model),
 										})}
 										{...(getDownloadSize && {
 											getDownloadSize: async () =>

--- a/src/unstable-temp/DownloadImageModal/DownloadImageModal.tsx
+++ b/src/unstable-temp/DownloadImageModal/DownloadImageModal.tsx
@@ -66,14 +66,17 @@ const getUniqueOsTypes = (
 	return uniq(osVersions[deviceTypeSlug].map((x) => x.osType));
 };
 
-export interface DownloadOptions extends FormModel {
+export interface DownloadOptionsBase {
 	appId: number;
 	releaseId?: number;
 	deviceType: string;
 	provisioningKeyName?: string;
 	downloadConfigOnly?: boolean;
 	version: string;
+	developmentMode?: boolean;
 }
+
+export interface DownloadOptions extends DownloadOptionsBase, FormModel {}
 
 export interface UnstableTempDownloadImageModalProps {
 	application: Application;

--- a/src/unstable-temp/DownloadImageModal/ImageForm.tsx
+++ b/src/unstable-temp/DownloadImageModal/ImageForm.tsx
@@ -12,7 +12,7 @@ import { Txt } from '../../components/Txt';
 
 import { DownloadFormModel, FormModel } from './FormModel';
 import { DeviceType } from './models';
-import { DownloadOptions } from './DownloadImageModal';
+import { DownloadOptions, DownloadOptionsBase } from './DownloadImageModal';
 import { TFunction } from '../../hooks/useTranslation';
 
 const debounceDownloadSize = debounce(
@@ -168,17 +168,24 @@ export const ImageForm = ({
 		actions[0].label,
 	);
 
-	const downloadOptions = React.useMemo(
-		() => ({
+	const downloadOptionsBase = React.useMemo(
+		(): DownloadOptionsBase => ({
 			appId,
 			releaseId,
 			deviceType: deviceType.slug,
-			version: rawVersion,
+			version: rawVersion ?? '',
 			developmentMode,
+		}),
+		[appId, releaseId, deviceType, rawVersion, developmentMode],
+	);
+
+	const downloadOptions = React.useMemo(
+		(): DownloadOptions => ({
+			...downloadOptionsBase,
 			...model,
 		}),
-		[appId, releaseId, deviceType, model, rawVersion, developmentMode],
-	) as DownloadOptions;
+		[downloadOptionsBase, model],
+	);
 
 	const startDownload = (downloadConfigOnly: boolean) => {
 		if (typeof onDownloadStart === 'function') {
@@ -241,17 +248,15 @@ export const ImageForm = ({
 			style={{ display: 'flex', flexDirection: 'column', height: '100%' }}
 			ref={formElement}
 		>
-			<input type="hidden" name="appId" value={appId} />
-			{releaseId && <input type="hidden" name="releaseId" value={releaseId} />}
 			<input type="hidden" name="_token" value={authToken} />
-			<input name="version" value={rawVersion ?? ''} type="hidden" />
-			<input
-				name="developmentMode"
-				value={developmentMode.toString()}
-				type="hidden"
-			/>
-			<input name="deviceType" value={deviceType?.slug} type="hidden" />
 			<input name="fileType" value=".zip" type="hidden" />
+
+			{Object.entries(downloadOptionsBase).map(([key, value]) => {
+				if (value === undefined) {
+					return null;
+				}
+				return <input type="hidden" name={key} key={key} value={`${value}`} />;
+			})}
 
 			{configurationComponent}
 

--- a/src/unstable-temp/DownloadImageModal/ImageForm.tsx
+++ b/src/unstable-temp/DownloadImageModal/ImageForm.tsx
@@ -98,7 +98,7 @@ interface ImageFormProps {
 		downloadOptions: DownloadOptions,
 	) => void;
 	setIsDownloadingConfig: (isDownloading: boolean) => void;
-	downloadConfig?: (model: FormModel) => Promise<void> | undefined;
+	downloadConfig?: (model: DownloadOptions) => Promise<void> | undefined;
 	getDownloadSize?: (
 		slug: string,
 		version: string | null,
@@ -134,6 +134,25 @@ export const ImageForm = ({
 	);
 	const [model, setModel] = React.useState<FormModel>({});
 
+	const downloadOptionsBase = React.useMemo(
+		(): DownloadOptionsBase => ({
+			appId,
+			releaseId,
+			deviceType: deviceType.slug,
+			version: rawVersion ?? '',
+			developmentMode,
+		}),
+		[appId, releaseId, deviceType, rawVersion, developmentMode],
+	);
+
+	const downloadOptions = React.useMemo(
+		(): DownloadOptions => ({
+			...downloadOptionsBase,
+			...model,
+		}),
+		[downloadOptionsBase, model],
+	);
+
 	const actions: ModalAction[] = [
 		...(modalActions ?? []),
 		{
@@ -154,7 +173,7 @@ export const ImageForm = ({
 			onClick: async () => {
 				if (downloadConfigOnly && downloadConfig) {
 					setIsDownloadingConfig(true);
-					await downloadConfig(model);
+					await downloadConfig(downloadOptions);
 					setIsDownloadingConfig(false);
 				}
 				startDownload(true);
@@ -166,25 +185,6 @@ export const ImageForm = ({
 
 	const [selectedActionLabel, setSelectedActionLabel] = React.useState<string>(
 		actions[0].label,
-	);
-
-	const downloadOptionsBase = React.useMemo(
-		(): DownloadOptionsBase => ({
-			appId,
-			releaseId,
-			deviceType: deviceType.slug,
-			version: rawVersion ?? '',
-			developmentMode,
-		}),
-		[appId, releaseId, deviceType, rawVersion, developmentMode],
-	);
-
-	const downloadOptions = React.useMemo(
-		(): DownloadOptions => ({
-			...downloadOptionsBase,
-			...model,
-		}),
-		[downloadOptionsBase, model],
 	);
 
 	const startDownload = (downloadConfigOnly: boolean) => {


### PR DESCRIPTION
Change-type: minor
See: https://www.flowdock.com/app/rulemotion/r-architecture/threads/YN4RClMOz6v6W-VCfoqBaNoliFZ
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have regenerated screenshots for any affected components with `npm run generate-snapshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
