### PR TITLE
Fix header for AutoUI collections not having space between buttons when wrapping

### DIFF
--- a/src/components/Filters/__snapshots__/Filters.stories.storyshot
+++ b/src/components/Filters/__snapshots__/Filters.stories.storyshot
@@ -7,10 +7,10 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
   >
     <div>
       <div
-        class="sc-gKclnd exdBHI sc-iCfMLu kkMeyg sc-cZMNgc gJCjeg"
+        class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-cZMNgc gJCjeg"
       >
         <div
-          class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI kZhRrI"
+          class="sc-gKclnd exdBHI sc-iCfMLu kkMeyg sc-hGPBjI kZhRrI"
         >
           <button
             class="StyledButton-sc-323bzc-0 cLGAaT sc-bqiRlB sc-ksdxgE edofBN gWXKEC sc-dJjYzT dofHJV"
@@ -1189,10 +1189,10 @@ exports[`Storyshots Core/Filters Compact 1`] = `
   >
     <div>
       <div
-        class="sc-gKclnd exdBHI sc-iCfMLu kkMeyg sc-cZMNgc gJCjeg"
+        class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-cZMNgc gJCjeg"
       >
         <div
-          class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI kZhRrI"
+          class="sc-gKclnd exdBHI sc-iCfMLu kkMeyg sc-hGPBjI kZhRrI"
         >
           <button
             class="StyledButton-sc-323bzc-0 jXhPZp sc-bqiRlB sc-ksdxgE edofBN gWXKEC sc-dJjYzT bSMRJA"
@@ -2357,10 +2357,10 @@ exports[`Storyshots Core/Filters Default 1`] = `
   >
     <div>
       <div
-        class="sc-gKclnd exdBHI sc-iCfMLu kkMeyg sc-cZMNgc gJCjeg"
+        class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-cZMNgc gJCjeg"
       >
         <div
-          class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI kZhRrI"
+          class="sc-gKclnd exdBHI sc-iCfMLu kkMeyg sc-hGPBjI kZhRrI"
         >
           <button
             class="StyledButton-sc-323bzc-0 cLGAaT sc-bqiRlB sc-ksdxgE edofBN gWXKEC sc-dJjYzT bSMRJA"
@@ -3538,10 +3538,10 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
   >
     <div>
       <div
-        class="sc-gKclnd exdBHI sc-iCfMLu kkMeyg sc-cZMNgc gJCjeg"
+        class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-cZMNgc gJCjeg"
       >
         <div
-          class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI kZhRrI"
+          class="sc-gKclnd exdBHI sc-iCfMLu kkMeyg sc-hGPBjI kZhRrI"
         >
           <button
             class="StyledButton-sc-323bzc-0 hcxFhQ sc-bqiRlB sc-ksdxgE edofBN gWXKEC sc-dJjYzT bSMRJA"
@@ -4723,10 +4723,10 @@ exports[`Storyshots Core/Filters Render Modes 1`] = `
   >
     <div>
       <div
-        class="sc-gKclnd exdBHI sc-iCfMLu kkMeyg sc-cZMNgc gJCjeg"
+        class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-cZMNgc gJCjeg"
       >
         <div
-          class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI kZhRrI"
+          class="sc-gKclnd exdBHI sc-iCfMLu kkMeyg sc-hGPBjI kZhRrI"
         >
           <button
             class="StyledButton-sc-323bzc-0 cLGAaT sc-bqiRlB sc-ksdxgE edofBN gWXKEC sc-dJjYzT bSMRJA"

--- a/src/components/Filters/index.tsx
+++ b/src/components/Filters/index.tsx
@@ -265,9 +265,20 @@ class BaseFilters extends React.Component<FiltersProps, FiltersState> {
 	public render() {
 		const { filters, searchString, showSearchDropDown } = this.state;
 
+		const renderingSummaryAndOtherComponents =
+			this.shouldRenderComponent('summary') &&
+			[
+				this.shouldRenderComponent('add'),
+				this.shouldRenderComponent('search'),
+				this.shouldRenderComponent('views'),
+			].includes(true);
+
 		return (
-			<FilterWrapper mb={3}>
-				<Flex justifyContent="space-between">
+			<FilterWrapper>
+				<Flex
+					justifyContent="space-between"
+					mb={renderingSummaryAndOtherComponents ? 3 : undefined}
+				>
 					{this.shouldRenderComponent('add') && (
 						<Button
 							mr={30}

--- a/src/extra/AutoUI/__snapshots__/AutoUI.stories.storyshot
+++ b/src/extra/AutoUI/__snapshots__/AutoUI.stories.storyshot
@@ -39,72 +39,16 @@ exports[`Storyshots Extra/AutoUI Default 1`] = `
                   order="-1,-1,-1,0"
                 >
                   <div
