### PR TITLE
Show error in download image modal if poll interval value is invalid

### DIFF
--- a/src/hooks/useTranslation.tsx
+++ b/src/hooks/useTranslation.tsx
@@ -36,6 +36,7 @@ const translationMap = {
 		'A tag name group exists on {{count}} other {{itemType}}s and will be overwritten.',
 	'warnings.fill_wifi_credentials':
 		'Please fill in the wifi credentials or select "Ethernet only" in the "Network Connection" section',
+	'warnings.some_fields_are_invalid': 'Some fields are invalid',
 	'warnings.image_deployed_to_docker':
 		'This image is deployed to docker so you can only download its config',
 
@@ -51,6 +52,10 @@ const translationMap = {
 		'Tag names beginning with {{namespace}} are reserved',
 	'fields_errors.tag_with_same_name_exists':
 		'A tag with the same name already exists',
+	'fields_errors.does_not_satisfy_minimum':
+		'Must be greater than or equal to {{minimum}}',
+	'fields_errors.does_not_satisfy_maximum':
+		'Must be less than or equal to {{maximum}}',
 
 	// DownloadImageModal
 	'placeholders.select_device_type': 'Select device type',

--- a/src/unstable-temp/DownloadImageModal/FormModel.tsx
+++ b/src/unstable-temp/DownloadImageModal/FormModel.tsx
@@ -6,11 +6,13 @@ import { Divider } from '../../components/Divider';
 import { Input } from '../../components/Input';
 import { Select } from '../../components/Select';
 import { RadioButtonGroup } from '../../components/RadioButtonGroup';
+import { Txt } from '../../components/Txt';
 import { Collapsible } from './Collapsible';
 import { PasswordInput } from './PasswordInput';
 import styled from 'styled-components';
 import { DeviceTypeOptions, DeviceTypeOptionsGroup } from './models';
 import { DocsLink } from './OsConfiguration';
+import { useTranslation } from '../../hooks/useTranslation';
 
 export const DownloadImageLabel = styled.label`
 	display: flex;
@@ -58,6 +60,7 @@ interface FormControlProps extends Omit<FormFieldsProps, 'options'> {
 }
 
 const FormControl = ({ onModelChange, options, model }: FormControlProps) => {
+	const { t } = useTranslation();
 	React.useEffect(() => {
 		if (model[options.name]) {
 			return;
@@ -68,6 +71,26 @@ const FormControl = ({ onModelChange, options, model }: FormControlProps) => {
 			onModelChange({ [options.name]: getDefaultValue(options) });
 		}
 	}, [options, model, onModelChange]);
+
+	const error = React.useMemo(() => {
+		const value = model[options.name];
+		if (value !== undefined && typeof value === 'number') {
+			if (options.min) {
+				if (value < options.min) {
+					return t('fields_errors.does_not_satisfy_minimum', {
+						minimum: options.min,
+					});
+				}
+			}
+			if (options.max) {
+				if (value > options.max) {
+					return t('fields_errors.does_not_satisfy_maximum', {
+						maximum: options.max,
+					});
+				}
+			}
+		}
+	}, [options, model]);
 
 	return (
 		<div style={options.hidden ? { display: 'none' } : {}}>
@@ -188,6 +211,11 @@ const FormControl = ({ onModelChange, options, model }: FormControlProps) => {
 							value={model[options.name] as string | undefined}
 							autoComplete="new-password"
 						/>
+					)}
+					{error && (
+						<Txt color="red" fontSize={10}>
+							{error}
+						</Txt>
 					)}
 				</>
 			)}


### PR DESCRIPTION
Show error in download image modal if poll interval value is invalid

Resolves: https://github.com/balena-io/balena-ui/issues/3321
FD: https://www.flowdock.com/app/rulemotion/public-s-community/threads/JQhGP_i2UgaNtnY62E7ZKScqePZ
Change-type: minor
Signed-off-by: Matthew Yarmolinsky <matthew-timothy@balena.io>

![image](https://user-images.githubusercontent.com/22177187/171717064-9209fdfd-23f1-42ff-9ef2-276e9d1b9622.png)

---

##### Contributor checklist

<!-- For completed items, change [ ] to [x].  -->

- [ ] I have regenerated jest snapshots for any affected components with `npm run generate-snapshots`

##### Reviewer Guidelines

- When submitting a review, please pick:
  - '_Approve_' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '_Request Changes_' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '_Comment_' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)

---
