### PR TITLE
Add Breadcrumbs dark mode

### DIFF
--- a/src/components/Breadcrumbs/index.tsx
+++ b/src/components/Breadcrumbs/index.tsx
@@ -5,18 +5,30 @@ import { Flex } from '../Flex';
 import { Txt } from '../Txt';
 import { useTheme } from '../../hooks/useTheme';
 
-const Circle = styled(Flex)<{ isLast: boolean; emphasized?: boolean }>`
+const Circle = styled(Flex)<{
+	isLast: boolean;
+	emphasized?: boolean;
+	dark?: boolean;
+}>`
 	border: 1px solid
 		${(props) =>
 			props.isLast
-				? props.theme.colors.quartenary.light
+				? props.dark
+					? props.theme.colors.secondary.dark
+					: props.theme.colors.quartenary.light
+				: props.dark
+				? props.theme.colors.tertiary.light
 				: props.theme.colors.text.light};
 	border-radius: 50%;
 	width: ${(props) => props.theme.space[props.emphasized ? 3 : 2]}px;
 	height: ${(props) => props.theme.space[props.emphasized ? 3 : 2]}px;
 	background: ${(props) =>
 		props.isLast
-			? props.theme.colors.quartenary.light
+			? props.dark
+				? props.theme.colors.secondary.dark
+				: props.theme.colors.quartenary.light
+			: props.dark
+			? props.theme.colors.tertiary.light
 			: props.theme.colors.text.light};
 `;
 
@@ -33,6 +45,8 @@ export interface BreadcrumbsProps {
 	crumbs: Crumb[];
 	/** If true, use a larger Breadcrumbs */
 	emphasized?: boolean;
+	/** if true , show dark theme breadcrumb */
+	dark?: boolean;
 }
 
 const BreadcrumbContent = React.memo(
@@ -71,7 +85,7 @@ const BreadcrumbContent = React.memo(
 	},
 );
 
-export const Breadcrumbs = ({ crumbs, emphasized }: BreadcrumbsProps) => {
+export const Breadcrumbs = ({ crumbs, emphasized, dark }: BreadcrumbsProps) => {
 	const theme = useTheme();
 	return (
 		<Flex flexDirection="column" flexWrap="wrap" width="100%">
@@ -83,13 +97,17 @@ export const Breadcrumbs = ({ crumbs, emphasized }: BreadcrumbsProps) => {
 						<Txt
 							bold={isLast}
 							fontSize={2}
-							color={isLast ? 'white' : 'secondary.semilight'}
+							color={
+								isLast
+									? `${dark ? 'secondary.dark' : 'white'}`
+									: `${dark ? 'tertiary.light' : 'secondary.semilight'}`
+							}
 							key={crumb.text}
 							width="100%"
 						>
 							<Flex flexDirection="column" width="100%">
 								<Flex alignItems="center" width="100%">
-									<Circle isLast={isLast} emphasized={emphasized} />
+									<Circle dark={dark} isLast={isLast} emphasized={emphasized} />
 									<Flex width={`calc(100% - ${theme.space[2]}px)`} pl={2}>
 										{crumb.onClick ? (
 											<Link
@@ -120,7 +138,11 @@ export const Breadcrumbs = ({ crumbs, emphasized }: BreadcrumbsProps) => {
 										width={theme.space[emphasized ? 3 : 2]}
 										justifyContent="center"
 									>
-										<Flex height={theme.space[4]} width="1px" bg="text.light" />
+										<Flex
+											height={theme.space[4]}
+											width="1px"
+											bg={`text.${dark ? 'dark' : 'light'}`}
+										/>
 									</Flex>
 								)}
 							</Flex>


### PR DESCRIPTION
Change-type: minor
Signed-off-by: Andrea Rosci <andrear@balena.io>

default (light):
<img width="163" alt="Screenshot 2022-04-14 at 15 25 58" src="https://user-images.githubusercontent.com/7238159/163400510-756b33f0-ea14-44c8-b876-643a142097a7.png">

dark mode: 
<img width="169" alt="Screenshot 2022-04-14 at 15 13 08" src="https://user-images.githubusercontent.com/7238159/163399955-9588da66-777e-45ac-84d4-4b43089cee70.png">

---

##### Contributor checklist

<!-- For completed items, change [ ] to [x].  -->

- [ ] I have regenerated jest snapshots for any affected components with `npm run generate-snapshots`

##### Reviewer Guidelines

- When submitting a review, please pick:
  - '_Approve_' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '_Request Changes_' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '_Comment_' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)

---
