### PR TITLE
Add `disableAutoHeadingLinking` prop to Markdown

### DIFF
--- a/src/extra/Markdown/index.tsx
+++ b/src/extra/Markdown/index.tsx
@@ -197,6 +197,7 @@ export const getProcessor = (
 	sanitizerOptions?: any,
 	disableRawHtml?: boolean,
 	disableCodeHighlight?: boolean,
+	disableAutoHeadingLinking?: boolean,
 	decorators?: Decorator[] | undefined,
 ) => {
 	let processor = unified()
@@ -208,9 +209,11 @@ export const getProcessor = (
 		processor = processor.use(prism, { ignoreMissing: true });
 	}
 
-	processor = processor.use(slug).use(autoLinkHeadings, {
-		properties: { className: 'heading-anchor-link' },
-	});
+	if (!disableAutoHeadingLinking) {
+		processor = processor.use(slug).use(autoLinkHeadings, {
+			properties: { className: 'heading-anchor-link' },
+		});
+	}
 
 	if (!disableRawHtml) {
 		processor = processor.use(raw);
@@ -264,6 +267,8 @@ export type MarkdownProps = TxtProps & {
 	disableCodeHighlight?: boolean;
 	/** Decorate part of the text if it matches some condition */
 	decorators?: Decorator[];
+	/** Disable automatic heading linking */
+	disableAutoHeadingLinking?: boolean;
 };
 
 export const MarkdownBase = ({
@@ -273,6 +278,7 @@ export const MarkdownBase = ({
 	disableRawHtml,
 	disableCodeHighlight,
 	decorators,
+	disableAutoHeadingLinking,
 	...rest
 }: MarkdownProps) => {
 	const content = React.useMemo(() => {
@@ -282,6 +288,7 @@ export const MarkdownBase = ({
 				sanitizerOptions,
 				disableRawHtml,
 				disableCodeHighlight,
+				disableAutoHeadingLinking,
 				decorators,
 			).processSync(children) as any
 		).result; // type any because vFile types doesn't contains result, even though it should.
@@ -292,6 +299,7 @@ export const MarkdownBase = ({
 		disableCodeHighlight,
 		decorators,
 		children,
+		disableAutoHeadingLinking,
 	]);
 
 	return <MarkdownWrapper {...rest}>{content}</MarkdownWrapper>;


### PR DESCRIPTION
Add `disableAutoHeadingLinking` prop to Markdown

Change-type: minor
Signed-off-by: Matthew Yarmolinsky <matthew-timothy@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have regenerated screenshots for any affected components with `npm run generate-snapshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