-                    class="sc-gKclnd exdBHI sc-iCfMLu kkMeyg sc-cZMNgc gJCjeg"
+                    class="sc-gKclnd exdBHI sc-iCfMLu kkMeyg"
                   >
                     <div
-                      class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI kZhRrI"
+                      class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-cZMNgc gJCjeg"
                     >
-                      <button
-                        class="StyledButton-sc-323bzc-0 fovDxF sc-bqiRlB sc-hBUSln edofBN kbjQvu sc-dJjYzT bSMRJA"
-                        type="button"
-                      >
-                        <div
-                          class="StyledBox-sc-13pk1d4-0 hLqWpM"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            class="svg-inline--fa fa-filter "
-                            data-icon="filter"
-                            data-prefix="fas"
-                            focusable="false"
-                            role="img"
-                            viewBox="0 0 512 512"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M3.853 54.87C10.47 40.9 24.54 32 40 32H472C487.5 32 501.5 40.9 508.1 54.87C514.8 68.84 512.7 85.37 502.1 97.33L320 320.9V448C320 460.1 313.2 471.2 302.3 476.6C291.5 482 278.5 480.9 268.8 473.6L204.8 425.6C196.7 419.6 192 410.1 192 400V320.9L9.042 97.33C-.745 85.37-2.765 68.84 3.854 54.87L3.853 54.87z"
-                              fill="currentColor"
-                            />
-                          </svg>
-                          <div
-                            class="StyledBox__StyledBoxGap-sc-13pk1d4-1 hDcxXI"
-                          />
-                          Add filter
-                        </div>
-                      </button>
                       <div
-                        class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-dtMgUX lllbMy"
-                      >
-                        <div
-                          class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-khQegj dljPk dJsfTS sc-hUpaCq igPhtM"
-                        >
-                          <input
-                            placeholder="Search entries..."
-                            value=""
-                          />
-                          <svg
-                            aria-hidden="true"
-                            class="svg-inline--fa fa-magnifying-glass search-icon"
-                            data-icon="magnifying-glass"
-                            data-prefix="fas"
-                            focusable="false"
-                            role="img"
-                            viewBox="0 0 512 512"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M500.3 443.7l-119.7-119.7c27.22-40.41 40.65-90.9 33.46-144.7C401.8 87.79 326.8 13.32 235.2 1.723C99.01-15.51-15.51 99.01 1.724 235.2c11.6 91.64 86.08 166.7 177.6 178.9c53.8 7.189 104.3-6.236 144.7-33.46l119.7 119.7c15.62 15.62 40.95 15.62 56.57 0C515.9 484.7 515.9 459.3 500.3 443.7zM79.1 208c0-70.58 57.42-128 128-128s128 57.42 128 128c0 70.58-57.42 128-128 128S79.1 278.6 79.1 208z"
-                              fill="currentColor"
-                            />
-                          </svg>
-                        </div>
-                        
-                      </div>
-                      <div
-                        class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-jOxtWs iRYYIV sc-bTfYFJ jQBzNp"
+                        class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI kZhRrI"
                       >
                         <button
-                          class="StyledButton-sc-323bzc-0 jFToxV sc-bqiRlB sc-hBUSln edofBN dlhkLz sc-dJjYzT cGuTUx sc-eLwHnm kxmuUM"
+                          class="StyledButton-sc-323bzc-0 fovDxF sc-bqiRlB sc-hBUSln edofBN kbjQvu sc-dJjYzT bSMRJA"
                           type="button"
                         >
                           <div
