### PR TITLE
Add `disabled` property to ButtonGroup component

### DIFF
--- a/src/components/ButtonGroup/__snapshots__/ButtonGroup.stories.storyshot
+++ b/src/components/ButtonGroup/__snapshots__/ButtonGroup.stories.storyshot
@@ -6,7 +6,7 @@ exports[`Storyshots Core/ButtonGroup Default 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
   >
     <div
-      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-jIZahH iKIurY hlMcTG"
+      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-jIZahH iKIurY kPjfux"
     >
       <button
         class="StyledButton-sc-323bzc-0 feSBMv sc-breuTD sc-hAZoDl Krizp gjEvOJ sc-dIouRR kAoSkv"
@@ -37,7 +37,7 @@ exports[`Storyshots Core/ButtonGroup Group Select 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
   >
     <div
-      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-jIZahH liHVdE gcoUsA"
+      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-jIZahH liHVdE gNofWH"
       value="[object Object]"
     >
       <button
@@ -69,7 +69,7 @@ exports[`Storyshots Core/ButtonGroup With Icon Button 1`] = `
     class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
   >
     <div
-      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-jIZahH iKIurY hlMcTG"
+      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-jIZahH iKIurY kPjfux"
     >
       <button
         class="StyledButton-sc-323bzc-0 iPrszx sc-breuTD sc-hAZoDl Krizp gjEvOJ sc-dIouRR kAoSkv"

--- a/src/components/ButtonGroup/index.tsx
+++ b/src/components/ButtonGroup/index.tsx
@@ -14,6 +14,7 @@ export interface ButtonGroupOption {
 export interface ButtonGroupWithOptionsProps
 	extends Omit<FlexProps, 'children'> {
 	options: OptionType[];
+	disabled?: string;
 	value?: OptionType;
 	onGroupChange: (value: OptionType) => void;
 }
@@ -25,10 +26,14 @@ export type ButtonGroupProps = FlexProps | ButtonGroupWithOptionsProps;
  *
  * [View story source](https://github.com/balena-io-modules/rendition/blob/master/src/components/ButtonGroup/ButtonGroup.stories.tsx)
  */
-const ButtonGroupBase = styled(Flex)<{ isSelect?: boolean }>`
-		${(props) =>
-			props.isSelect
-				? `
+const ButtonGroupBase = styled(Flex)<{
+	isSelect?: boolean;
+	disabled?: boolean;
+}>`
+	${(props) => props.disabled && `cursor: not-allowed;`}
+	${(props) =>
+		props.isSelect
+			? `
 			border: 1px solid ${props.theme.global.control.border.color};
 			width: fit-content;
 			border-radius: ${props.theme.button.border.radius};
@@ -38,7 +43,7 @@ const ButtonGroupBase = styled(Flex)<{ isSelect?: boolean }>`
 				border: 0px;
 			}
 		`
-				: `
+			: `
 		> * {
 			&:first-child {
 				border-top-right-radius: 0;
@@ -64,14 +69,19 @@ const ButtonGroupBase = styled(Flex)<{ isSelect?: boolean }>`
 				z-index: 1;
 			}
 		`}
-	}
 `;
 
 export const ButtonGroup = (props: ButtonGroupProps) => {
 	if ('options' in props) {
-		const { onGroupChange, height, ...otherProps } = props;
+		const { onGroupChange, height, disabled, ...otherProps } = props;
 		return (
-			<ButtonGroupBase isSelect {...otherProps} alignItems="center">
+			<ButtonGroupBase
+				isSelect
+				{...otherProps}
+				alignItems="center"
+				disabled={!!disabled}
+				tooltip={disabled}
+			>
 				{props.options.map((option) => {
 					const label = typeof option !== 'object' ? option : option.label;
 					return (
@@ -88,6 +98,7 @@ export const ButtonGroup = (props: ButtonGroupProps) => {
 								}
 							}}
 							height={height}
+							disabled={!!disabled}
 						>
 							{label}
 						</Button>

--- a/src/components/Pager/__snapshots__/Pager.stories.storyshot
+++ b/src/components/Pager/__snapshots__/Pager.stories.storyshot
@@ -28,7 +28,7 @@ exports[`Storyshots Core/Pager Default 1`] = `
         class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY"
       >
         <div
-          class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-jIZahH iKIurY hlMcTG"
+          class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-jIZahH iKIurY kPjfux"
         >
           <button
             class="StyledButton-sc-323bzc-0 jIlaYJ sc-breuTD sc-hAZoDl Krizp eagAYV sc-dIouRR kAoSkv rendition-pager__btn--prev"
@@ -105,7 +105,7 @@ exports[`Storyshots Core/Pager Fuzzy 1`] = `
         class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY"
       >
         <div
-          class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-jIZahH iKIurY hlMcTG"
+          class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-jIZahH iKIurY kPjfux"
         >
           <button
             class="StyledButton-sc-323bzc-0 jIlaYJ sc-breuTD sc-hAZoDl Krizp eagAYV sc-dIouRR kAoSkv rendition-pager__btn--prev"

--- a/src/components/Table/__snapshots__/Table.stories.storyshot
+++ b/src/components/Table/__snapshots__/Table.stories.storyshot
@@ -3537,7 +3537,7 @@ exports[`Storyshots Core/Table With Fuzzy Pager 1`] = `
             class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY"
           >
             <div
-              class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-jIZahH iKIurY hlMcTG"
+              class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-jIZahH iKIurY kPjfux"
             >
               <button
                 class="StyledButton-sc-323bzc-0 iNgVbb sc-breuTD sc-hAZoDl Krizp eagAYV sc-dIouRR kAoSkv rendition-pager__btn--prev"
@@ -3828,7 +3828,7 @@ exports[`Storyshots Core/Table With Fuzzy Pager 1`] = `
             class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY"
           >
             <div
-              class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-jIZahH iKIurY hlMcTG"
+              class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-jIZahH iKIurY kPjfux"
             >
               <button
                 class="StyledButton-sc-323bzc-0 iNgVbb sc-breuTD sc-hAZoDl Krizp eagAYV sc-dIouRR kAoSkv rendition-pager__btn--prev"
@@ -4417,7 +4417,7 @@ exports[`Storyshots Core/Table With Pager 1`] = `
             class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY"
           >
             <div
-              class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-jIZahH iKIurY hlMcTG"
+              class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-jIZahH iKIurY kPjfux"
             >
               <button
                 class="StyledButton-sc-323bzc-0 iNgVbb sc-breuTD sc-hAZoDl Krizp eagAYV sc-dIouRR kAoSkv rendition-pager__btn--prev"
@@ -4708,7 +4708,7 @@ exports[`Storyshots Core/Table With Pager 1`] = `
             class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY"
           >
             <div
-              class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-jIZahH iKIurY hlMcTG"
+              class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-jIZahH iKIurY kPjfux"
             >
               <button
                 class="StyledButton-sc-323bzc-0 iNgVbb sc-breuTD sc-hAZoDl Krizp eagAYV sc-dIouRR kAoSkv rendition-pager__btn--prev"

--- a/src/extra/AutoUI/__snapshots__/AutoUI.stories.storyshot
+++ b/src/extra/AutoUI/__snapshots__/AutoUI.stories.storyshot
@@ -559,7 +559,7 @@ exports[`Storyshots Extra/AutoUI Default 1`] = `
                     class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY"
                   >
                     <div
-                      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-jIZahH iKIurY hlMcTG"
+                      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-jIZahH iKIurY kPjfux"
                     >
                       <button
                         class="StyledButton-sc-323bzc-0 iNgVbb sc-breuTD sc-hAZoDl Krizp eagAYV sc-dIouRR kAoSkv rendition-pager__btn--prev"


### PR DESCRIPTION
Add `disabled` property to ButtonGroup component

Connects-to: https://github.com/balena-io/balena-ui/pull/5410
Change-type: minor
Signed-off-by: Matthew Yarmolinsky <matthew-timothy@balena.io>

---

##### Contributor checklist

<!-- For completed items, change [ ] to [x].  -->

- [ ] I have regenerated jest snapshots for any affected components with `npm run generate-snapshots`

##### Reviewer Guidelines

- When submitting a review, please pick:
  - '_Approve_' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '_Request Changes_' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '_Comment_' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)

---
