### PR TITLE
Make lens renderer height fill container

### DIFF
--- a/src/components/Spinner/index.tsx
+++ b/src/components/Spinner/index.tsx
@@ -21,10 +21,6 @@ const CircleLoader = styled.div<Pick<InternalSpinnerProps, 'emphasized'>>`
 	animation-fill-mode: both;
 `;
 
-const Container = styled.div`
-	position: relative;
-`;
-
 const SpinnerContainer = styled(Flex)`
 	position: absolute;
 	top: 0;
@@ -34,7 +30,7 @@ const SpinnerContainer = styled(Flex)`
 	z-index: 4;
 `;
 
-const ChildrenContainer = styled.div<Pick<InternalSpinnerProps, 'show'>>`
+const ChildrenContainer = styled(Flex)<Pick<InternalSpinnerProps, 'show'>>`
 	opacity: ${(props) => (props.show ? 0.4 : 1)};
 	transition: opacity 250ms;
 	z-index: 3;
@@ -79,15 +75,17 @@ const BaseSpinner = ({
 	}
 
 	return (
-		<Container {...otherProps}>
+		<Flex flexDirection="column" {...otherProps}>
 			{show && (
 				<SpinnerContainer justifyContent="center" alignItems="center">
 					<Base label={label} emphasized={emphasized} />
 				</SpinnerContainer>
 			)}
 
-			<ChildrenContainer show={show}>{children}</ChildrenContainer>
-		</Container>
+			<ChildrenContainer flexDirection="column" show={show}>
+				{children}
+			</ChildrenContainer>
+		</Flex>
 	);
 };
 


### PR DESCRIPTION
Make lens renderer height fill container

Change-type: patch
Signed-off-by: Matthew Yarmolinsky <matthew-timothy@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have regenerated screenshots for any affected components with `npm run generate-snapshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
