### PR TITLE
DownloadImageModal: Infer the getting started link

### DIFF
--- a/src/unstable-temp/DownloadImageModal/ApplicationInstructions.tsx
+++ b/src/unstable-temp/DownloadImageModal/ApplicationInstructions.tsx
@@ -10,7 +10,7 @@ import { List } from '../../components/List';
 import { Heading } from '../../components/Heading';
 import { useTranslation } from '../../hooks/useTranslation';
 import { DeviceType, DeviceTypeInstructions } from './models';
-import { getGettingStartedLink, interpolateMustache } from './utils';
+import { interpolateMustache } from './utils';
 
 export type OsOptions = ReturnType<typeof getUserOs>;
 
@@ -115,20 +115,18 @@ export const ApplicationInstructions = React.memo(
 
 				<InstructionsList instructions={finalInstructions} />
 
-				{!!deviceType.gettingStartedLink && (
-					<Flex mt={4}>
-						<Txt>
-							For more details please refer to our{' '}
-							<Link
-								blank
-								href={getGettingStartedLink(deviceType, normalizedOs)}
-							>
-								Getting Started Guide
-							</Link>
-							.
-						</Txt>
-					</Flex>
-				)}
+				<Flex mt={4}>
+					<Txt>
+						For more details please refer to our{' '}
+						<Link
+							blank
+							href={`https://www.balena.io/docs/learn/getting-started/${deviceType.slug}/nodejs/`}
+						>
+							Getting Started Guide
+						</Link>
+						.
+					</Txt>
+				</Flex>
 			</Flex>
 		);
 	},

--- a/src/unstable-temp/DownloadImageModal/models.ts
+++ b/src/unstable-temp/DownloadImageModal/models.ts
@@ -84,12 +84,6 @@ export interface DeviceTypeInstructions {
 	osx: string[];
 	windows: string[];
 }
-export interface DeviceTypeGettingStartedLink {
-	linux: string;
-	osx: string;
-	windows: string;
-	[key: string]: string;
-}
 export interface DeviceTypeOptions {
 	options: DeviceTypeOptionsGroup[];
 	collapsed: boolean;
@@ -120,8 +114,6 @@ export interface DeviceType {
 	imageDownloadAlerts?: DeviceTypeDownloadAlert[];
 	/** @deprecated */
 	instructions?: string[] | DeviceTypeInstructions;
-	/** @deprecated */
-	gettingStartedLink?: string | DeviceTypeGettingStartedLink;
 	/** @deprecated */
 	options?: DeviceTypeOptions[];
 	/** @deprecated */

--- a/src/unstable-temp/DownloadImageModal/utils.ts
+++ b/src/unstable-temp/DownloadImageModal/utils.ts
@@ -1,5 +1,5 @@
 import template from 'lodash/template';
-import { DeviceType, OptionalNavigationResource, OsTypesEnum } from './models';
+import { OptionalNavigationResource, OsTypesEnum } from './models';
 import { Dictionary } from '../../common-types';
 
 export const OS_VARIANT_FULL_DISPLAY_TEXT_MAP: Dictionary<string> = {
@@ -18,22 +18,6 @@ export const interpolateMustache = (
 	data: { [key: string]: string },
 	tpl: string,
 ) => template(tpl, { interpolate: /{{([\s\S]+?)}}/g })(data);
-
-export const getGettingStartedLink = (
-	deviceType: DeviceType,
-	preferredOsType: 'linux' | 'osx' | 'windows' = 'windows',
-) => {
-	if (!deviceType || !deviceType.gettingStartedLink) {
-		return '';
-	}
-	if (typeof deviceType.gettingStartedLink === 'string') {
-		return deviceType.gettingStartedLink;
-	}
-	return (
-		deviceType.gettingStartedLink[preferredOsType] ||
-		deviceType.gettingStartedLink['windows']
-	);
-};
 
 export const getOsTypeName = (osTypeSlug: string) => {
 	switch (osTypeSlug) {


### PR DESCRIPTION
Change-type: minor
See: https://jel.ly.fish/improvement-stop-relying-device-types-v1-device-type-json-unrelated-things-4fbac3c
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have regenerated screenshots for any affected components with `npm run generate-snapshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
