### PR TITLE
Fix TableColumnSelector showing an empty group when there are no tags

### DIFF
--- a/src/components/Table/TableColumnSelector.tsx
+++ b/src/components/Table/TableColumnSelector.tsx
@@ -139,8 +139,8 @@ export const TableColumnSelector = function <T extends TableColumnState>(
 	const canAddTagColumn = !failedAddColumnRule;
 	const addTagColumnTitle = failedAddColumnRule && failedAddColumnRule.message;
 
-	const memoizedItems = React.useMemo(
-		(): DropdownOption[][] => [
+	const memoizedItems = React.useMemo(() => {
+		const items: DropdownOption[][] = [
 			columns
 				.filter((col) => !col.locked)
 				.map((col) => ({
@@ -167,25 +167,27 @@ export const TableColumnSelector = function <T extends TableColumnState>(
 						stopEvent(e);
 					},
 				})),
-			!tagKeys
-				? []
-				: [
-						{
-							content: (
-								<Flex alignItems="center">
-									<ItemIcon>
-										<FontAwesomeIcon icon={faPlus} />
-									</ItemIcon>
-									{addTagColumnTitle ?? 'Add Tag Column'}
-								</Flex>
-							),
-							onClick: () => canAddTagColumn && addTagColumn(),
-							disabled: !canAddTagColumn,
-						},
-				  ],
-		],
-		[columns, tagKeys, addTagColumn],
-	);
+		];
+
+		if (tagKeys) {
+			items.push([
+				{
+					content: (
+						<Flex alignItems="center">
+							<ItemIcon>
+								<FontAwesomeIcon icon={faPlus} />
+							</ItemIcon>
+							{addTagColumnTitle ?? 'Add Tag Column'}
+						</Flex>
+					),
+					onClick: () => canAddTagColumn && addTagColumn(),
+					disabled: !canAddTagColumn,
+				},
+			]);
+		}
+
+		return items;
+	}, [columns, tagKeys, addTagColumn]);
 
 	return (
 		<DropDownButton


### PR DESCRIPTION
Fix TableColumnSelector showing an empty group when there are no tags

Change-type: patch
Signed-off-by: Matthew Yarmolinsky <matthew-timothy@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have regenerated screenshots for any affected components with `npm run generate-snapshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
