### PR TITLE
Add `secondaryIcon` prop to Breadcrumbs component

### DIFF
--- a/src/components/Breadcrumbs/index.tsx
+++ b/src/components/Breadcrumbs/index.tsx
@@ -25,6 +25,7 @@ export interface Crumb {
 	href?: string;
 	icon?: React.ReactNode;
 	onClick?: (event: React.MouseEvent) => void;
+	secondaryIcon?: React.ReactNode;
 }
 
 export interface BreadcrumbsProps {
@@ -35,7 +36,11 @@ export interface BreadcrumbsProps {
 }
 
 const BreadcrumbContent = React.memo(
-	({ icon, text }: Pick<Crumb, 'icon' | 'text'>) => {
+	({
+		icon,
+		text,
+		secondaryIcon,
+	}: Pick<Crumb, 'icon' | 'text' | 'secondaryIcon'>) => {
 		const crumbRef = React.useRef<HTMLDivElement>(null);
 		const [shouldShowTooltip, setShouldShowTooltip] = React.useState(false);
 
@@ -60,6 +65,7 @@ const BreadcrumbContent = React.memo(
 				>
 					{text}
 				</Txt>
+				{secondaryIcon && <Flex ml={2}>{secondaryIcon}</Flex>}
 			</Flex>
 		);
 	},
@@ -95,10 +101,15 @@ export const Breadcrumbs = ({ crumbs, emphasized }: BreadcrumbsProps) => {
 												<BreadcrumbContent
 													text={crumb.text}
 													icon={crumb.icon}
+													secondaryIcon={crumb.secondaryIcon}
 												/>
 											</Link>
 										) : (
-											<BreadcrumbContent text={crumb.text} icon={crumb.icon} />
+											<BreadcrumbContent
+												text={crumb.text}
+												icon={crumb.icon}
+												secondaryIcon={crumb.secondaryIcon}
+											/>
 										)}
 									</Flex>
 								</Flex>


### PR DESCRIPTION
Add `secondaryIcon` prop to Breadcrumbs component

Change-type: minor
Signed-off-by: Matthew Yarmolinsky <matthew-timothy@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have regenerated screenshots for any affected components with `npm run generate-snapshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
