### PR TITLE
Make sort icon for table column headers remain on the same line as the text

### DIFF
--- a/src/components/Avatar/__snapshots__/Avatar.stories.storyshot
+++ b/src/components/Avatar/__snapshots__/Avatar.stories.storyshot
@@ -7,7 +7,7 @@ exports[`Storyshots Core/Avatar Default 1`] = `
   >
     
     <div
-      class="StyledBox-sc-13pk1d4-0 kVFNVq StyledAvatar-sc-1suyamb-1 sc-egNfGp jwNySN"
+      class="StyledBox-sc-13pk1d4-0 kVFNVq StyledAvatar-sc-1suyamb-1 sc-ddcaxn cRGiDA"
     >
       <svg
         aria-hidden="true"
@@ -36,7 +36,7 @@ exports[`Storyshots Core/Avatar Emphasized 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 iaZwhG StyledAvatar-sc-1suyamb-1 sc-egNfGp jwNySN"
+      class="StyledBox-sc-13pk1d4-0 iaZwhG StyledAvatar-sc-1suyamb-1 sc-ddcaxn cRGiDA"
     >
       <div
         class="sc-ivTmOn dNJphr sc-cxabCf kEsRji"
@@ -54,7 +54,7 @@ exports[`Storyshots Core/Avatar With First Name 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 kVFNVq StyledAvatar-sc-1suyamb-1 sc-egNfGp jwNySN"
+      class="StyledBox-sc-13pk1d4-0 kVFNVq StyledAvatar-sc-1suyamb-1 sc-ddcaxn cRGiDA"
     >
       <div
         class="sc-ivTmOn dNJphr sc-cxabCf kEsRji"
@@ -72,7 +72,7 @@ exports[`Storyshots Core/Avatar With Full Name 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 kVFNVq StyledAvatar-sc-1suyamb-1 sc-egNfGp jwNySN"
+      class="StyledBox-sc-13pk1d4-0 kVFNVq StyledAvatar-sc-1suyamb-1 sc-ddcaxn cRGiDA"
     >
       <div
         class="sc-ivTmOn dNJphr sc-cxabCf kEsRji"
@@ -90,7 +90,7 @@ exports[`Storyshots Core/Avatar With Image 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 bkfLqh StyledAvatar-sc-1suyamb-1 sc-egNfGp jwNySN"
+      class="StyledBox-sc-13pk1d4-0 bkfLqh StyledAvatar-sc-1suyamb-1 sc-ddcaxn cRGiDA"
     />
     
   </div>
@@ -103,7 +103,7 @@ exports[`Storyshots Core/Avatar With Last Name 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 kVFNVq StyledAvatar-sc-1suyamb-1 sc-egNfGp jwNySN"
+      class="StyledBox-sc-13pk1d4-0 kVFNVq StyledAvatar-sc-1suyamb-1 sc-ddcaxn cRGiDA"
     >
       <div
         class="sc-ivTmOn dNJphr sc-cxabCf kEsRji"

--- a/src/components/Breadcrumbs/__snapshots__/Breadcrumbs.stories.storyshot
+++ b/src/components/Breadcrumbs/__snapshots__/Breadcrumbs.stories.storyshot
@@ -19,7 +19,7 @@ exports[`Storyshots Core/Breadcrumbs Default 1`] = `
             class="sc-gKXOVf QRSBg sc-iBkjds gNjzDq sc-hHLeRK liHVdE"
           >
             <div
-              class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-hFrEEg iKIurY ftWzhq"
+              class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-egNfGp iKIurY jxbFQs"
             />
             <div
               class="sc-gKXOVf QRSBg sc-iBkjds dqCdat sc-hHLeRK iKIurY"
@@ -62,7 +62,7 @@ exports[`Storyshots Core/Breadcrumbs Default 1`] = `
             class="sc-gKXOVf QRSBg sc-iBkjds gNjzDq sc-hHLeRK liHVdE"
           >
             <div
-              class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-hFrEEg iKIurY ftWzhq"
+              class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-egNfGp iKIurY jxbFQs"
             />
             <div
               class="sc-gKXOVf QRSBg sc-iBkjds dqCdat sc-hHLeRK iKIurY"
@@ -105,7 +105,7 @@ exports[`Storyshots Core/Breadcrumbs Default 1`] = `
             class="sc-gKXOVf QRSBg sc-iBkjds gNjzDq sc-hHLeRK liHVdE"
           >
             <div
-              class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-hFrEEg iKIurY kHqFwK"
+              class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-egNfGp iKIurY haMNUc"
             />
             <div
               class="sc-gKXOVf QRSBg sc-iBkjds dqCdat sc-hHLeRK iKIurY"
@@ -176,7 +176,7 @@ exports[`Storyshots Core/Breadcrumbs Wrapped 1`] = `
               class="sc-gKXOVf QRSBg sc-iBkjds gNjzDq sc-hHLeRK liHVdE"
             >
               <div
-                class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-hFrEEg iKIurY ftWzhq"
+                class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-egNfGp iKIurY jxbFQs"
               />
               <div
                 class="sc-gKXOVf QRSBg sc-iBkjds dqCdat sc-hHLeRK iKIurY"
@@ -219,7 +219,7 @@ exports[`Storyshots Core/Breadcrumbs Wrapped 1`] = `
               class="sc-gKXOVf QRSBg sc-iBkjds gNjzDq sc-hHLeRK liHVdE"
             >
               <div
-                class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-hFrEEg iKIurY ftWzhq"
+                class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-egNfGp iKIurY jxbFQs"
               />
               <div
                 class="sc-gKXOVf QRSBg sc-iBkjds dqCdat sc-hHLeRK iKIurY"
@@ -262,7 +262,7 @@ exports[`Storyshots Core/Breadcrumbs Wrapped 1`] = `
               class="sc-gKXOVf QRSBg sc-iBkjds gNjzDq sc-hHLeRK liHVdE"
             >
               <div
-                class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-hFrEEg iKIurY kHqFwK"
+                class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-egNfGp iKIurY haMNUc"
               />
               <div
                 class="sc-gKXOVf QRSBg sc-iBkjds dqCdat sc-hHLeRK iKIurY"

--- a/src/components/Container/__snapshots__/Container.stories.storyshot
+++ b/src/components/Container/__snapshots__/Container.stories.storyshot
@@ -6,7 +6,7 @@ exports[`Storyshots Core/Container Centered Content 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
   >
     <div
-      class="sc-gKXOVf QRSBg sc-iBkjds bkEkLP sc-jKDlA-D iNkNXJ sc-bTMaZy iamCcR"
+      class="sc-gKXOVf QRSBg sc-iBkjds bkEkLP sc-iWajrY dbYklC sc-jKDlA-D cLwCtV"
     >
       <h3
         class="sc-ciZhAO btUqKl sc-jdAMXn iwAvbM"
@@ -24,7 +24,7 @@ exports[`Storyshots Core/Container Default 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
   >
     <div
-      class="sc-gKXOVf QRSBg sc-iBkjds bkEkLP sc-jKDlA-D loJEki sc-bTMaZy iamCcR"
+      class="sc-gKXOVf QRSBg sc-iBkjds bkEkLP sc-iWajrY kplmVJ sc-jKDlA-D cLwCtV"
     >
       <h3
         class="sc-ciZhAO btUqKl sc-jdAMXn iwAvbM"

--- a/src/components/Copy/__snapshots__/Copy.stories.storyshot
+++ b/src/components/Copy/__snapshots__/Copy.stories.storyshot
@@ -9,7 +9,7 @@ exports[`Storyshots Core/Copy Always Show 1`] = `
       class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-bBrHrO HodyL"
     >
       <div
-        class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-grVGCS iKIurY ikgPpo"
+        class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-iJkHyd iKIurY bAXBaZ"
       >
         <div
           class="sc-gKXOVf ckXSHX sc-iBkjds gNjzDq sc-hHLeRK eTSHtc"
@@ -18,7 +18,7 @@ exports[`Storyshots Core/Copy Always Show 1`] = `
             class="sc-fmrZth clkOUX"
           >
             <div
-              class="sc-eXBvqI jmlAON sc-kngDgl juYrxT"
+              class="sc-eXBvqI jmlAON sc-afnQL gYeoiq"
             >
               <div
                 data-display="table-head"

--- a/src/components/Filters/__snapshots__/Filters.stories.storyshot
+++ b/src/components/Filters/__snapshots__/Filters.stories.storyshot
@@ -131,7 +131,7 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
           Bulbasaur
         </h2>
         <table
-          class="sc-chKnlQ klBmRy"
+          class="sc-kIZKsT WUDsB"
         >
           <tbody>
             <tr>
@@ -221,7 +221,7 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
           Ivysaur
         </h2>
         <table
-          class="sc-chKnlQ klBmRy"
+          class="sc-kIZKsT WUDsB"
         >
           <tbody>
             <tr>
@@ -311,7 +311,7 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
           Venusaur
         </h2>
         <table
-          class="sc-chKnlQ klBmRy"
+          class="sc-kIZKsT WUDsB"
         >
           <tbody>
             <tr>
@@ -401,7 +401,7 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
           Charmander
         </h2>
         <table
-          class="sc-chKnlQ klBmRy"
+          class="sc-kIZKsT WUDsB"
         >
           <tbody>
             <tr>
@@ -491,7 +491,7 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
           Charmeleon
         </h2>
         <table
-          class="sc-chKnlQ klBmRy"
+          class="sc-kIZKsT WUDsB"
         >
           <tbody>
             <tr>
@@ -583,7 +583,7 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
           Charizard
         </h2>
         <table
-          class="sc-chKnlQ klBmRy"
+          class="sc-kIZKsT WUDsB"
         >
           <tbody>
             <tr>
@@ -702,7 +702,7 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
           Squirtle
         </h2>
         <table
-          class="sc-chKnlQ klBmRy"
+          class="sc-kIZKsT WUDsB"
         >
           <tbody>
             <tr>
@@ -821,7 +821,7 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
           Wartortle
         </h2>
         <table
-          class="sc-chKnlQ klBmRy"
+          class="sc-kIZKsT WUDsB"
         >
           <tbody>
             <tr>
@@ -911,7 +911,7 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
           Blastoise
         </h2>
         <table
-          class="sc-chKnlQ klBmRy"
+          class="sc-kIZKsT WUDsB"
         >
           <tbody>
             <tr>
@@ -1001,7 +1001,7 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
           Caterpie
         </h2>
         <table
-          class="sc-chKnlQ klBmRy"
+          class="sc-kIZKsT WUDsB"
         >
           <tbody>
             <tr>
@@ -1091,7 +1091,7 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
           Staryu
         </h2>
         <table
-          class="sc-chKnlQ klBmRy"
+          class="sc-kIZKsT WUDsB"
         >
           <tbody>
             <tr>
@@ -1298,7 +1298,7 @@ exports[`Storyshots Core/Filters Compact 1`] = `
           Bulbasaur
         </h2>
         <table
-          class="sc-chKnlQ klBmRy"
+          class="sc-kIZKsT WUDsB"
         >
           <tbody>
             <tr>
@@ -1388,7 +1388,7 @@ exports[`Storyshots Core/Filters Compact 1`] = `
           Ivysaur
         </h2>
         <table
-          class="sc-chKnlQ klBmRy"
+          class="sc-kIZKsT WUDsB"
         >
           <tbody>
             <tr>
@@ -1478,7 +1478,7 @@ exports[`Storyshots Core/Filters Compact 1`] = `
           Venusaur
         </h2>
         <table
-          class="sc-chKnlQ klBmRy"
+          class="sc-kIZKsT WUDsB"
         >
           <tbody>
             <tr>
@@ -1568,7 +1568,7 @@ exports[`Storyshots Core/Filters Compact 1`] = `
           Charmander
         </h2>
         <table
-          class="sc-chKnlQ klBmRy"
+          class="sc-kIZKsT WUDsB"
         >
           <tbody>
             <tr>
@@ -1658,7 +1658,7 @@ exports[`Storyshots Core/Filters Compact 1`] = `
           Charmeleon
         </h2>
         <table
-          class="sc-chKnlQ klBmRy"
+          class="sc-kIZKsT WUDsB"
         >
           <tbody>
             <tr>
@@ -1750,7 +1750,7 @@ exports[`Storyshots Core/Filters Compact 1`] = `
           Charizard
         </h2>
         <table
-          class="sc-chKnlQ klBmRy"
+          class="sc-kIZKsT WUDsB"
         >
           <tbody>
             <tr>
@@ -1869,7 +1869,7 @@ exports[`Storyshots Core/Filters Compact 1`] = `
           Squirtle
         </h2>
         <table
-          class="sc-chKnlQ klBmRy"
+          class="sc-kIZKsT WUDsB"
         >
           <tbody>
             <tr>
@@ -1988,7 +1988,7 @@ exports[`Storyshots Core/Filters Compact 1`] = `
           Wartortle
         </h2>
         <table
-          class="sc-chKnlQ klBmRy"
+          class="sc-kIZKsT WUDsB"
         >
           <tbody>
             <tr>
@@ -2078,7 +2078,7 @@ exports[`Storyshots Core/Filters Compact 1`] = `
           Blastoise
         </h2>
         <table
-          class="sc-chKnlQ klBmRy"
+          class="sc-kIZKsT WUDsB"
         >
           <tbody>
             <tr>
@@ -2168,7 +2168,7 @@ exports[`Storyshots Core/Filters Compact 1`] = `
           Caterpie
         </h2>
         <table
-          class="sc-chKnlQ klBmRy"
+          class="sc-kIZKsT WUDsB"
         >
           <tbody>
             <tr>
@@ -2258,7 +2258,7 @@ exports[`Storyshots Core/Filters Compact 1`] = `
           Staryu
         </h2>
         <table
-          class="sc-chKnlQ klBmRy"
+          class="sc-kIZKsT WUDsB"
         >
           <tbody>
             <tr>
@@ -2478,7 +2478,7 @@ exports[`Storyshots Core/Filters Default 1`] = `
           Bulbasaur
         </h2>
         <table
-          class="sc-chKnlQ klBmRy"
+          class="sc-kIZKsT WUDsB"
         >
           <tbody>
             <tr>
@@ -2568,7 +2568,7 @@ exports[`Storyshots Core/Filters Default 1`] = `
           Ivysaur
         </h2>
         <table
-          class="sc-chKnlQ klBmRy"
+          class="sc-kIZKsT WUDsB"
         >
           <tbody>
             <tr>
@@ -2658,7 +2658,7 @@ exports[`Storyshots Core/Filters Default 1`] = `
           Venusaur
         </h2>
         <table
-          class="sc-chKnlQ klBmRy"
+          class="sc-kIZKsT WUDsB"
         >
           <tbody>
             <tr>
@@ -2748,7 +2748,7 @@ exports[`Storyshots Core/Filters Default 1`] = `
           Charmander
         </h2>
         <table
-          class="sc-chKnlQ klBmRy"
+          class="sc-kIZKsT WUDsB"
         >
           <tbody>
             <tr>
@@ -2838,7 +2838,7 @@ exports[`Storyshots Core/Filters Default 1`] = `
           Charmeleon
         </h2>
         <table
-          class="sc-chKnlQ klBmRy"
+          class="sc-kIZKsT WUDsB"
         >
           <tbody>
             <tr>
@@ -2930,7 +2930,7 @@ exports[`Storyshots Core/Filters Default 1`] = `
           Charizard
         </h2>
         <table
-          class="sc-chKnlQ klBmRy"
+          class="sc-kIZKsT WUDsB"
         >
           <tbody>
             <tr>
@@ -3049,7 +3049,7 @@ exports[`Storyshots Core/Filters Default 1`] = `
           Squirtle
         </h2>
         <table
-          class="sc-chKnlQ klBmRy"
+          class="sc-kIZKsT WUDsB"
         >
           <tbody>
             <tr>
@@ -3168,7 +3168,7 @@ exports[`Storyshots Core/Filters Default 1`] = `
           Wartortle
         </h2>
         <table
-          class="sc-chKnlQ klBmRy"
+          class="sc-kIZKsT WUDsB"
         >
           <tbody>
             <tr>
@@ -3258,7 +3258,7 @@ exports[`Storyshots Core/Filters Default 1`] = `
           Blastoise
         </h2>
         <table
-          class="sc-chKnlQ klBmRy"
+          class="sc-kIZKsT WUDsB"
         >
           <tbody>
             <tr>
@@ -3348,7 +3348,7 @@ exports[`Storyshots Core/Filters Default 1`] = `
           Caterpie
         </h2>
         <table
-          class="sc-chKnlQ klBmRy"
+          class="sc-kIZKsT WUDsB"
         >
           <tbody>
             <tr>
@@ -3438,7 +3438,7 @@ exports[`Storyshots Core/Filters Default 1`] = `
           Staryu
         </h2>
         <table
-          class="sc-chKnlQ klBmRy"
+          class="sc-kIZKsT WUDsB"
         >
           <tbody>
             <tr>
@@ -3662,7 +3662,7 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
           Bulbasaur
         </h2>
         <table
-          class="sc-chKnlQ klBmRy"
+          class="sc-kIZKsT WUDsB"
         >
           <tbody>
             <tr>
@@ -3752,7 +3752,7 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
           Ivysaur
         </h2>
         <table
-          class="sc-chKnlQ klBmRy"
+          class="sc-kIZKsT WUDsB"
         >
           <tbody>
             <tr>
@@ -3842,7 +3842,7 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
           Venusaur
         </h2>
         <table
-          class="sc-chKnlQ klBmRy"
+          class="sc-kIZKsT WUDsB"
         >
           <tbody>
             <tr>
@@ -3932,7 +3932,7 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
           Charmander
         </h2>
         <table
-          class="sc-chKnlQ klBmRy"
+          class="sc-kIZKsT WUDsB"
         >
           <tbody>
             <tr>
@@ -4022,7 +4022,7 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
           Charmeleon
         </h2>
         <table
-          class="sc-chKnlQ klBmRy"
+          class="sc-kIZKsT WUDsB"
         >
           <tbody>
             <tr>
@@ -4114,7 +4114,7 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
           Charizard
         </h2>
         <table
-          class="sc-chKnlQ klBmRy"
+          class="sc-kIZKsT WUDsB"
         >
           <tbody>
             <tr>
@@ -4233,7 +4233,7 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
           Squirtle
         </h2>
         <table
-          class="sc-chKnlQ klBmRy"
+          class="sc-kIZKsT WUDsB"
         >
           <tbody>
             <tr>
@@ -4352,7 +4352,7 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
           Wartortle
         </h2>
         <table
-          class="sc-chKnlQ klBmRy"
+          class="sc-kIZKsT WUDsB"
         >
           <tbody>
             <tr>
@@ -4442,7 +4442,7 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
           Blastoise
         </h2>
         <table
-          class="sc-chKnlQ klBmRy"
+          class="sc-kIZKsT WUDsB"
         >
           <tbody>
             <tr>
@@ -4532,7 +4532,7 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
           Caterpie
         </h2>
         <table
-          class="sc-chKnlQ klBmRy"
+          class="sc-kIZKsT WUDsB"
         >
           <tbody>
             <tr>
@@ -4622,7 +4622,7 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
           Staryu
         </h2>
         <table
-          class="sc-chKnlQ klBmRy"
+          class="sc-kIZKsT WUDsB"
         >
           <tbody>
             <tr>
@@ -4934,7 +4934,7 @@ exports[`Storyshots Core/Filters Render Modes 1`] = `
           Squirtle
         </h2>
         <table
-          class="sc-chKnlQ klBmRy"
+          class="sc-kIZKsT WUDsB"
         >
           <tbody>
             <tr>

--- a/src/components/Form/__snapshots__/Form.stories.storyshot
+++ b/src/components/Form/__snapshots__/Form.stories.storyshot
@@ -262,7 +262,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                         id="root_first_seen__description"
                       >
                         <div
-                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-kIZKsT geXume"
+                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-ckCjom goeKAB"
                         >
                           <div>
                             <p
@@ -305,7 +305,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                         id="root_poke_password__description"
                       >
                         <div
-                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-kIZKsT geXume"
+                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-ckCjom goeKAB"
                         >
                           <div>
                             <p
@@ -412,7 +412,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                           id="root_tags__description"
                         >
                           <div
-                            class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-kIZKsT geXume"
+                            class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-ckCjom goeKAB"
                           >
                             <div>
                               <p
@@ -744,7 +744,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                         id="root_first_seen__description"
                       >
                         <div
-                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-kIZKsT geXume"
+                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-ckCjom goeKAB"
                         >
                           <div>
                             <p
@@ -787,7 +787,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                         id="root_poke_password__description"
                       >
                         <div
-                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-kIZKsT geXume"
+                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-ckCjom goeKAB"
                         >
                           <div>
                             <p
@@ -894,7 +894,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                           id="root_tags__description"
                         >
                           <div
-                            class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-kIZKsT geXume"
+                            class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-ckCjom goeKAB"
                           >
                             <div>
                               <p
@@ -1234,7 +1234,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                         id="root_first_seen__description"
                       >
                         <div
-                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-kIZKsT geXume"
+                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-ckCjom goeKAB"
                         >
                           <div>
                             <p
@@ -1278,7 +1278,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                         id="root_poke_password__description"
                       >
                         <div
-                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-kIZKsT geXume"
+                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-ckCjom goeKAB"
                         >
                           <div>
                             <p
@@ -1387,7 +1387,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                           id="root_tags__description"
                         >
                           <div
-                            class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-kIZKsT geXume"
+                            class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-ckCjom goeKAB"
                           >
                             <div>
                               <p
@@ -1719,7 +1719,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                         id="root_first_seen__description"
                       >
                         <div
-                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-kIZKsT geXume"
+                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-ckCjom goeKAB"
                         >
                           <div>
                             <p
@@ -1762,7 +1762,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                         id="root_poke_password__description"
                       >
                         <div
-                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-kIZKsT geXume"
+                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-ckCjom goeKAB"
                         >
                           <div>
                             <p
@@ -1869,7 +1869,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                           id="root_tags__description"
                         >
                           <div
-                            class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-kIZKsT geXume"
+                            class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-ckCjom goeKAB"
                           >
                             <div>
                               <p
@@ -2196,7 +2196,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                         id="root_first_seen__description"
                       >
                         <div
-                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-kIZKsT geXume"
+                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-ckCjom goeKAB"
                         >
                           <div>
                             <p
@@ -2239,7 +2239,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                         id="root_poke_password__description"
                       >
                         <div
-                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-kIZKsT geXume"
+                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-ckCjom goeKAB"
                         >
                           <div>
                             <p
@@ -2346,7 +2346,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                           id="root_tags__description"
                         >
                           <div
-                            class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-kIZKsT geXume"
+                            class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-ckCjom goeKAB"
                           >
                             <div>
                               <p
@@ -2571,7 +2571,7 @@ exports[`Storyshots Core/Form With Extra Widgets 1`] = `
       class="sc-gKXOVf QRSBg sc-iBkjds bBZNJf"
     >
       <div
-        class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-kIZKsT geXume"
+        class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-ckCjom goeKAB"
       >
         <div>
           <h1
@@ -3431,7 +3431,7 @@ Rendition contains widgets for rendering Markdown and Mermaid text formats that 
                         Markdown
                       </label>
                       <div
-                        class="sc-geuGuN iFFFfs"
+                        class="sc-gPpHY gmynQJ"
                         id="simplemde-editor-1-wrapper"
                       >
                         <textarea
@@ -3719,7 +3719,7 @@ Rendition contains widgets for rendering Markdown and Mermaid text formats that 
                         Captcha
                       </label>
                       <div
-                        class="sc-ckCjom dRTbpO"
+                        class="sc-geuGuN jDxJny"
                       />
                     </div>
                   </div>
@@ -3816,7 +3816,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                         id="root_Name"
                       >
                         <div
-                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-kIZKsT geXume"
+                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-ckCjom goeKAB"
                         >
                           <div>
                             <p
@@ -4026,7 +4026,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                         id="root_first_seen__description"
                       >
                         <div
-                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-kIZKsT geXume"
+                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-ckCjom goeKAB"
                         >
                           <div>
                             <p
@@ -4069,7 +4069,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                         id="root_poke_password__description"
                       >
                         <div
-                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-kIZKsT geXume"
+                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-ckCjom goeKAB"
                         >
                           <div>
                             <p
@@ -4200,7 +4200,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                           id="root_tags__description"
                         >
                           <div
-                            class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-kIZKsT geXume"
+                            class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-ckCjom goeKAB"
                           >
                             <div>
                               <p
@@ -4886,7 +4886,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                         id="root_first_seen__description"
                       >
                         <div
-                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-kIZKsT geXume"
+                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-ckCjom goeKAB"
                         >
                           <div>
                             <p
@@ -4929,7 +4929,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                         id="root_poke_password__description"
                       >
                         <div
-                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-kIZKsT geXume"
+                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-ckCjom goeKAB"
                         >
                           <div>
                             <p
@@ -5060,7 +5060,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                           id="root_tags__description"
                         >
                           <div
-                            class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-kIZKsT geXume"
+                            class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-ckCjom goeKAB"
                           >
                             <div>
                               <p
@@ -5201,7 +5201,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                             class="sc-gKXOVf QRSBg sc-iBkjds QRvXl sc-hHLeRK dzJWYl sc-dFdIVH wJFOl"
                           >
                             <div
-                              class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-kIZKsT geXume"
+                              class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-ckCjom goeKAB"
                             >
                               <div>
                                 <p
@@ -5431,7 +5431,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                         id="root_first_seen__description"
                       >
                         <div
-                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-kIZKsT geXume"
+                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-ckCjom goeKAB"
                         >
                           <div>
                             <p
@@ -5474,7 +5474,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                         id="root_poke_password__description"
                       >
                         <div
-                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-kIZKsT geXume"
+                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-ckCjom goeKAB"
                         >
                           <div>
                             <p
@@ -5605,7 +5605,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                           id="root_tags__description"
                         >
                           <div
-                            class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-kIZKsT geXume"
+                            class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-ckCjom goeKAB"
                           >
                             <div>
                               <p

--- a/src/components/Navbar/__snapshots__/Navbar.stories.storyshot
+++ b/src/components/Navbar/__snapshots__/Navbar.stories.storyshot
@@ -9,7 +9,7 @@ exports[`Storyshots Core/Navbar Default 1`] = `
       class="sc-gKXOVf QRSBg sc-iBkjds dNoAeF"
     >
       <div
-        class="sc-gKXOVf QRSBg sc-iBkjds bkEkLP sc-jKDlA-D loJEki sc-bTMaZy iamCcR"
+        class="sc-gKXOVf QRSBg sc-iBkjds bkEkLP sc-iWajrY kplmVJ sc-jKDlA-D cLwCtV"
       >
         <div
           class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK lQaPL"
@@ -18,7 +18,7 @@ exports[`Storyshots Core/Navbar Default 1`] = `
             class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY"
           >
             <div
-              class="sc-gKXOVf QRSBg sc-iBkjds fcYCAY sc-tQuYZ gNNjZm"
+              class="sc-gKXOVf QRSBg sc-iBkjds fcYCAY sc-bTMaZy dRHQxg"
             >
               <a
                 class="sc-eKBdFk gZLGMu sc-bUbCnL kxhRCL"
@@ -33,7 +33,7 @@ exports[`Storyshots Core/Navbar Default 1`] = `
               </a>
             </div>
             <div
-              class="sc-gKXOVf QRSBg sc-iBkjds dyRNlF sc-dSuTWQ cPshHd"
+              class="sc-gKXOVf QRSBg sc-iBkjds dyRNlF sc-tQuYZ fTCKDa"
             >
               <svg
                 aria-hidden="true"
@@ -53,7 +53,7 @@ exports[`Storyshots Core/Navbar Default 1`] = `
             </div>
           </div>
           <div
-            class="sc-gKXOVf QRSBg sc-iBkjds guQguK sc-hHLeRK sc-hZFzCs iKIurY MZUUd"
+            class="sc-gKXOVf QRSBg sc-iBkjds guQguK sc-hHLeRK sc-dSuTWQ iKIurY cboQvr"
           >
             <div
               class="sc-gKXOVf QRSBg sc-iBkjds fdUOap sc-hHLeRK lQaPL"

--- a/src/components/Notifications/__snapshots__/Notifications.stories.storyshot
+++ b/src/components/Notifications/__snapshots__/Notifications.stories.storyshot
@@ -9,7 +9,7 @@ exports[`Storyshots Core/Notifications Default 1`] = `
       class="sc-gKXOVf QRSBg sc-iBkjds iqcFkW sc-hHLeRK dzJWYl"
     >
       <div
-        class="react-notification-root sc-iWajrY bcEHmZ"
+        class="react-notification-root sc-fxvKuh qqLpx"
       >
         <div
           class="notification-container-top-left"
@@ -25,7 +25,7 @@ exports[`Storyshots Core/Notifications Default 1`] = `
               class="notification-item n-child"
             >
               <div
-                class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-dmRaPn iKIurY gdKzWA sc-gicCDI cmHWGP sc-fxvKuh kcOext"
+                class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-dmRaPn iKIurY gdKzWA sc-gicCDI cmHWGP sc-gJwTLC cBbmFu"
               >
                 
                 <div
@@ -71,7 +71,7 @@ exports[`Storyshots Core/Notifications Default 1`] = `
               class="notification-item n-child"
             >
               <div
-                class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-dmRaPn iKIurY gdKzWA sc-gicCDI cmHWGP sc-fxvKuh kcOext"
+                class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-dmRaPn iKIurY gdKzWA sc-gicCDI cmHWGP sc-gJwTLC cBbmFu"
               >
                 
                 <div
@@ -167,7 +167,7 @@ exports[`Storyshots Core/Notifications Positioning 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
   >
     <div
-      class="react-notification-root sc-iWajrY bcEHmZ"
+      class="react-notification-root sc-fxvKuh qqLpx"
     >
       <div
         class="notification-container-top-left"
@@ -180,7 +180,7 @@ exports[`Storyshots Core/Notifications Positioning 1`] = `
             class="notification-item n-child"
           >
             <div
-              class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-dmRaPn iKIurY gdKzWA sc-gicCDI cmHWGP sc-fxvKuh kcOext"
+              class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-dmRaPn iKIurY gdKzWA sc-gicCDI cmHWGP sc-gJwTLC cBbmFu"
             >
               
               <div
@@ -230,7 +230,7 @@ exports[`Storyshots Core/Notifications Positioning 1`] = `
             class="notification-item n-child"
           >
             <div
-              class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-dmRaPn iKIurY gdKzWA sc-gicCDI cmHWGP sc-fxvKuh kcOext"
+              class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-dmRaPn iKIurY gdKzWA sc-gicCDI cmHWGP sc-gJwTLC cBbmFu"
             >
               
               <div
@@ -280,7 +280,7 @@ exports[`Storyshots Core/Notifications Positioning 1`] = `
             class="notification-item n-child"
           >
             <div
-              class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-dmRaPn iKIurY gdKzWA sc-gicCDI cmHWGP sc-fxvKuh kcOext"
+              class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-dmRaPn iKIurY gdKzWA sc-gicCDI cmHWGP sc-gJwTLC cBbmFu"
             >
               
               <div
@@ -330,7 +330,7 @@ exports[`Storyshots Core/Notifications Positioning 1`] = `
             class="notification-item n-child"
           >
             <div
-              class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-dmRaPn iKIurY gdKzWA sc-gicCDI cmHWGP sc-fxvKuh kcOext"
+              class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-dmRaPn iKIurY gdKzWA sc-gicCDI cmHWGP sc-gJwTLC cBbmFu"
             >
               
               <div
@@ -380,7 +380,7 @@ exports[`Storyshots Core/Notifications Positioning 1`] = `
             class="notification-item n-child"
           >
             <div
-              class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-dmRaPn iKIurY gdKzWA sc-gicCDI cmHWGP sc-fxvKuh kcOext"
+              class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-dmRaPn iKIurY gdKzWA sc-gicCDI cmHWGP sc-gJwTLC cBbmFu"
             >
               
               <div
@@ -433,7 +433,7 @@ exports[`Storyshots Core/Notifications Positioning 1`] = `
               class="notification-item n-child"
             >
               <div
-                class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-dmRaPn iKIurY gdKzWA sc-gicCDI cmHWGP sc-fxvKuh kcOext"
+                class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-dmRaPn iKIurY gdKzWA sc-gicCDI cmHWGP sc-gJwTLC cBbmFu"
               >
                 
                 <div
@@ -484,7 +484,7 @@ exports[`Storyshots Core/Notifications Positioning 1`] = `
             class="notification-item n-child"
           >
             <div
-              class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-dmRaPn iKIurY gdKzWA sc-gicCDI cmHWGP sc-fxvKuh kcOext"
+              class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-dmRaPn iKIurY gdKzWA sc-gicCDI cmHWGP sc-gJwTLC cBbmFu"
             >
               
               <div
@@ -591,7 +591,7 @@ exports[`Storyshots Core/Notifications Types 1`] = `
       class="sc-gKXOVf QRSBg sc-iBkjds iqcFkW sc-hHLeRK dzJWYl"
     >
       <div
-        class="react-notification-root sc-iWajrY bcEHmZ"
+        class="react-notification-root sc-fxvKuh qqLpx"
       >
         <div
           class="notification-container-top-left"
@@ -607,7 +607,7 @@ exports[`Storyshots Core/Notifications Types 1`] = `
               class="notification-item n-child"
             >
               <div
-                class="sc-gKXOVf QRSBg sc-iBkjds dnRYSM sc-hHLeRK sc-dmRaPn iKIurY FGhRa sc-gicCDI cmHWGP sc-fxvKuh kcOext"
+                class="sc-gKXOVf QRSBg sc-iBkjds dnRYSM sc-hHLeRK sc-dmRaPn iKIurY FGhRa sc-gicCDI cmHWGP sc-gJwTLC cBbmFu"
               >
                 <div
                   class="sc-ivTmOn dNJphr sc-cxabCf eemXLs"
@@ -675,7 +675,7 @@ exports[`Storyshots Core/Notifications Types 1`] = `
               class="notification-item n-child"
             >
               <div
-                class="sc-gKXOVf QRSBg sc-iBkjds gdzJDO sc-hHLeRK sc-dmRaPn iKIurY kIPQvp sc-gicCDI cmHWGP sc-fxvKuh kcOext"
+                class="sc-gKXOVf QRSBg sc-iBkjds gdzJDO sc-hHLeRK sc-dmRaPn iKIurY kIPQvp sc-gicCDI cmHWGP sc-gJwTLC cBbmFu"
               >
                 <div
                   class="sc-ivTmOn dNJphr sc-cxabCf bLiaOm"
@@ -743,7 +743,7 @@ exports[`Storyshots Core/Notifications Types 1`] = `
               class="notification-item n-child"
             >
               <div
-                class="sc-gKXOVf QRSBg sc-iBkjds gwVQPy sc-hHLeRK sc-dmRaPn iKIurY blUbwm sc-gicCDI cmHWGP sc-fxvKuh kcOext"
+                class="sc-gKXOVf QRSBg sc-iBkjds gwVQPy sc-hHLeRK sc-dmRaPn iKIurY blUbwm sc-gicCDI cmHWGP sc-gJwTLC cBbmFu"
               >
                 <div
                   class="sc-ivTmOn dNJphr sc-cxabCf CTiCS"
@@ -811,7 +811,7 @@ exports[`Storyshots Core/Notifications Types 1`] = `
               class="notification-item n-child"
             >
               <div
-                class="sc-gKXOVf QRSBg sc-iBkjds gDBmYX sc-hHLeRK sc-dmRaPn iKIurY jrmdGN sc-gicCDI cmHWGP sc-fxvKuh kcOext"
+                class="sc-gKXOVf QRSBg sc-iBkjds gDBmYX sc-hHLeRK sc-dmRaPn iKIurY jrmdGN sc-gicCDI cmHWGP sc-gJwTLC cBbmFu"
               >
                 <div
                   class="sc-gKXOVf ckXSHX sc-iBkjds iAZiqN"

--- a/src/components/Table/TableBase.tsx
+++ b/src/components/Table/TableBase.tsx
@@ -130,10 +130,6 @@ const Base = styled.div<InternalTableBaseProps>`
 	}
 `;
 
-const HeaderButton = styled(Button)`
-	display: block;
-`;
-
 type CheckedTypes = 'none' | 'some' | 'all';
 
 interface TableBaseState<T> {
@@ -580,7 +576,7 @@ export class TableBase<T> extends React.Component<
 												data-display="table-cell"
 												key={item.key || (item.field as string)}
 											>
-												<HeaderButton
+												<Button
 													data-field={item.field}
 													plain
 													primary={sort.field === item.field}
@@ -596,7 +592,7 @@ export class TableBase<T> extends React.Component<
 																: ''
 														}
 													/>
-												</HeaderButton>
+												</Button>
 											</div>
 										);
 									}

--- a/src/components/Table/__snapshots__/Table.stories.storyshot
+++ b/src/components/Table/__snapshots__/Table.stories.storyshot
@@ -6,7 +6,7 @@ exports[`Storyshots Core/Table Default 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
   >
     <div
-      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-grVGCS iKIurY ikgPpo"
+      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-iJkHyd iKIurY bAXBaZ"
     >
       <div
         class="sc-gKXOVf ckXSHX sc-iBkjds gNjzDq sc-hHLeRK eTSHtc"
@@ -15,7 +15,7 @@ exports[`Storyshots Core/Table Default 1`] = `
           class="sc-fmrZth clkOUX"
         >
           <div
-            class="sc-eXBvqI jmlAON sc-kngDgl juYrxT"
+            class="sc-eXBvqI jmlAON sc-afnQL gYeoiq"
           >
             <div
               data-display="table-head"
@@ -27,7 +27,7 @@ exports[`Storyshots Core/Table Default 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv sc-iFwKgL iVbDRm"
+                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv"
                     data-field="Name"
                     type="button"
                   >
@@ -55,7 +55,7 @@ exports[`Storyshots Core/Table Default 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv sc-iFwKgL iVbDRm"
+                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv"
                     data-field="pokedex_number"
                     type="button"
                   >
@@ -83,7 +83,7 @@ exports[`Storyshots Core/Table Default 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv sc-iFwKgL iVbDRm"
+                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv"
                     data-field="Category"
                     type="button"
                   >
@@ -111,7 +111,7 @@ exports[`Storyshots Core/Table Default 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv sc-iFwKgL iVbDRm"
+                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv"
                     data-field="first_seen"
                     type="button"
                   >
@@ -509,7 +509,7 @@ exports[`Storyshots Core/Table Sorted 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
   >
     <div
-      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-grVGCS iKIurY ikgPpo"
+      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-iJkHyd iKIurY bAXBaZ"
     >
       <div
         class="sc-gKXOVf ckXSHX sc-iBkjds gNjzDq sc-hHLeRK eTSHtc"
@@ -518,7 +518,7 @@ exports[`Storyshots Core/Table Sorted 1`] = `
           class="sc-fmrZth clkOUX"
         >
           <div
-            class="sc-eXBvqI jmlAON sc-kngDgl juYrxT"
+            class="sc-eXBvqI jmlAON sc-afnQL gYeoiq"
           >
             <div
               data-display="table-head"
@@ -530,7 +530,7 @@ exports[`Storyshots Core/Table Sorted 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 iFDLDn sc-breuTD sc-bjUoiL Krizp dANmhT sc-dIouRR kAoSkv sc-iFwKgL iVbDRm"
+                    class="StyledButton-sc-323bzc-0 iFDLDn sc-breuTD sc-bjUoiL Krizp dANmhT sc-dIouRR kAoSkv"
                     data-field="Name"
                     type="button"
                   >
@@ -558,7 +558,7 @@ exports[`Storyshots Core/Table Sorted 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv sc-iFwKgL iVbDRm"
+                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv"
                     data-field="pokedex_number"
                     type="button"
                   >
@@ -586,7 +586,7 @@ exports[`Storyshots Core/Table Sorted 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv sc-iFwKgL iVbDRm"
+                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv"
                     data-field="Category"
                     type="button"
                   >
@@ -614,7 +614,7 @@ exports[`Storyshots Core/Table Sorted 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv sc-iFwKgL iVbDRm"
+                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv"
                     data-field="first_seen"
                     type="button"
                   >
@@ -1012,7 +1012,7 @@ exports[`Storyshots Core/Table With Anchor Rows 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
   >
     <div
-      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-grVGCS iKIurY ikgPpo"
+      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-iJkHyd iKIurY bAXBaZ"
     >
       <div
         class="sc-gKXOVf ckXSHX sc-iBkjds gNjzDq sc-hHLeRK eTSHtc"
@@ -1021,7 +1021,7 @@ exports[`Storyshots Core/Table With Anchor Rows 1`] = `
           class="sc-fmrZth clkOUX"
         >
           <div
-            class="sc-eXBvqI gomuLP sc-kngDgl juYrxT"
+            class="sc-eXBvqI gomuLP sc-afnQL gYeoiq"
           >
             <div
               data-display="table-head"
@@ -1033,7 +1033,7 @@ exports[`Storyshots Core/Table With Anchor Rows 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv sc-iFwKgL iVbDRm"
+                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv"
                     data-field="Name"
                     type="button"
                   >
@@ -1061,7 +1061,7 @@ exports[`Storyshots Core/Table With Anchor Rows 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv sc-iFwKgL iVbDRm"
+                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv"
                     data-field="pokedex_number"
                     type="button"
                   >
@@ -1089,7 +1089,7 @@ exports[`Storyshots Core/Table With Anchor Rows 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv sc-iFwKgL iVbDRm"
+                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv"
                     data-field="Category"
                     type="button"
                   >
@@ -1117,7 +1117,7 @@ exports[`Storyshots Core/Table With Anchor Rows 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv sc-iFwKgL iVbDRm"
+                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv"
                     data-field="first_seen"
                     type="button"
                   >
@@ -1603,7 +1603,7 @@ exports[`Storyshots Core/Table With Checkboxes 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
   >
     <div
-      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-grVGCS iKIurY ikgPpo"
+      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-iJkHyd iKIurY bAXBaZ"
     >
       <div
         class="sc-gKXOVf ckXSHX sc-iBkjds gNjzDq sc-hHLeRK eTSHtc"
@@ -1612,7 +1612,7 @@ exports[`Storyshots Core/Table With Checkboxes 1`] = `
           class="sc-fmrZth clkOUX"
         >
           <div
-            class="sc-eXBvqI jzuVmz sc-kngDgl lbrOJe"
+            class="sc-eXBvqI jzuVmz sc-afnQL lGfaj"
           >
             <div
               data-display="table-head"
@@ -1659,7 +1659,7 @@ exports[`Storyshots Core/Table With Checkboxes 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv sc-iFwKgL iVbDRm"
+                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv"
                     data-field="Name"
                     type="button"
                   >
@@ -1687,7 +1687,7 @@ exports[`Storyshots Core/Table With Checkboxes 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv sc-iFwKgL iVbDRm"
+                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv"
                     data-field="pokedex_number"
                     type="button"
                   >
@@ -1715,7 +1715,7 @@ exports[`Storyshots Core/Table With Checkboxes 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv sc-iFwKgL iVbDRm"
+                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv"
                     data-field="Category"
                     type="button"
                   >
@@ -1743,7 +1743,7 @@ exports[`Storyshots Core/Table With Checkboxes 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv sc-iFwKgL iVbDRm"
+                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv"
                     data-field="first_seen"
                     type="button"
                   >
@@ -2452,7 +2452,7 @@ exports[`Storyshots Core/Table With Conditional Row Classes 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
   >
     <div
-      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-grVGCS iKIurY ikgPpo"
+      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-iJkHyd iKIurY bAXBaZ"
     >
       <div
         class="sc-gKXOVf ckXSHX sc-iBkjds gNjzDq sc-hHLeRK eTSHtc"
@@ -2461,7 +2461,7 @@ exports[`Storyshots Core/Table With Conditional Row Classes 1`] = `
           class="sc-fmrZth clkOUX"
         >
           <div
-            class="sc-eXBvqI jmlAON sc-kngDgl juYrxT"
+            class="sc-eXBvqI jmlAON sc-afnQL gYeoiq"
           >
             <div
               data-display="table-head"
@@ -2473,7 +2473,7 @@ exports[`Storyshots Core/Table With Conditional Row Classes 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv sc-iFwKgL iVbDRm"
+                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv"
                     data-field="Name"
                     type="button"
                   >
@@ -2501,7 +2501,7 @@ exports[`Storyshots Core/Table With Conditional Row Classes 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv sc-iFwKgL iVbDRm"
+                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv"
                     data-field="pokedex_number"
                     type="button"
                   >
@@ -2529,7 +2529,7 @@ exports[`Storyshots Core/Table With Conditional Row Classes 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv sc-iFwKgL iVbDRm"
+                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv"
                     data-field="Category"
                     type="button"
                   >
@@ -2557,7 +2557,7 @@ exports[`Storyshots Core/Table With Conditional Row Classes 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv sc-iFwKgL iVbDRm"
+                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv"
                     data-field="first_seen"
                     type="button"
                   >
@@ -2955,7 +2955,7 @@ exports[`Storyshots Core/Table With Custom Columns 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
   >
     <div
-      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-grVGCS iKIurY ikgPpo"
+      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-iJkHyd iKIurY bAXBaZ"
     >
       <div
         class="sc-gKXOVf ckXSHX sc-iBkjds gNjzDq sc-hHLeRK eTSHtc"
@@ -2964,7 +2964,7 @@ exports[`Storyshots Core/Table With Custom Columns 1`] = `
           class="sc-fmrZth clkOUX"
         >
           <div
-            class="sc-eXBvqI jmlAON sc-kngDgl ccAfIL"
+            class="sc-eXBvqI jmlAON sc-afnQL bbgvAm"
           >
             <div
               data-display="table-head"
@@ -2976,7 +2976,7 @@ exports[`Storyshots Core/Table With Custom Columns 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv sc-iFwKgL iVbDRm"
+                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv"
                     data-field="Name"
                     type="button"
                   >
@@ -3004,7 +3004,7 @@ exports[`Storyshots Core/Table With Custom Columns 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv sc-iFwKgL iVbDRm"
+                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv"
                     data-field="pokedex_number"
                     type="button"
                   >
@@ -3032,7 +3032,7 @@ exports[`Storyshots Core/Table With Custom Columns 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv sc-iFwKgL iVbDRm"
+                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv"
                     data-field="Category"
                     type="button"
                   >
@@ -3060,7 +3060,7 @@ exports[`Storyshots Core/Table With Custom Columns 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv sc-iFwKgL iVbDRm"
+                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv"
                     data-field="first_seen"
                     type="button"
                   >
@@ -3448,7 +3448,7 @@ exports[`Storyshots Core/Table With Custom Columns 1`] = `
         </div>
       </div>
       <div
-        class="sc-afnQL ipIVCr"
+        class="sc-grVGCS iGNLvD"
       >
         <div
           class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-fXynhf ifKwFV sc-jIAOiI bpUFTZ"
@@ -3465,7 +3465,7 @@ exports[`Storyshots Core/Table With Custom Columns 1`] = `
               >
                 <svg
                   aria-hidden="true"
-                  class="svg-inline--fa fa-gear sc-iqGgem bLXaTV"
+                  class="svg-inline--fa fa-gear sc-iFwKgL fbKFaR"
                   data-icon="gear"
                   data-prefix="fas"
                   focusable="false"
@@ -3509,7 +3509,7 @@ exports[`Storyshots Core/Table With Fuzzy Pager 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
   >
     <div
-      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-grVGCS iKIurY ikgPpo"
+      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-iJkHyd iKIurY bAXBaZ"
     >
       <div
         class="sc-gKXOVf ckXSHX sc-iBkjds gNjzDq sc-hHLeRK eTSHtc"
@@ -3587,7 +3587,7 @@ exports[`Storyshots Core/Table With Fuzzy Pager 1`] = `
           class="sc-fmrZth clkOUX"
         >
           <div
-            class="sc-eXBvqI jmlAON sc-kngDgl juYrxT"
+            class="sc-eXBvqI jmlAON sc-afnQL gYeoiq"
           >
             <div
               data-display="table-head"
@@ -3599,7 +3599,7 @@ exports[`Storyshots Core/Table With Fuzzy Pager 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv sc-iFwKgL iVbDRm"
+                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv"
                     data-field="Name"
                     type="button"
                   >
@@ -3627,7 +3627,7 @@ exports[`Storyshots Core/Table With Fuzzy Pager 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv sc-iFwKgL iVbDRm"
+                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv"
                     data-field="pokedex_number"
                     type="button"
                   >
@@ -3655,7 +3655,7 @@ exports[`Storyshots Core/Table With Fuzzy Pager 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv sc-iFwKgL iVbDRm"
+                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv"
                     data-field="Category"
                     type="button"
                   >
@@ -3683,7 +3683,7 @@ exports[`Storyshots Core/Table With Fuzzy Pager 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv sc-iFwKgL iVbDRm"
+                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv"
                     data-field="first_seen"
                     type="button"
                   >
@@ -3886,7 +3886,7 @@ exports[`Storyshots Core/Table With Highlighted Rows 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
   >
     <div
-      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-grVGCS iKIurY ikgPpo"
+      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-iJkHyd iKIurY bAXBaZ"
     >
       <div
         class="sc-gKXOVf ckXSHX sc-iBkjds gNjzDq sc-hHLeRK eTSHtc"
@@ -3895,7 +3895,7 @@ exports[`Storyshots Core/Table With Highlighted Rows 1`] = `
           class="sc-fmrZth clkOUX"
         >
           <div
-            class="sc-eXBvqI jmlAON sc-kngDgl juYrxT"
+            class="sc-eXBvqI jmlAON sc-afnQL gYeoiq"
           >
             <div
               data-display="table-head"
@@ -3907,7 +3907,7 @@ exports[`Storyshots Core/Table With Highlighted Rows 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv sc-iFwKgL iVbDRm"
+                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv"
                     data-field="Name"
                     type="button"
                   >
@@ -3935,7 +3935,7 @@ exports[`Storyshots Core/Table With Highlighted Rows 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv sc-iFwKgL iVbDRm"
+                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv"
                     data-field="pokedex_number"
                     type="button"
                   >
@@ -3963,7 +3963,7 @@ exports[`Storyshots Core/Table With Highlighted Rows 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv sc-iFwKgL iVbDRm"
+                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv"
                     data-field="Category"
                     type="button"
                   >
@@ -3991,7 +3991,7 @@ exports[`Storyshots Core/Table With Highlighted Rows 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv sc-iFwKgL iVbDRm"
+                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv"
                     data-field="first_seen"
                     type="button"
                   >
@@ -4389,7 +4389,7 @@ exports[`Storyshots Core/Table With Pager 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
   >
     <div
-      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-grVGCS iKIurY ikgPpo"
+      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-iJkHyd iKIurY bAXBaZ"
     >
       <div
         class="sc-gKXOVf ckXSHX sc-iBkjds gNjzDq sc-hHLeRK eTSHtc"
@@ -4467,7 +4467,7 @@ exports[`Storyshots Core/Table With Pager 1`] = `
           class="sc-fmrZth clkOUX"
         >
           <div
-            class="sc-eXBvqI jmlAON sc-kngDgl juYrxT"
+            class="sc-eXBvqI jmlAON sc-afnQL gYeoiq"
           >
             <div
               data-display="table-head"
@@ -4479,7 +4479,7 @@ exports[`Storyshots Core/Table With Pager 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv sc-iFwKgL iVbDRm"
+                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv"
                     data-field="Name"
                     type="button"
                   >
@@ -4507,7 +4507,7 @@ exports[`Storyshots Core/Table With Pager 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv sc-iFwKgL iVbDRm"
+                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv"
                     data-field="pokedex_number"
                     type="button"
                   >
@@ -4535,7 +4535,7 @@ exports[`Storyshots Core/Table With Pager 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv sc-iFwKgL iVbDRm"
+                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv"
                     data-field="Category"
                     type="button"
                   >
@@ -4563,7 +4563,7 @@ exports[`Storyshots Core/Table With Pager 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv sc-iFwKgL iVbDRm"
+                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv"
                     data-field="first_seen"
                     type="button"
                   >
@@ -4766,7 +4766,7 @@ exports[`Storyshots Core/Table With Prefix 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
   >
     <div
-      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-grVGCS iKIurY ikgPpo"
+      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-iJkHyd iKIurY bAXBaZ"
     >
       <div
         class="sc-gKXOVf ckXSHX sc-iBkjds gNjzDq sc-hHLeRK eTSHtc"
@@ -4775,7 +4775,7 @@ exports[`Storyshots Core/Table With Prefix 1`] = `
           class="sc-fmrZth clkOUX"
         >
           <div
-            class="sc-eXBvqI jmlAON sc-kngDgl juYrxT"
+            class="sc-eXBvqI jmlAON sc-afnQL gYeoiq"
           >
             <div
               data-display="table-head"
@@ -4787,7 +4787,7 @@ exports[`Storyshots Core/Table With Prefix 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv sc-iFwKgL iVbDRm"
+                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv"
                     data-field="Name"
                     type="button"
                   >
@@ -4815,7 +4815,7 @@ exports[`Storyshots Core/Table With Prefix 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv sc-iFwKgL iVbDRm"
+                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv"
                     data-field="pokedex_number"
                     type="button"
                   >
@@ -4843,7 +4843,7 @@ exports[`Storyshots Core/Table With Prefix 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv sc-iFwKgL iVbDRm"
+                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv"
                     data-field="Category"
                     type="button"
                   >
@@ -4871,7 +4871,7 @@ exports[`Storyshots Core/Table With Prefix 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv sc-iFwKgL iVbDRm"
+                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv"
                     data-field="first_seen"
                     type="button"
                   >
@@ -5291,7 +5291,7 @@ exports[`Storyshots Core/Table With Row Click 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
   >
     <div
-      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-grVGCS iKIurY ikgPpo"
+      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-iJkHyd iKIurY bAXBaZ"
     >
       <div
         class="sc-gKXOVf ckXSHX sc-iBkjds gNjzDq sc-hHLeRK eTSHtc"
@@ -5300,7 +5300,7 @@ exports[`Storyshots Core/Table With Row Click 1`] = `
           class="sc-fmrZth clkOUX"
         >
           <div
-            class="sc-eXBvqI gomuLP sc-kngDgl juYrxT"
+            class="sc-eXBvqI gomuLP sc-afnQL gYeoiq"
           >
             <div
               data-display="table-head"
@@ -5312,7 +5312,7 @@ exports[`Storyshots Core/Table With Row Click 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv sc-iFwKgL iVbDRm"
+                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv"
                     data-field="Name"
                     type="button"
                   >
@@ -5340,7 +5340,7 @@ exports[`Storyshots Core/Table With Row Click 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv sc-iFwKgL iVbDRm"
+                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv"
                     data-field="pokedex_number"
                     type="button"
                   >
@@ -5368,7 +5368,7 @@ exports[`Storyshots Core/Table With Row Click 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv sc-iFwKgL iVbDRm"
+                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv"
                     data-field="Category"
                     type="button"
                   >
@@ -5396,7 +5396,7 @@ exports[`Storyshots Core/Table With Row Click 1`] = `
                   data-display="table-cell"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv sc-iFwKgL iVbDRm"
+                    class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv"
                     data-field="first_seen"
                     type="button"
                   >

--- a/src/components/Tabs/__snapshots__/Tabs.stories.storyshot
+++ b/src/components/Tabs/__snapshots__/Tabs.stories.storyshot
@@ -6,7 +6,7 @@ exports[`Storyshots Core/Tabs Compact 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hANpeK StyledTabs-sc-a4fwxl-2 eCNyif sc-cHPgQl eiiGFR sc-KfMfS fZowXR"
+      class="StyledBox-sc-13pk1d4-0 hANpeK StyledTabs-sc-a4fwxl-2 eCNyif sc-hZFzCs dWIRre sc-cHPgQl ewVPQt"
       role="tablist"
     >
       <div
@@ -137,7 +137,7 @@ exports[`Storyshots Core/Tabs Default 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hANpeK StyledTabs-sc-a4fwxl-2 eCNyif sc-cHPgQl tbYlo sc-KfMfS fZowXR"
+      class="StyledBox-sc-13pk1d4-0 hANpeK StyledTabs-sc-a4fwxl-2 eCNyif sc-hZFzCs dPnJWL sc-cHPgQl ewVPQt"
       role="tablist"
     >
       <div
@@ -217,7 +217,7 @@ exports[`Storyshots Core/Tabs With Long Titles 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hANpeK StyledTabs-sc-a4fwxl-2 eCNyif sc-cHPgQl tbYlo sc-KfMfS fZowXR"
+      class="StyledBox-sc-13pk1d4-0 hANpeK StyledTabs-sc-a4fwxl-2 eCNyif sc-hZFzCs dPnJWL sc-cHPgQl ewVPQt"
       role="tablist"
     >
       <div

--- a/src/components/Terminal/__snapshots__/Terminal.stories.storyshot
+++ b/src/components/Terminal/__snapshots__/Terminal.stories.storyshot
@@ -9,10 +9,10 @@ exports[`Storyshots Core/Terminal Default 1`] = `
       style="height: 500px;"
     >
       <div
-        class="sc-gKXOVf ckXSHX sc-iBkjds eRknfj sc-hHLeRK sc-dkSuNL iKIurY lbAmpu"
+        class="sc-gKXOVf ckXSHX sc-iBkjds eRknfj sc-hHLeRK sc-cwpsFg iKIurY jPlCnz"
       >
         <div
-          class="sc-gKXOVf ckXSHX sc-iBkjds ipRjux sc-hHLeRK sc-gJwTLC eTSHtc gPNPjF"
+          class="sc-gKXOVf ckXSHX sc-iBkjds ipRjux sc-hHLeRK sc-dkSuNL eTSHtc lmRyIH"
         />
       </div>
     </div>
@@ -29,10 +29,10 @@ exports[`Storyshots Core/Terminal Noninteractive Terminal 1`] = `
       style="height: 500px;"
     >
       <div
-        class="sc-gKXOVf ckXSHX sc-iBkjds eRknfj sc-hHLeRK sc-dkSuNL iKIurY lbAmpu"
+        class="sc-gKXOVf ckXSHX sc-iBkjds eRknfj sc-hHLeRK sc-cwpsFg iKIurY jPlCnz"
       >
         <div
-          class="sc-gKXOVf ckXSHX sc-iBkjds ipRjux sc-hHLeRK sc-gJwTLC eTSHtc gPNPjF"
+          class="sc-gKXOVf ckXSHX sc-iBkjds ipRjux sc-hHLeRK sc-dkSuNL eTSHtc lmRyIH"
         />
       </div>
     </div>

--- a/src/extra/AutoUI/__snapshots__/AutoUI.stories.storyshot
+++ b/src/extra/AutoUI/__snapshots__/AutoUI.stories.storyshot
@@ -32,7 +32,7 @@ exports[`Storyshots Extra/AutoUI Default 1`] = `
               class="sc-gKXOVf QRSBg sc-iBkjds diGonb"
             >
               <div
-                class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-cuqtlR klWzuj eXTlRI"
+                class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-liHMlC klWzuj liUAJq"
               >
                 <div
                   class="sc-gKXOVf klumOZ sc-iBkjds hNqnWQ"
@@ -161,7 +161,7 @@ exports[`Storyshots Extra/AutoUI Default 1`] = `
               </div>
             </div>
             <div
-              class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-grVGCS iKIurY ikgPpo"
+              class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-iJkHyd iKIurY bAXBaZ"
             >
               <div
                 class="sc-gKXOVf ckXSHX sc-iBkjds gNjzDq sc-hHLeRK eTSHtc"
@@ -170,7 +170,7 @@ exports[`Storyshots Extra/AutoUI Default 1`] = `
                   class="sc-fmrZth clkOUX"
                 >
                   <div
-                    class="sc-eXBvqI gomuLP sc-kngDgl ccAfIL"
+                    class="sc-eXBvqI gomuLP sc-afnQL bbgvAm"
                   >
                     <div
                       data-display="table-head"
@@ -182,7 +182,7 @@ exports[`Storyshots Extra/AutoUI Default 1`] = `
                           data-display="table-cell"
                         >
                           <button
-                            class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv sc-iFwKgL iVbDRm"
+                            class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv"
                             data-field="title"
                             type="button"
                           >
@@ -210,7 +210,7 @@ exports[`Storyshots Extra/AutoUI Default 1`] = `
                           data-display="table-cell"
                         >
                           <button
-                            class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv sc-iFwKgL iVbDRm"
+                            class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv"
                             data-field="description"
                             type="button"
                           >
@@ -238,7 +238,7 @@ exports[`Storyshots Extra/AutoUI Default 1`] = `
                           data-display="table-cell"
                         >
                           <button
-                            class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv sc-iFwKgL iVbDRm"
+                            class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv"
                             data-field="public_key"
                             type="button"
                           >
@@ -266,7 +266,7 @@ exports[`Storyshots Extra/AutoUI Default 1`] = `
                           data-display="table-cell"
                         >
                           <button
-                            class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv sc-iFwKgL iVbDRm"
+                            class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv"
                             data-field="fingerprint"
                             type="button"
                           >
@@ -608,7 +608,7 @@ exports[`Storyshots Extra/AutoUI Default 1`] = `
                 </div>
               </div>
               <div
-                class="sc-afnQL bFozks"
+                class="sc-grVGCS iQEHCQ"
               >
                 <div
                   class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-fXynhf ifKwFV sc-jIAOiI bpUFTZ"
@@ -625,7 +625,7 @@ exports[`Storyshots Extra/AutoUI Default 1`] = `
                       >
                         <svg
                           aria-hidden="true"
-                          class="svg-inline--fa fa-gear sc-iqGgem bLXaTV"
+                          class="svg-inline--fa fa-gear sc-iFwKgL fbKFaR"
                           data-icon="gear"
                           data-prefix="fas"
                           focusable="false"

--- a/src/extra/Markdown/__snapshots__/Markdown.stories.storyshot
+++ b/src/extra/Markdown/__snapshots__/Markdown.stories.storyshot
@@ -6,7 +6,7 @@ exports[`Storyshots Extra/Markdown Customized 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
   >
     <div
-      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-grVGCS iKIurY ikgPpo"
+      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-iJkHyd iKIurY bAXBaZ"
     >
       <div
         class="sc-gKXOVf ckXSHX sc-iBkjds gNjzDq sc-hHLeRK eTSHtc"
@@ -15,7 +15,7 @@ exports[`Storyshots Extra/Markdown Customized 1`] = `
           class="sc-fmrZth clkOUX"
         >
           <div
-            class="sc-eXBvqI jmlAON sc-kngDgl juYrxT"
+            class="sc-eXBvqI jmlAON sc-afnQL gYeoiq"
           >
             <div
               data-display="table-head"
@@ -76,7 +76,7 @@ exports[`Storyshots Extra/Markdown Customized 1`] = `
                         class="sc-gKXOVf QRSBg sc-iBkjds gRMaZo"
                       >
                         <div
-                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-kIZKsT geXume"
+                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-ckCjom goeKAB"
                         >
                           <div>
                             <h1
@@ -113,7 +113,7 @@ exports[`Storyshots Extra/Markdown Customized 1`] = `
                         class="sc-gKXOVf QRSBg sc-iBkjds gRMaZo"
                       >
                         <div
-                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-kIZKsT geXume"
+                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-ckCjom goeKAB"
                         >
                           <div>
                             A title
@@ -167,7 +167,7 @@ exports[`Storyshots Extra/Markdown Customized 1`] = `
                         class="sc-gKXOVf QRSBg sc-iBkjds gRMaZo"
                       >
                         <div
-                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-kIZKsT geXume"
+                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-ckCjom goeKAB"
                         >
                           <div>
                             <h1
@@ -204,7 +204,7 @@ exports[`Storyshots Extra/Markdown Customized 1`] = `
                         class="sc-gKXOVf QRSBg sc-iBkjds gRMaZo"
                       >
                         <div
-                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-kIZKsT geXume"
+                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-ckCjom goeKAB"
                         >
                           <div>
                             A title
@@ -252,7 +252,7 @@ exports[`Storyshots Extra/Markdown Customized 1`] = `
                         class="sc-gKXOVf QRSBg sc-iBkjds gRMaZo"
                       >
                         <div
-                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-kIZKsT geXume"
+                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-ckCjom goeKAB"
                         >
                           <div>
                             <h1
@@ -289,7 +289,7 @@ exports[`Storyshots Extra/Markdown Customized 1`] = `
                         class="sc-gKXOVf QRSBg sc-iBkjds gRMaZo"
                       >
                         <div
-                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-kIZKsT geXume"
+                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-ckCjom goeKAB"
                         >
                           <div>
                             <h1
@@ -320,7 +320,7 @@ exports[`Storyshots Extra/Markdown Default 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
   >
     <div
-      class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-kIZKsT geXume"
+      class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-ckCjom goeKAB"
     >
       <div>
         <h1
@@ -1126,7 +1126,7 @@ exports[`Storyshots Extra/Markdown With Decorators 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
   >
     <div
-      class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-kIZKsT geXume"
+      class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-ckCjom goeKAB"
     >
       <div>
         <p

--- a/src/extra/MarkdownEditor/__snapshots__/MarkdownEditor.stories.storyshot
+++ b/src/extra/MarkdownEditor/__snapshots__/MarkdownEditor.stories.storyshot
@@ -6,7 +6,7 @@ exports[`Storyshots Extra/MarkdownEditor Default 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
   >
     <div
-      class="sc-geuGuN iFFFfs"
+      class="sc-gPpHY gmynQJ"
       id="simplemde-editor-2-wrapper"
     >
       <textarea


### PR DESCRIPTION
Make sort icon for table column headers remain on the same line as the text

Connects-to: https://github.com/balena-io/balena-ui/issues/5420
Change-type: patch
Signed-off-by: Matthew Yarmolinsky <matthew-timothy@balena.io>

---

##### Contributor checklist

<!-- For completed items, change [ ] to [x].  -->

- [ ] I have regenerated jest snapshots for any affected components with `npm run generate-snapshots`

##### Reviewer Guidelines

- When submitting a review, please pick:
  - '_Approve_' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '_Request Changes_' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '_Comment_' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)

---
