### PR TITLE
Remove storedFilters from the dependency array in PersistentFilter's useEffect

### DIFF
--- a/src/extra/AutoUI/Filters/PersistentFilters.tsx
+++ b/src/extra/AutoUI/Filters/PersistentFilters.tsx
@@ -17,6 +17,7 @@ import {
 } from '../../../components/Filters/SchemaSieve';
 import { getFromLocalStorage, setToLocalStorage } from '../../../utils';
 import type { History } from 'history';
+import isEqual from 'lodash/isEqual';
 
 export interface ListQueryStringFilterObject {
 	n: FilterSignature['field'];
@@ -142,7 +143,9 @@ export const PersistentFilters = ({
 	// When the component mounts, filters from the page URL,
 	// then communicate them back to the parent component.
 	React.useEffect(() => {
-		onFiltersUpdate?.(storedFilters);
+		if (!isEqual(storedFilters, filters)) {
+			onFiltersUpdate?.(storedFilters);
+		}
 	}, [storedFilters]);
 
 	const viewsUpdate = (views: FiltersView[]) => {


### PR DESCRIPTION
Remove storedFilters from the dependency array in PersistentFilter's useEffect

Change-type: patch
Signed-off-by: Matthew Yarmolinsky <matthew-timothy@balena.io>

---

##### Contributor checklist

<!-- For completed items, change [ ] to [x].  -->

- [ ] I have regenerated jest snapshots for any affected components with `npm run generate-snapshots`

##### Reviewer Guidelines

- When submitting a review, please pick:
  - '_Approve_' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '_Request Changes_' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '_Comment_' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)

---
