### PR TITLE
Add missing dependency on react-router

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "react-helmet": "^6.1.0",
     "react-monaco-editor": "^0.45.0",
     "react-notifications-component": "^2.4.1",
+    "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0",
     "react-simplemde-editor": "^4.1.5",
     "regex-parser": "^2.2.11",


### PR DESCRIPTION
AutoUI explicitly imports `react-router` but it's not a dependency
of rendition defined in package.json, instead being implicitly installed
through `react-router-dom`. This can cause a lot of headaches,
especially for downstream libraries using rendition.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

