### PR TITLE
Remove extra gap between AutoUI header and Filters summary, and between Filters summary and the rendered lens

### DIFF
--- a/src/components/Filters/Summary.tsx
+++ b/src/components/Filters/Summary.tsx
@@ -54,7 +54,7 @@ class FilterSummary extends React.Component<
 	public render() {
 		const { scopes } = this.props;
 		return (
-			<Box p={3} mt={3} width="100%" bg="quartenary.light">
+			<Box p={3} width="100%" bg="quartenary.light">
 				{this.state.showForm && (
 					<Modal
 						title="Save current view"

--- a/src/components/Filters/__snapshots__/Filters.stories.storyshot
+++ b/src/components/Filters/__snapshots__/Filters.stories.storyshot
@@ -4814,7 +4814,7 @@ exports[`Storyshots Core/Filters Render Modes 1`] = `
           </div>
         </div>
         <div
-          class="sc-gKclnd exdBHI sc-iCfMLu duYDGb"
+          class="sc-gKclnd exdBHI sc-iCfMLu iQtKll"
         >
           <div
             class="sc-gKclnd exdBHI sc-iCfMLu rflXv sc-hGPBjI kZhRrI"

--- a/src/components/Filters/index.tsx
+++ b/src/components/Filters/index.tsx
@@ -302,7 +302,7 @@ class BaseFilters extends React.Component<FiltersProps, FiltersState> {
 							label="Add filter"
 							compact={this.props.compact}
 							{...this.props.addFilterButtonProps}
-						></Button>
+						/>
 					)}
 
 					{this.shouldRenderComponent('search') && (

--- a/src/extra/AutoUI/__snapshots__/AutoUI.stories.storyshot
+++ b/src/extra/AutoUI/__snapshots__/AutoUI.stories.storyshot
@@ -166,13 +166,6 @@ exports[`Storyshots Extra/AutoUI Default 1`] = `
                   />
                 </div>
               </div>
-              <div
-                class="sc-gKclnd exdBHI sc-iCfMLu kkMeyg sc-cZMNgc gJCjeg"
-              >
-                <div
-                  class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI kZhRrI"
-                />
-              </div>
             </div>
             <div
               class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-gslxeA dljPk jLImRG"

--- a/src/extra/AutoUI/index.tsx
+++ b/src/extra/AutoUI/index.tsx
@@ -350,13 +350,15 @@ export const AutoUI = <T extends AutoUIBaseResource<T>>({
 										</HeaderGrid>
 									)}
 								</HeaderGrid>
-								<Filters
-									renderMode={'summary'}
-									schema={model.schema}
-									filters={filters}
-									autouiContext={autouiContext}
-									changeFilters={setFilters}
-								/>
+								{filters.length > 0 && (
+									<Filters
+										renderMode={'summary'}
+										schema={model.schema}
+										filters={filters}
+										autouiContext={autouiContext}
+										changeFilters={setFilters}
+									/>
+								)}
 							</Box>
 							{data.length === 0 && (
 								<NoRecordsFoundArrow>


### PR DESCRIPTION
Remove extra gap between AutoUI header and Filters summary, and between Filters summary and the rendered lens

Resolves: https://github.com/balena-io/balena-ui/issues/4900
Change-type: patch
Signed-off-by: Matthew Yarmolinsky <matthew-timothy@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have regenerated screenshots for any affected components with `npm run generate-snapshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
