### PR TITLE
DownloadImageModal: Add the provisioning key expiry date in the advanced options

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
     "lodash": "^4.17.21",
     "memoizee": "^0.4.15",
     "mermaid": "^8.13.9",
+    "moment": "^2.29.3",
     "pinejs-client-fetch": "^0.2.2",
     "prismjs": "^1.25.0",
     "prop-types": "^15.7.2",

--- a/src/hooks/useTranslation.tsx
+++ b/src/hooks/useTranslation.tsx
@@ -67,6 +67,7 @@ const translationMap = {
 
 	'labels.instructions': 'Instructions',
 	'labels.provisioning_key_name': 'Provisioning Key name',
+	'labels.provisioning_key_expiry_date': 'Provisioning Key expiring on',
 
 	'info.production_and_enterprise_plan_only':
 		'production and enterprise plan only',

--- a/src/unstable-temp/DownloadImageModal/DownloadImageModal.tsx
+++ b/src/unstable-temp/DownloadImageModal/DownloadImageModal.tsx
@@ -71,6 +71,7 @@ export interface DownloadOptionsBase {
 	releaseId?: number;
 	deviceType: string;
 	provisioningKeyName?: string;
+	provisioningKeyExpiryDate?: string;
 	downloadConfigOnly?: boolean;
 	version: string;
 	developmentMode?: boolean;

--- a/src/unstable-temp/DownloadImageModal/FormModel.tsx
+++ b/src/unstable-temp/DownloadImageModal/FormModel.tsx
@@ -13,6 +13,7 @@ import styled from 'styled-components';
 import { DeviceTypeOptions, DeviceTypeOptionsGroup } from './models';
 import { DocsLink } from './OsConfiguration';
 import { useTranslation } from '../../hooks/useTranslation';
+import moment from 'moment';
 
 export const DownloadImageLabel = styled.label`
 	display: flex;
@@ -198,6 +199,42 @@ const FormControl = ({ onModelChange, options, model }: FormControlProps) => {
 								autoComplete="new-password"
 							/>
 						</Box>
+					)}
+
+					{options.type === 'datetime-local' && (
+						<>
+							<input
+								type="hidden"
+								name={options.name}
+								value={
+									!!model[options.name]
+										? moment(model[options.name] as string)
+												.utc()
+												.format()
+										: undefined
+								}
+							/>
+							<Input
+								mb={2}
+								type="datetime-local"
+								value={
+									!!model[options.name]
+										? (model[options.name] as string)
+										: undefined
+								}
+								onChange={(e: React.FormEvent<HTMLInputElement>) => {
+									console.log(e.currentTarget.value);
+									onModelChange({
+										[options.name]: e.currentTarget.value,
+									});
+								}}
+								onKeyPress={(e) => {
+									if (e.key === 'Enter' && !!model[options.name]) {
+										onModelChange({ [options.name]: undefined });
+									}
+								}}
+							/>
+						</>
 					)}
 
 					{(!options.type || options.type === 'text') && (

--- a/src/unstable-temp/DownloadImageModal/ImageForm.tsx
+++ b/src/unstable-temp/DownloadImageModal/ImageForm.tsx
@@ -18,6 +18,7 @@ import {
 import { DownloadOptions, DownloadOptionsBase } from './DownloadImageModal';
 import { TFunction } from '../../hooks/useTranslation';
 import pickBy from 'lodash/pickBy';
+import moment from 'moment';
 
 const ETCHER_OPEN_IMAGE_URL = 'https://www.balena.io/etcher/open-image-url';
 const POLL_INTERVAL_DOCS =
@@ -71,6 +72,14 @@ const getDeviceTypeOptions = (t: TFunction, deviceType: DeviceType) => {
 				default: '',
 				type: 'text',
 			});
+
+			group.options.push({
+				message: t('labels.provisioning_key_expiry_date'),
+				name: 'provisioningKeyExpiryDate',
+				default: '',
+				type: 'datetime-local',
+			});
+
 			group.options.map((option) => {
 				if (option.message === 'Check for updates every X minutes') {
 					option.docs = POLL_INTERVAL_DOCS;
@@ -402,6 +411,15 @@ export const ImageForm = ({
 							: action?.tooltip
 					}
 					onClick={(event: React.MouseEvent) => {
+						if (downloadOptions.provisioningKeyExpiryDate) {
+							// Convert to UTC for /download
+							downloadOptions.provisioningKeyExpiryDate = moment(
+								downloadOptions.provisioningKeyExpiryDate,
+							)
+								.utc()
+								.format();
+						}
+
 						if (action?.onClick) {
 							action.onClick(event, downloadOptions);
 						}


### PR DESCRIPTION
Change-Type: minor
Signed-off-by: Nitish Agarwal <1592163+nitishagar@users.noreply.github.com>

HQ: https://jel.ly.fish/e450713f-001c-4470-b571-71724aeb0869
See: https://www.flowdock.com/app/rulemotion/resin-tech/threads/vx-rBrpDBqXtkdtMmSU5MmPYSlb
Depends-on: https://github.com/balena-io/balena-sdk/pull/1217

Screenshot:
![Screenshot 2022-05-12 at 15-12-13 STAGING balena dashboard Fleets](https://user-images.githubusercontent.com/1592163/168041947-fa4e3f5d-3746-4ef7-9dde-0aec280c68bb.png)


