### PR TITLE
Make notification options accept prefix from alert props

### DIFF
--- a/src/components/Notifications/index.tsx
+++ b/src/components/Notifications/index.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import ReactNotification, { store } from 'react-notifications-component';
 import styled from 'styled-components';
 import { animations } from '../../animations';
-import { Alert } from '../Alert';
+import { Alert, AlertProps } from '../Alert';
 import styles from './defaultStyle';
 
 type CONTAINER =
@@ -15,7 +15,7 @@ type CONTAINER =
 
 type NOTIFICATION_TYPE = 'danger' | 'warning' | 'success' | 'info';
 
-export interface NotificationOptions {
+export interface NotificationOptions extends Pick<AlertProps, 'prefix'> {
 	/** The content you wish to display in the notification */
 	content: React.ReactNode;
 	/** A callback function that is triggered when the "dismiss" button is clicked */
@@ -70,19 +70,13 @@ const getTransformedOptions = (
 	}
 };
 
-type NotificationContainerProps = {
-	children: React.ReactNode;
-	type?: NotificationOptions['type'];
-	onDismiss: NotificationOptions['onDismiss'];
-	id: NotificationOptions['id'];
-};
-
 const NotificationContainer = ({
-	children,
+	content,
 	type,
 	onDismiss,
 	id,
-}: NotificationContainerProps) => {
+	...props
+}: NotificationOptions) => {
 	return (
 		<FullWidthContainer
 			emphasized={Boolean(type)}
@@ -96,8 +90,9 @@ const NotificationContainer = ({
 				}
 				store.removeNotification(id);
 			}}
+			{...props}
 		>
-			{children}
+			{content}
 		</FullWidthContainer>
 	);
 };
@@ -161,9 +156,9 @@ export const notifications = {
 					type={transformedOptions.type}
 					onDismiss={transformedOptions.onDismiss}
 					id={transformedOptions.id}
-				>
-					{transformedOptions.content}
-				</NotificationContainer>
+					content={transformedOptions.content}
+					prefix={transformedOptions.prefix}
+				/>
 			),
 		});
 	},


### PR DESCRIPTION
Make notification options accept prefix from alert props

Change-type: minor
Signed-off-by: Matthew Yarmolinsky <matthew-timothy@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have regenerated screenshots for any affected components with `npm run generate-snapshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
