### PR TITLE
Mermaid: Add support for callback functions in graphs

### DIFF
--- a/src/extra/Mermaid/Mermaid.stories.tsx
+++ b/src/extra/Mermaid/Mermaid.stories.tsx
@@ -8,6 +8,7 @@ export default {
 } as Meta;
 
 const Template = createTemplate<MermaidProps>(Mermaid);
+(window as any).callback = (e: any) => console.log('click', e);
 export const Default = createStory<MermaidProps>(Template, {
 	value: `
   graph TD;
@@ -15,5 +16,9 @@ export const Default = createStory<MermaidProps>(Template, {
       A-->C;
       B-->D;
       C-->D;
+			click A callback;
   `,
+	callbackFunctions: {
+		callback: (e: any) => console.log('on click callback:', e),
+	},
 });

--- a/src/extra/Mermaid/index.tsx
+++ b/src/extra/Mermaid/index.tsx
@@ -1,3 +1,4 @@
+import forEach from 'lodash/forEach';
 import mermaid from 'mermaid';
 import * as React from 'react';
 import uuid from 'uuid/v4';
@@ -6,6 +7,10 @@ import { Box, BoxProps } from '../../components/Box';
 export interface MermaidProps extends BoxProps {
 	/** The mermaid source that should be rendered */
 	value: string;
+	/** An object of callback functions that can be called in the mermaid graph. Functions are called with the ID of the node that was clicked. Note: These values are attached to the window object, which can cause collisions with other properties. */
+	callbackFunctions?: {
+		[name: string]: (value: string) => any;
+	};
 }
 
 /**
@@ -31,6 +36,16 @@ export class Mermaid extends React.Component<MermaidProps, {}> {
 	}
 
 	public componentDidMount() {
+		const { callbackFunctions } = this.props;
+		// MermaidJS expects callback functions to be attached to the window object
+		if (callbackFunctions) {
+			forEach(callbackFunctions, (callback, name) => {
+				(window as any)[name] = callback;
+			});
+			mermaid.initialize({
+				securityLevel: 'loose',
+			});
+		}
 		this.renderSVG();
 	}
 


### PR DESCRIPTION
Fixes https://github.com/balena-io-modules/rendition/issues/1543

This change allows you to pass an object of callback functions that can
be called from click events in mermaid.
These functions have to be bound to the window object to work with
mermaid, which could potentially cause some problems if charts have the
same callback names.
I did try putting the mermaid chart inside an iframe to isolate the
functions, but I couldn't get this working - it seems mermaid then
cannot find the global function to call.

Change-type: minor
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

<!-- You can remove tags that do not apply. -->
Connects-to: # <!-- waffle convention to track a PR's status through its connected, open issue -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->
Change-type: major|minor|patch <!-- The change type of this PR -->

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] I have regenerated screenshots for any affected components with `npm run generate-snapshots`
- [x] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
