### PR TITLE
Change danger notifications to error notifications

### DIFF
--- a/src/components/Notifications/__snapshots__/Notifications.stories.storyshot
+++ b/src/components/Notifications/__snapshots__/Notifications.stories.storyshot
@@ -814,31 +814,35 @@ exports[`Storyshots Core/Notifications Types 1`] = `
                 class="sc-gKclnd exdBHI sc-iCfMLu bqJAXg sc-hGPBjI sc-dlVxhl dljPk fImdLd sc-llYSUQ FJxnU sc-dSfdvi guToaT"
               >
                 <div
-                  class="sc-fKVqWL hOcWtv sc-bBHxTw hFmZAP"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="svg-inline--fa fa-ban fa-w-16 "
-                    data-icon="ban"
-                    data-prefix="fas"
-                    focusable="false"
-                    role="img"
-                    viewBox="0 0 512 512"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M256 8C119.034 8 8 119.033 8 256s111.034 248 248 248 248-111.034 248-248S392.967 8 256 8zm130.108 117.892c65.448 65.448 70 165.481 20.677 235.637L150.47 105.216c70.204-49.356 170.226-44.735 235.638 20.676zM125.892 386.108c-65.448-65.448-70-165.481-20.677-235.637L361.53 406.784c-70.203 49.356-170.226 44.736-235.638-20.676z"
-                      fill="currentColor"
-                    />
-                  </svg>
-                </div>
-                <div
                   class="sc-gKclnd iQIogj sc-iCfMLu bvZgoS"
                 >
                   <span
                     class="sc-fKVqWL Gjjzu sc-iwjdpV fivJgS"
                   >
-                    Danger!
+                    <span
+                      class="sc-fKVqWL hOcWtv sc-iwjdpV ZRnYE"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="svg-inline--fa fa-ban fa-w-16 "
+                        data-icon="ban"
+                        data-prefix="fas"
+                        focusable="false"
+                        role="img"
+                        viewBox="0 0 512 512"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M256 8C119.034 8 8 119.033 8 256s111.034 248 248 248 248-111.034 248-248S392.967 8 256 8zm130.108 117.892c65.448 65.448 70 165.481 20.677 235.637L150.47 105.216c70.204-49.356 170.226-44.735 235.638 20.676zM125.892 386.108c-65.448-65.448-70-165.481-20.677-235.637L361.53 406.784c-70.203 49.356-170.226 44.736-235.638-20.676z"
+                          fill="currentColor"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      class="sc-fKVqWL hOcWtv sc-iwjdpV iXrUAY"
+                    >
+                      Error!
+                    </span>
                   </span>
                   <span
                     class="sc-fKVqWL hOcWtv sc-iwjdpV mljjg"

--- a/src/components/Notifications/index.tsx
+++ b/src/components/Notifications/index.tsx
@@ -4,6 +4,10 @@ import styled from 'styled-components';
 import { animations } from '../../animations';
 import { Alert, AlertProps } from '../Alert';
 import styles from './defaultStyle';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faBan } from '@fortawesome/free-solid-svg-icons/faBan';
+import { Txt } from '../Txt';
+import theme from '../../theme';
 
 type CONTAINER =
 	| 'top-left'
@@ -75,7 +79,7 @@ const NotificationContainer = ({
 	type,
 	onDismiss,
 	id,
-	...props
+	prefix,
 }: NotificationOptions) => {
 	return (
 		<FullWidthContainer
@@ -90,7 +94,17 @@ const NotificationContainer = ({
 				}
 				store.removeNotification(id);
 			}}
-			{...props}
+			prefix={
+				prefix ??
+				(type === 'danger' ? (
+					<>
+						<Txt.span color={theme.colors.danger.main} mr={2}>
+							<FontAwesomeIcon icon={faBan} />
+						</Txt.span>
+						<Txt.span>Error!</Txt.span>
+					</>
+				) : undefined)
+			}
 		>
 			{content}
 		</FullWidthContainer>


### PR DESCRIPTION
Change danger notifications to error notifications

FD: https://www.flowdock.com/app/rulemotion/resin-frontend/threads/i7dEOqote-5iBI4oktUGgfcrrUF
Change-type: major
Signed-off-by: Matthew Yarmolinsky <matthew-timothy@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have regenerated screenshots for any affected components with `npm run generate-snapshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
