### PR TITLE
Table: Add fuzzy pager option

### DIFF
--- a/src/components/Pager/Pager.stories.tsx
+++ b/src/components/Pager/Pager.stories.tsx
@@ -29,3 +29,12 @@ export const Default = createStory<PagerProps>(Template, {
 	nextPage: () => null,
 	prevPage: () => null,
 });
+
+export const Fuzzy = createStory<PagerProps>(Template, {
+	totalItems: 200,
+	itemsPerPage: 50,
+	page: 1,
+	nextPage: () => null,
+	prevPage: () => null,
+	fuzzy: true,
+});

--- a/src/components/Pager/__snapshots__/Pager.stories.storyshot
+++ b/src/components/Pager/__snapshots__/Pager.stories.storyshot
@@ -17,9 +17,88 @@ exports[`Storyshots Core/Pager Default 1`] = `
           100
         </strong>
          
-        of 
+        of
+         
         <strong>
           436
+          
+        </strong>
+      </div>
+      <div
+        class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI dljPk"
+      >
+        <div
+          class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-kLwhqv dljPk bzMIBI"
+        >
+          <button
+            class="StyledButton-sc-323bzc-0 gKeRwL sc-bqiRlB sc-hBUSln edofBN dlhkLz sc-dJjYzT cGuTUx rendition-pager__btn--prev"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="svg-inline--fa fa-chevron-left "
+              data-icon="chevron-left"
+              data-prefix="fas"
+              focusable="false"
+              role="img"
+              viewBox="0 0 320 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M224 480c-8.188 0-16.38-3.125-22.62-9.375l-192-192c-12.5-12.5-12.5-32.75 0-45.25l192-192c12.5-12.5 32.75-12.5 45.25 0s12.5 32.75 0 45.25L77.25 256l169.4 169.4c12.5 12.5 12.5 32.75 0 45.25C240.4 476.9 232.2 480 224 480z"
+                fill="currentColor"
+              />
+            </svg>
+          </button>
+          <button
+            class="StyledButton-sc-323bzc-0 gKeRwL sc-bqiRlB sc-hBUSln edofBN dlhkLz sc-dJjYzT cGuTUx rendition-pager__btn--next"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="svg-inline--fa fa-chevron-right "
+              data-icon="chevron-right"
+              data-prefix="fas"
+              focusable="false"
+              role="img"
+              viewBox="0 0 320 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M96 480c-8.188 0-16.38-3.125-22.62-9.375c-12.5-12.5-12.5-32.75 0-45.25L242.8 256L73.38 86.63c-12.5-12.5-12.5-32.75 0-45.25s32.75-12.5 45.25 0l192 192c12.5 12.5 12.5 32.75 0 45.25l-192 192C112.4 476.9 104.2 480 96 480z"
+                fill="currentColor"
+              />
+            </svg>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Core/Pager Fuzzy 1`] = `
+<div>
+  <div
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fXEqDS hyLvgQ"
+  >
+    <div
+      class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI dLlxyS"
+    >
+      <div
+        class="sc-fKVqWL hOcWtv sc-bBHxTw fYiSNr"
+      >
+        <strong>
+          51
+           - 
+          100
+        </strong>
+         
+        of
+         
+        <strong>
+          200
+          +
         </strong>
       </div>
       <div

--- a/src/components/Pager/index.tsx
+++ b/src/components/Pager/index.tsx
@@ -8,6 +8,7 @@ import { Flex, FlexProps } from '../Flex';
 import { Txt } from '../Txt';
 
 const BasePager = ({
+	fuzzy,
 	totalItems,
 	itemsPerPage,
 	page,
@@ -24,7 +25,11 @@ const BasePager = ({
 				<strong>
 					{lowerBound + 1} - {upperBound}
 				</strong>{' '}
-				of <strong>{totalItems}</strong>
+				of{' '}
+				<strong>
+					{totalItems}
+					{fuzzy ? '+' : ''}
+				</strong>
 			</Txt>
 
 			<Flex>
@@ -65,6 +70,8 @@ export interface PagerProps extends FlexProps {
 	nextPage: () => void;
 	/** Callback invoked when the "previous page" button is clicked */
 	prevPage: () => void;
+	/** If true, the total number of items shown will be indicated as being approximate. Useful for when you don't now the full size of your dataset. Only used if `usePager` is true. */
+	fuzzy?: boolean;
 }
 
 /**

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -78,6 +78,14 @@ export const WithPager = createStory<TableProps<any>>(Template, {
 	pagerPosition: 'both',
 });
 
+export const WithFuzzyPager = createStory<TableProps<any>>(Template, {
+	usePager: true,
+	itemsPerPage: 3,
+	pagerPosition: 'both',
+	fuzzyPager: true,
+	data: PokeDex.slice(0, 5),
+});
+
 export const Sorted = createStory<TableProps<any>>(Template, {
 	sort: { field: 'Name', reverse: true },
 });

--- a/src/components/Table/TableBase.tsx
+++ b/src/components/Table/TableBase.tsx
@@ -518,6 +518,7 @@ export class TableBase<T> extends React.Component<
 			getRowHref,
 			getRowClass,
 			className,
+			fuzzyPager,
 		} = this.props;
 
 		const { page, sort } = this.state;
@@ -544,6 +545,7 @@ export class TableBase<T> extends React.Component<
 				{shouldShowPaper &&
 					(_pagerPosition === 'top' || _pagerPosition === 'both') && (
 						<Pager
+							fuzzy={fuzzyPager}
 							totalItems={totalItems}
 							itemsPerPage={_itemsPerPage}
 							page={page}
@@ -655,6 +657,7 @@ export class TableBase<T> extends React.Component<
 				{shouldShowPaper &&
 					(_pagerPosition === 'bottom' || _pagerPosition === 'both') && (
 						<Pager
+							fuzzy={fuzzyPager}
 							totalItems={totalItems}
 							itemsPerPage={_itemsPerPage}
 							page={page}
@@ -708,6 +711,8 @@ export interface TableBaseProps<T> {
 	getRowClass?: (row: T) => string[];
 	/** If true, a pager will be used when displaying items. */
 	usePager?: boolean;
+	/** If true, the total number of items shown on the page will be indicated as being approximate. Useful for when you don't now the full size of your dataset. Only used if `usePager` is true. */
+	fuzzyPager?: boolean;
 	/** The number of items to be shown per page. Only used if `usePager` is true. Defaults to 50. */
 	itemsPerPage?: number;
 	/** Sets whether the pager is displayed at the top of the table, the bottom of the table or in both positions. Only used if `usePager` is true. Defaults to `top`. */

--- a/src/components/Table/__snapshots__/Table.stories.storyshot
+++ b/src/components/Table/__snapshots__/Table.stories.storyshot
@@ -3503,6 +3503,383 @@ exports[`Storyshots Core/Table With Custom Columns 1`] = `
 </div>
 `;
 
+exports[`Storyshots Core/Table With Fuzzy Pager 1`] = `
+<div>
+  <div
+    class="StyledGrommet-sc-19lkkz7-0 hExPlF sc-fXEqDS hyLvgQ"
+  >
+    <div
+      class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-gslxeA dljPk jLImRG"
+    >
+      <div
+        class="sc-gKclnd iQIogj sc-iCfMLu frGhDt sc-hGPBjI kBwkZQ"
+      >
+        <div
+          class="sc-gKclnd exdBHI sc-iCfMLu rflXv sc-hGPBjI dLlxyS"
+        >
+          <div
+            class="sc-fKVqWL hOcWtv sc-bBHxTw fYiSNr"
+          >
+            <strong>
+              1
+               - 
+              3
+            </strong>
+             
+            of
+             
+            <strong>
+              5
+              +
+            </strong>
+          </div>
+          <div
+            class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI dljPk"
+          >
+            <div
+              class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-kLwhqv dljPk bzMIBI"
+            >
+              <button
+                class="StyledButton-sc-323bzc-0 GAqvF sc-bqiRlB sc-hBUSln edofBN dlhkLz sc-dJjYzT cGuTUx rendition-pager__btn--prev"
+                disabled=""
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="svg-inline--fa fa-chevron-left "
+                  data-icon="chevron-left"
+                  data-prefix="fas"
+                  focusable="false"
+                  role="img"
+                  viewBox="0 0 320 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M224 480c-8.188 0-16.38-3.125-22.62-9.375l-192-192c-12.5-12.5-12.5-32.75 0-45.25l192-192c12.5-12.5 32.75-12.5 45.25 0s12.5 32.75 0 45.25L77.25 256l169.4 169.4c12.5 12.5 12.5 32.75 0 45.25C240.4 476.9 232.2 480 224 480z"
+                    fill="currentColor"
+                  />
+                </svg>
+              </button>
+              <button
+                class="StyledButton-sc-323bzc-0 gKeRwL sc-bqiRlB sc-hBUSln edofBN dlhkLz sc-dJjYzT cGuTUx rendition-pager__btn--next"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="svg-inline--fa fa-chevron-right "
+                  data-icon="chevron-right"
+                  data-prefix="fas"
+                  focusable="false"
+                  role="img"
+                  viewBox="0 0 320 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M96 480c-8.188 0-16.38-3.125-22.62-9.375c-12.5-12.5-12.5-32.75 0-45.25L242.8 256L73.38 86.63c-12.5-12.5-12.5-32.75 0-45.25s32.75-12.5 45.25 0l192 192c12.5 12.5 12.5 32.75 0 45.25l-192 192C112.4 476.9 104.2 480 96 480z"
+                    fill="currentColor"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
+        </div>
+        <div
+          class="sc-fmciRz gXrEcX"
+        >
+          <div
+            class="sc-eXlEPa kUkFif sc-kmQMED fTascr"
+          >
+            <div
+              data-display="table-head"
+            >
+              <div
+                data-display="table-row"
+              >
+                <div
+                  data-display="table-cell"
+                >
+                  <button
+                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-iFMAIt jGlqMa"
+                    data-field="Name"
+                    type="button"
+                  >
+                    Name
+                     
+                    <svg
+                      aria-hidden="true"
+                      class="svg-inline--fa fa-sort "
+                      color=""
+                      data-icon="sort"
+                      data-prefix="fas"
+                      focusable="false"
+                      role="img"
+                      viewBox="0 0 320 512"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M27.66 224h264.7c24.6 0 36.89-29.78 19.54-47.12l-132.3-136.8c-5.406-5.406-12.47-8.107-19.53-8.107c-7.055 0-14.09 2.701-19.45 8.107L8.119 176.9C-9.229 194.2 3.055 224 27.66 224zM292.3 288H27.66c-24.6 0-36.89 29.77-19.54 47.12l132.5 136.8C145.9 477.3 152.1 480 160 480c7.053 0 14.12-2.703 19.53-8.109l132.3-136.8C329.2 317.8 316.9 288 292.3 288z"
+                        fill="currentColor"
+                      />
+                    </svg>
+                  </button>
+                </div>
+                <div
+                  data-display="table-cell"
+                >
+                  <button
+                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-iFMAIt jGlqMa"
+                    data-field="pokedex_number"
+                    type="button"
+                  >
+                    National Pokedex Number
+                     
+                    <svg
+                      aria-hidden="true"
+                      class="svg-inline--fa fa-sort "
+                      color=""
+                      data-icon="sort"
+                      data-prefix="fas"
+                      focusable="false"
+                      role="img"
+                      viewBox="0 0 320 512"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M27.66 224h264.7c24.6 0 36.89-29.78 19.54-47.12l-132.3-136.8c-5.406-5.406-12.47-8.107-19.53-8.107c-7.055 0-14.09 2.701-19.45 8.107L8.119 176.9C-9.229 194.2 3.055 224 27.66 224zM292.3 288H27.66c-24.6 0-36.89 29.77-19.54 47.12l132.5 136.8C145.9 477.3 152.1 480 160 480c7.053 0 14.12-2.703 19.53-8.109l132.3-136.8C329.2 317.8 316.9 288 292.3 288z"
+                        fill="currentColor"
+                      />
+                    </svg>
+                  </button>
+                </div>
+                <div
+                  data-display="table-cell"
+                >
+                  <button
+                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-iFMAIt jGlqMa"
+                    data-field="Category"
+                    type="button"
+                  >
+                    Category
+                     
+                    <svg
+                      aria-hidden="true"
+                      class="svg-inline--fa fa-sort "
+                      color=""
+                      data-icon="sort"
+                      data-prefix="fas"
+                      focusable="false"
+                      role="img"
+                      viewBox="0 0 320 512"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M27.66 224h264.7c24.6 0 36.89-29.78 19.54-47.12l-132.3-136.8c-5.406-5.406-12.47-8.107-19.53-8.107c-7.055 0-14.09 2.701-19.45 8.107L8.119 176.9C-9.229 194.2 3.055 224 27.66 224zM292.3 288H27.66c-24.6 0-36.89 29.77-19.54 47.12l132.5 136.8C145.9 477.3 152.1 480 160 480c7.053 0 14.12-2.703 19.53-8.109l132.3-136.8C329.2 317.8 316.9 288 292.3 288z"
+                        fill="currentColor"
+                      />
+                    </svg>
+                  </button>
+                </div>
+                <div
+                  data-display="table-cell"
+                >
+                  <button
+                    class="StyledButton-sc-323bzc-0 idryEU sc-bqiRlB sc-bkkeKt edofBN hOYLYz sc-dJjYzT cGuTUx sc-iFMAIt jGlqMa"
+                    data-field="first_seen"
+                    type="button"
+                  >
+                    First Seen
+                     
+                    <svg
+                      aria-hidden="true"
+                      class="svg-inline--fa fa-sort "
+                      color=""
+                      data-icon="sort"
+                      data-prefix="fas"
+                      focusable="false"
+                      role="img"
+                      viewBox="0 0 320 512"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M27.66 224h264.7c24.6 0 36.89-29.78 19.54-47.12l-132.3-136.8c-5.406-5.406-12.47-8.107-19.53-8.107c-7.055 0-14.09 2.701-19.45 8.107L8.119 176.9C-9.229 194.2 3.055 224 27.66 224zM292.3 288H27.66c-24.6 0-36.89 29.77-19.54 47.12l132.5 136.8C145.9 477.3 152.1 480 160 480c7.053 0 14.12-2.703 19.53-8.109l132.3-136.8C329.2 317.8 316.9 288 292.3 288z"
+                        fill="currentColor"
+                      />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+            </div>
+            <div
+              data-display="table-body"
+            >
+              <div
+                class=""
+                data-display="table-row"
+                data-highlight="false"
+              >
+                <a
+                  data-display="table-cell"
+                  data-key="1"
+                >
+                  Bulbasaur
+                </a>
+                <a
+                  data-display="table-cell"
+                  data-key="1"
+                >
+                  <code>
+                    1
+                  </code>
+                </a>
+                <a
+                  data-display="table-cell"
+                  data-key="1"
+                >
+                  Seed
+                </a>
+                <a
+                  data-display="table-cell"
+                  data-key="1"
+                />
+              </div>
+              <div
+                class=""
+                data-display="table-row"
+                data-highlight="false"
+              >
+                <a
+                  data-display="table-cell"
+                  data-key="2"
+                >
+                  Ivysaur
+                </a>
+                <a
+                  data-display="table-cell"
+                  data-key="2"
+                >
+                  <code>
+                    2
+                  </code>
+                </a>
+                <a
+                  data-display="table-cell"
+                  data-key="2"
+                >
+                  Seed
+                </a>
+                <a
+                  data-display="table-cell"
+                  data-key="2"
+                />
+              </div>
+              <div
+                class=""
+                data-display="table-row"
+                data-highlight="false"
+              >
+                <a
+                  data-display="table-cell"
+                  data-key="3"
+                >
+                  Venusaur
+                </a>
+                <a
+                  data-display="table-cell"
+                  data-key="3"
+                >
+                  <code>
+                    3
+                  </code>
+                </a>
+                <a
+                  data-display="table-cell"
+                  data-key="3"
+                >
+                  Seed
+                </a>
+                <a
+                  data-display="table-cell"
+                  data-key="3"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="sc-gKclnd exdBHI sc-iCfMLu gALdNb sc-hGPBjI dLlxyS"
+        >
+          <div
+            class="sc-fKVqWL hOcWtv sc-bBHxTw fYiSNr"
+          >
+            <strong>
+              1
+               - 
+              3
+            </strong>
+             
+            of
+             
+            <strong>
+              5
+              +
+            </strong>
+          </div>
+          <div
+            class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI dljPk"
+          >
+            <div
+              class="sc-gKclnd exdBHI sc-iCfMLu jciJBO sc-hGPBjI sc-kLwhqv dljPk bzMIBI"
+            >
+              <button
+                class="StyledButton-sc-323bzc-0 GAqvF sc-bqiRlB sc-hBUSln edofBN dlhkLz sc-dJjYzT cGuTUx rendition-pager__btn--prev"
+                disabled=""
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="svg-inline--fa fa-chevron-left "
+                  data-icon="chevron-left"
+                  data-prefix="fas"
+                  focusable="false"
+                  role="img"
+                  viewBox="0 0 320 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M224 480c-8.188 0-16.38-3.125-22.62-9.375l-192-192c-12.5-12.5-12.5-32.75 0-45.25l192-192c12.5-12.5 32.75-12.5 45.25 0s12.5 32.75 0 45.25L77.25 256l169.4 169.4c12.5 12.5 12.5 32.75 0 45.25C240.4 476.9 232.2 480 224 480z"
+                    fill="currentColor"
+                  />
+                </svg>
+              </button>
+              <button
+                class="StyledButton-sc-323bzc-0 gKeRwL sc-bqiRlB sc-hBUSln edofBN dlhkLz sc-dJjYzT cGuTUx rendition-pager__btn--next"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="svg-inline--fa fa-chevron-right "
+                  data-icon="chevron-right"
+                  data-prefix="fas"
+                  focusable="false"
+                  role="img"
+                  viewBox="0 0 320 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M96 480c-8.188 0-16.38-3.125-22.62-9.375c-12.5-12.5-12.5-32.75 0-45.25L242.8 256L73.38 86.63c-12.5-12.5-12.5-32.75 0-45.25s32.75-12.5 45.25 0l192 192c12.5 12.5 12.5 32.75 0 45.25l-192 192C112.4 476.9 104.2 480 96 480z"
+                    fill="currentColor"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storyshots Core/Table With Highlighted Rows 1`] = `
 <div>
   <div
