### PR TITLE
DownloadImageModal: Remove deployArtifact check for hiding instructions

### DIFF
--- a/src/unstable-temp/DownloadImageModal/ApplicationInstructions.tsx
+++ b/src/unstable-temp/DownloadImageModal/ApplicationInstructions.tsx
@@ -71,11 +71,7 @@ export const ApplicationInstructions = React.memo(
 			}
 		}, [currentOs, setCurrentOs, instructions, hasOsSpecificInstructions]);
 
-		if (
-			!deviceType ||
-			!instructions ||
-			deviceType?.yocto?.deployArtifact === 'empty'
-		) {
+		if (!deviceType || !instructions) {
 			return <Txt>{t('no_data.no_instructions_found')}</Txt>;
 		}
 


### PR DESCRIPTION
We will now surface them whenver they exist.
The deployArtifact was 'empty' only for DTs
that didn't have instructions anyway.

Change-type: patch
See: https://jel.ly.fish/improvement-stop-relying-device-types-v1-device-type-json-unrelated-things-4fbac3c
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

<!-- You can remove tags that do not apply. -->
Connects-to: # <!-- waffle convention to track a PR's status through its connected, open issue -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->
Change-type: major|minor|patch <!-- The change type of this PR -->

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have regenerated screenshots for any affected components with `npm run generate-snapshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
