### PR TITLE
Fix install failure on node 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "prettier": "^2.4.1",
     "react": "^16.14.0",
     "react-dom": "^16.14.0",
-    "react-monaco-editor": "^0.45.0",
+    "react-monaco-editor": "0.40.0",
     "rimraf": "^3.0.2",
     "sinon": "^4.5.0",
     "strip-css-comments": "^3.0.0",


### PR DESCRIPTION
This change pins `react-monaco-editor` to v40, as more recent versions
declare a peer dependency on react v17 (instead of v16).
Older versions of npm would let the install continue and raise
a warning, but more recent versions (>v6) will fail the install.
See https://docs.npmjs.com/cli/v8/configuring-npm/package-json#peerdependencies

Fixes https://github.com/balena-io-modules/rendition/issues/1538

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

<!-- You can remove tags that do not apply. -->
Connects-to: # <!-- waffle convention to track a PR's status through its connected, open issue -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->
Change-type: major|minor|patch <!-- The change type of this PR -->

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] I have regenerated screenshots for any affected components with `npm run generate-snapshots`
- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