@@ -4029,9 +4406,11 @@ exports[`Storyshots Core/Table With Pager 1`] = `
               3
             </strong>
              
-            of 
+            of
+             
             <strong>
               11
+              
             </strong>
           </div>
           <div
@@ -4318,9 +4697,11 @@ exports[`Storyshots Core/Table With Pager 1`] = `
               3
             </strong>
              
-            of 
+            of
+             
             <strong>
               11
+              
             </strong>
           </div>
           <div

--- a/src/extra/AutoUI/__snapshots__/AutoUI.stories.storyshot
+++ b/src/extra/AutoUI/__snapshots__/AutoUI.stories.storyshot
@@ -559,9 +559,11 @@ exports[`Storyshots Extra/AutoUI Default 1`] = `
                       7
                     </strong>
                      
-                    of 
+                    of
+                     
                     <strong>
                       7
+                      
                     </strong>
                   </div>
                   <div


### PR DESCRIPTION
This change adds a new property `fuzzyPager`, that if true, the total number of items shown on the page will be indicated as being approximate. Useful for when you don't now the full size of your dataset. This is only used if `usePager` is true.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

<!-- You can remove tags that do not apply. -->
Connects-to: # <!-- waffle convention to track a PR's status through its connected, open issue -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->
Change-type: major|minor|patch <!-- The change type of this PR -->

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have regenerated screenshots for any affected components with `npm run generate-snapshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
