### PR TITLE
Remove duplicate contributor checklist item on PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,18 +1,23 @@
 <!-- You can remove tags that do not apply. -->
+
 Connects-to: # <!-- waffle convention to track a PR's status through its connected, open issue -->
 See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
 Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->
 Change-type: major|minor|patch <!-- The change type of this PR -->
 
 ---
+
 ##### Contributor checklist
+
 <!-- For completed items, change [ ] to [x].  -->
-- [ ] I have regenerated screenshots for any affected components with `npm run generate-snapshots`
-- [ ] I have regenerated jest snapshots for any affected components with `npm run jest -- -u`
+
+- [ ] I have regenerated jest snapshots for any affected components with `npm run generate-snapshots`
 
 ##### Reviewer Guidelines
+
 - When submitting a review, please pick:
-  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
-  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
-  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
+  - '_Approve_' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
+  - '_Request Changes_' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
+  - '_Comment_' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
+
 ---


### PR DESCRIPTION
The contributor checklist was basically asking people to generate the
jest snapshots twice using different commands!
This change just instructs people to run `generate-snapshots`.

Generating screenshots is a throwback to when we did visual regression
testing using a headless browser. Now we are able to utilise
styled-components to get a fully accurate visual representation using
only snapshots, which makes the screenshot comment outdated.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>
