### PR TITLE
Add docs link to poll interval field in download image modal

### DIFF
--- a/src/unstable-temp/DownloadImageModal/FormModel.tsx
+++ b/src/unstable-temp/DownloadImageModal/FormModel.tsx
@@ -10,6 +10,7 @@ import { Collapsible } from './Collapsible';
 import { PasswordInput } from './PasswordInput';
 import styled from 'styled-components';
 import { DeviceTypeOptions, DeviceTypeOptionsGroup } from './models';
+import { DocsLink } from './OsConfiguration';
 
 export const DownloadImageLabel = styled.label`
 	display: flex;
@@ -81,7 +82,10 @@ const FormControl = ({ onModelChange, options, model }: FormControlProps) => {
 			{!options.hidden && (
 				<>
 					{options.type !== 'confirm' && (
-						<DownloadImageLabel>{options.message}</DownloadImageLabel>
+						<DownloadImageLabel>
+							{options.message}
+							{!!options.docs && <DocsLink href={options.docs} />}
+						</DownloadImageLabel>
 					)}
 
 					{options.type === 'list' && options.choices?.length === 1 && (
@@ -147,8 +151,8 @@ const FormControl = ({ onModelChange, options, model }: FormControlProps) => {
 					{options.type === 'number' && (
 						<Input
 							mb={2}
-							type="number"
 							name={options.name}
+							type="number"
 							onChange={(e) => {
 								const parsed = toNumber(e.target.value);
 								if (!isNaN(parsed)) {
@@ -292,6 +296,6 @@ export const DownloadFormModel = ({
 			}
 			model={model}
 			options={options}
-		></FormFields>
+		/>
 	);
 };

--- a/src/unstable-temp/DownloadImageModal/ImageForm.tsx
+++ b/src/unstable-temp/DownloadImageModal/ImageForm.tsx
@@ -15,7 +15,9 @@ import { DownloadOptions, DownloadOptionsBase } from './DownloadImageModal';
 import { TFunction } from '../../hooks/useTranslation';
 import pickBy from 'lodash/pickBy';
 
-const ETCHER_OPEN_IMAGE_URL = `https://www.balena.io/etcher/open-image-url`;
+const ETCHER_OPEN_IMAGE_URL = 'https://www.balena.io/etcher/open-image-url';
+const POLL_INTERVAL_DOCS =
+	'https://www.balena.io/docs/reference/supervisor/bandwidth-reduction/#side-effects--warnings';
 
 const debounceDownloadSize = debounce(
 	async (
@@ -64,6 +66,12 @@ const getDeviceTypeOptions = (t: TFunction, deviceType: DeviceType) => {
 				name: 'provisioningKeyName',
 				default: '',
 				type: 'text',
+			});
+			group.options.map((option) => {
+				if (option.message === 'Check for updates every X minutes') {
+					option.docs = POLL_INTERVAL_DOCS;
+				}
+				return option;
 			});
 		}
 

--- a/src/unstable-temp/DownloadImageModal/models.ts
+++ b/src/unstable-temp/DownloadImageModal/models.ts
@@ -99,6 +99,7 @@ export interface DeviceTypeOptionsGroup {
 	type: string;
 	min?: number;
 	max?: number;
+	docs?: string;
 	hidden?: boolean;
 	when?: Dictionary<number | string | boolean>;
 	choices?: string[] | number[];


### PR DESCRIPTION
Add docs link to poll interval field in download image modal

Connects-to: https://github.com/balena-io/balena-ui/issues/3321
FD: https://www.flowdock.com/app/rulemotion/public-s-community/threads/JQhGP_i2UgaNtnY62E7ZKScqePZ
Change-type: minor
Signed-off-by: Matthew Yarmolinsky <matthew-timothy@balena.io>

---

##### Contributor checklist

<!-- For completed items, change [ ] to [x].  -->

- [ ] I have regenerated jest snapshots for any affected components with `npm run generate-snapshots`

##### Reviewer Guidelines

- When submitting a review, please pick:
  - '_Approve_' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '_Request Changes_' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '_Comment_' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)

---