@@ -112,48 +56,108 @@ exports[`Storyshots Extra/AutoUI Default 1`] = `
                           >
                             <svg
                               aria-hidden="true"
-                              class="svg-inline--fa fa-chart-pie "
-                              data-icon="chart-pie"
+                              class="svg-inline--fa fa-filter "
+                              data-icon="filter"
                               data-prefix="fas"
                               focusable="false"
                               role="img"
-                              viewBox="0 0 576 512"
+                              viewBox="0 0 512 512"
                               xmlns="http://www.w3.org/2000/svg"
                             >
                               <path
-                                d="M304 16.58C304 7.555 310.1 0 320 0C443.7 0 544 100.3 544 224C544 233 536.4 240 527.4 240H304V16.58zM32 272C32 150.7 122.1 50.34 238.1 34.25C248.2 32.99 256 40.36 256 49.61V288L412.5 444.5C419.2 451.2 418.7 462.2 411 467.7C371.8 495.6 323.8 512 272 512C139.5 512 32 404.6 32 272zM558.4 288C567.6 288 575 295.8 573.8 305C566.1 360.9 539.1 410.6 499.9 447.3C493.9 452.1 484.5 452.5 478.7 446.7L320 288H558.4z"
+                                d="M3.853 54.87C10.47 40.9 24.54 32 40 32H472C487.5 32 501.5 40.9 508.1 54.87C514.8 68.84 512.7 85.37 502.1 97.33L320 320.9V448C320 460.1 313.2 471.2 302.3 476.6C291.5 482 278.5 480.9 268.8 473.6L204.8 425.6C196.7 419.6 192 410.1 192 400V320.9L9.042 97.33C-.745 85.37-2.765 68.84 3.854 54.87L3.853 54.87z"
                                 fill="currentColor"
                               />
                             </svg>
                             <div
                               class="StyledBox__StyledBoxGap-sc-13pk1d4-1 hDcxXI"
                             />
-                            <div
-                              class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI iqksqQ"
+                            Add filter
+                          </div>
+                        </button>
+                        <div
+                          class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-dtMgUX lllbMy"
+                        >
+                          <div
+                            class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-khQegj dljPk dJsfTS sc-hUpaCq igPhtM"
+                          >
+                            <input
+                              placeholder="Search entries..."
+                              value=""
+                            />
+                            <svg
+                              aria-hidden="true"
+                              class="svg-inline--fa fa-magnifying-glass search-icon"
+                              data-icon="magnifying-glass"
+                              data-prefix="fas"
+                              focusable="false"
+                              role="img"
+                              viewBox="0 0 512 512"
+                              xmlns="http://www.w3.org/2000/svg"
                             >
-                              <div
-                                class="sc-gKclnd exdBHI sc-iCfMLu iBCaVk"
-                              >
-                                Views
-                              </div>
+                              <path
+                                d="M500.3 443.7l-119.7-119.7c27.22-40.41 40.65-90.9 33.46-144.7C401.8 87.79 326.8 13.32 235.2 1.723C99.01-15.51-15.51 99.01 1.724 235.2c11.6 91.64 86.08 166.7 177.6 178.9c53.8 7.189 104.3-6.236 144.7-33.46l119.7 119.7c15.62 15.62 40.95 15.62 56.57 0C515.9 484.7 515.9 459.3 500.3 443.7zM79.1 208c0-70.58 57.42-128 128-128s128 57.42 128 128c0 70.58-57.42 128-128 128S79.1 278.6 79.1 208z"
+                                fill="currentColor"
+                              />
+                            </svg>
+                          </div>
+                          
+                        </div>
+                        <div
+                          class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-jOxtWs iRYYIV sc-bTfYFJ jQBzNp"
+                        >
+                          <button
+                            class="StyledButton-sc-323bzc-0 jFToxV sc-bqiRlB sc-hBUSln edofBN dlhkLz sc-dJjYzT cGuTUx sc-eLwHnm kxmuUM"
+                            type="button"
+                          >
+                            <div
+                              class="StyledBox-sc-13pk1d4-0 hLqWpM"
+                            >
                               <svg
                                 aria-hidden="true"
-                                class="svg-inline--fa fa-chevron-down "
-                                data-icon="chevron-down"
+                                class="svg-inline--fa fa-chart-pie "
+                                data-icon="chart-pie"
                                 data-prefix="fas"
                                 focusable="false"
                                 role="img"
-                                viewBox="0 0 448 512"
+                                viewBox="0 0 576 512"
                                 xmlns="http://www.w3.org/2000/svg"
                               >
                                 <path
-                                  d="M224 416c-8.188 0-16.38-3.125-22.62-9.375l-192-192c-12.5-12.5-12.5-32.75 0-45.25s32.75-12.5 45.25 0L224 338.8l169.4-169.4c12.5-12.5 32.75-12.5 45.25 0s12.5 32.75 0 45.25l-192 192C240.4 412.9 232.2 416 224 416z"
+                                  d="M304 16.58C304 7.555 310.1 0 320 0C443.7 0 544 100.3 544 224C544 233 536.4 240 527.4 240H304V16.58zM32 272C32 150.7 122.1 50.34 238.1 34.25C248.2 32.99 256 40.36 256 49.61V288L412.5 444.5C419.2 451.2 418.7 462.2 411 467.7C371.8 495.6 323.8 512 272 512C139.5 512 32 404.6 32 272zM558.4 288C567.6 288 575 295.8 573.8 305C566.1 360.9 539.1 410.6 499.9 447.3C493.9 452.1 484.5 452.5 478.7 446.7L320 288H558.4z"
                                   fill="currentColor"
                                 />
                               </svg>
+                              <div
+                                class="StyledBox__StyledBoxGap-sc-13pk1d4-1 hDcxXI"
+                              />
+                              <div
+                                class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI iqksqQ"
+                              >
+                                <div
+                                  class="sc-gKclnd exdBHI sc-iCfMLu iBCaVk"
+                                >
+                                  Views
+                                </div>
+                                <svg
+                                  aria-hidden="true"
+                                  class="svg-inline--fa fa-chevron-down "
+                                  data-icon="chevron-down"
+                                  data-prefix="fas"
+                                  focusable="false"
+                                  role="img"
+                                  viewBox="0 0 448 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M224 416c-8.188 0-16.38-3.125-22.62-9.375l-192-192c-12.5-12.5-12.5-32.75 0-45.25s32.75-12.5 45.25 0L224 338.8l169.4-169.4c12.5-12.5 32.75-12.5 45.25 0s12.5 32.75 0 45.25l-192 192C240.4 412.9 232.2 416 224 416z"
+                                    fill="currentColor"
+                                  />
+                                </svg>
+                              </div>
                             </div>
-                          </div>
-                        </button>
+                          </button>
+                        </div>
                       </div>
                     </div>
                   </div>

--- a/src/extra/AutoUI/index.tsx
+++ b/src/extra/AutoUI/index.tsx
@@ -299,23 +299,25 @@ export const AutoUI = <T extends AutoUIBaseResource<T>>({
 										flex={['1 0 100%', '1 0 100%', '1 0 100%', 'auto']}
 									>
 										{showFilters && (
-											<Filters
-												schema={model.schema}
-												filters={filters}
-												autouiContext={autouiContext}
-												changeFilters={setFilters}
-												onSearch={(term) => (
-													<FocusSearch
-														searchTerm={term}
-														filtered={filtered}
-														selected={selected}
-														setSelected={setSelected}
-														autouiContext={autouiContext}
-														model={model}
-														hasUpdateActions={hasUpdateActions}
-													/>
-												)}
-											/>
+											<Box mb={3}>
+												<Filters
+													schema={model.schema}
+													filters={filters}
+													autouiContext={autouiContext}
+													changeFilters={setFilters}
+													onSearch={(term) => (
+														<FocusSearch
+															searchTerm={term}
+															filtered={filtered}
+															selected={selected}
+															setSelected={setSelected}
+															autouiContext={autouiContext}
+															model={model}
+															hasUpdateActions={hasUpdateActions}
+														/>
+													)}
+												/>
+											</Box>
 										)}
 									</Box>
 									{data.length > 0 && (


### PR DESCRIPTION
Fix header for AutoUI collections not having space between buttons when wrapping

Change-type: patch
Signed-off-by: Matthew Yarmolinsky <matthew-timothy@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have regenerated screenshots for any affected components with `npm run generate-snapshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
