### PR TITLE
Drop Modal component's titleElement and titleDetails properties in favor of the `title` property and add `JSX.Element` as an acceptable type for `title`

### DIFF
--- a/src/components/Accordion/__snapshots__/Accordion.stories.storyshot
+++ b/src/components/Accordion/__snapshots__/Accordion.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/Accordion Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 hANpeK"

--- a/src/components/Alert/__snapshots__/Alert.stories.storyshot
+++ b/src/components/Alert/__snapshots__/Alert.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/Alert Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="sc-gKXOVf QRSBg sc-iBkjds gwVQPy sc-hHLeRK sc-dmRaPn iKIurY eeClkm sc-gicCDI cmHWGP"
@@ -49,7 +49,7 @@ exports[`Storyshots Core/Alert Default 1`] = `
 exports[`Storyshots Core/Alert Emphasized 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="sc-gKXOVf QRSBg sc-iBkjds dnRYSM sc-hHLeRK sc-dmRaPn iKIurY dELywO sc-gicCDI cmHWGP"
@@ -95,7 +95,7 @@ exports[`Storyshots Core/Alert Emphasized 1`] = `
 exports[`Storyshots Core/Alert Plaintext 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY sc-gicCDI cmHWGP"
@@ -132,7 +132,7 @@ exports[`Storyshots Core/Alert Plaintext 1`] = `
 exports[`Storyshots Core/Alert With Link 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="sc-gKXOVf QRSBg sc-iBkjds gwVQPy sc-hHLeRK sc-dmRaPn iKIurY eeClkm sc-gicCDI cmHWGP"
@@ -169,7 +169,7 @@ exports[`Storyshots Core/Alert With Link 1`] = `
         >
           With a 
           <a
-            class="sc-eKBdFk eDgBSD sc-bUbCnL aUvHI"
+            class="sc-hlnMnd cpbYOv sc-eKBdFk cTggPd"
             color="primary.main"
             href="test"
           >
@@ -185,7 +185,7 @@ exports[`Storyshots Core/Alert With Link 1`] = `
 exports[`Storyshots Core/Alert Without Dismiss 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="sc-gKXOVf QRSBg sc-iBkjds gwVQPy sc-hHLeRK sc-dmRaPn iKIurY eeClkm sc-gicCDI cmHWGP"
@@ -231,7 +231,7 @@ exports[`Storyshots Core/Alert Without Dismiss 1`] = `
 exports[`Storyshots Core/Alert Without Prefix 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="sc-gKXOVf QRSBg sc-iBkjds gwVQPy sc-hHLeRK sc-dmRaPn iKIurY eeClkm sc-gicCDI cmHWGP"

--- a/src/components/Avatar/__snapshots__/Avatar.stories.storyshot
+++ b/src/components/Avatar/__snapshots__/Avatar.stories.storyshot
@@ -3,11 +3,11 @@
 exports[`Storyshots Core/Avatar Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     
     <div
-      class="StyledBox-sc-13pk1d4-0 kVFNVq StyledAvatar-sc-1suyamb-1 sc-itUGML ecjCgS"
+      class="StyledBox-sc-13pk1d4-0 kVFNVq StyledAvatar-sc-1suyamb-1 sc-hFrEEg jGjPiH"
     >
       <svg
         aria-hidden="true"
@@ -33,10 +33,10 @@ exports[`Storyshots Core/Avatar Default 1`] = `
 exports[`Storyshots Core/Avatar Emphasized 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 iaZwhG StyledAvatar-sc-1suyamb-1 sc-itUGML ecjCgS"
+      class="StyledBox-sc-13pk1d4-0 iaZwhG StyledAvatar-sc-1suyamb-1 sc-hFrEEg jGjPiH"
     >
       <div
         class="sc-ivTmOn dNJphr sc-cxabCf kEsRji"
@@ -51,10 +51,10 @@ exports[`Storyshots Core/Avatar Emphasized 1`] = `
 exports[`Storyshots Core/Avatar With First Name 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 kVFNVq StyledAvatar-sc-1suyamb-1 sc-itUGML ecjCgS"
+      class="StyledBox-sc-13pk1d4-0 kVFNVq StyledAvatar-sc-1suyamb-1 sc-hFrEEg jGjPiH"
     >
       <div
         class="sc-ivTmOn dNJphr sc-cxabCf kEsRji"
@@ -69,10 +69,10 @@ exports[`Storyshots Core/Avatar With First Name 1`] = `
 exports[`Storyshots Core/Avatar With Full Name 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 kVFNVq StyledAvatar-sc-1suyamb-1 sc-itUGML ecjCgS"
+      class="StyledBox-sc-13pk1d4-0 kVFNVq StyledAvatar-sc-1suyamb-1 sc-hFrEEg jGjPiH"
     >
       <div
         class="sc-ivTmOn dNJphr sc-cxabCf kEsRji"
@@ -87,10 +87,10 @@ exports[`Storyshots Core/Avatar With Full Name 1`] = `
 exports[`Storyshots Core/Avatar With Image 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 bkfLqh StyledAvatar-sc-1suyamb-1 sc-itUGML ecjCgS"
+      class="StyledBox-sc-13pk1d4-0 bkfLqh StyledAvatar-sc-1suyamb-1 sc-hFrEEg jGjPiH"
     />
     
   </div>
@@ -100,10 +100,10 @@ exports[`Storyshots Core/Avatar With Image 1`] = `
 exports[`Storyshots Core/Avatar With Last Name 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 kVFNVq StyledAvatar-sc-1suyamb-1 sc-itUGML ecjCgS"
+      class="StyledBox-sc-13pk1d4-0 kVFNVq StyledAvatar-sc-1suyamb-1 sc-hFrEEg jGjPiH"
     >
       <div
         class="sc-ivTmOn dNJphr sc-cxabCf kEsRji"

--- a/src/components/Badge/__snapshots__/Badge.stories.storyshot
+++ b/src/components/Badge/__snapshots__/Badge.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/Badge Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <span
       class="sc-ivTmOn dNJphr sc-llJcti CZjd sc-ezWOiH gTEQrB sc-bZkfAO eiBgNL"

--- a/src/components/Banner/__snapshots__/Banner.stories.storyshot
+++ b/src/components/Banner/__snapshots__/Banner.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/Banner Primary 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-kLLXSd fDtTuc jIGCuW sc-ikZpkk evalaj"

--- a/src/components/Box/__snapshots__/Box.stories.storyshot
+++ b/src/components/Box/__snapshots__/Box.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/Box Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="sc-gKXOVf QRSBg sc-iBkjds ipRjux"

--- a/src/components/Breadcrumbs/__snapshots__/Breadcrumbs.stories.storyshot
+++ b/src/components/Breadcrumbs/__snapshots__/Breadcrumbs.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/Breadcrumbs Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="sc-gKXOVf QRSBg sc-iBkjds gNjzDq sc-hHLeRK dUykMD"
@@ -19,13 +19,13 @@ exports[`Storyshots Core/Breadcrumbs Default 1`] = `
             class="sc-gKXOVf QRSBg sc-iBkjds gNjzDq sc-hHLeRK liHVdE"
           >
             <div
-              class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-jWEIYm iKIurY iWCKqs"
+              class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-ESujJ iKIurY iPkcIm"
             />
             <div
               class="sc-gKXOVf QRSBg sc-iBkjds dqCdat sc-hHLeRK iKIurY"
             >
               <a
-                class="sc-eKBdFk eDgBSD sc-bUbCnL jeJqf"
+                class="sc-hlnMnd cpbYOv sc-eKBdFk cnMDLq"
                 color="primary.main"
                 href="/?path=/story/core-breadcrumbs--default"
                 style="display: inherit;"
@@ -62,13 +62,13 @@ exports[`Storyshots Core/Breadcrumbs Default 1`] = `
             class="sc-gKXOVf QRSBg sc-iBkjds gNjzDq sc-hHLeRK liHVdE"
           >
             <div
-              class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-jWEIYm iKIurY iWCKqs"
+              class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-ESujJ iKIurY iPkcIm"
             />
             <div
               class="sc-gKXOVf QRSBg sc-iBkjds dqCdat sc-hHLeRK iKIurY"
             >
               <a
-                class="sc-eKBdFk eDgBSD sc-bUbCnL jeJqf"
+                class="sc-hlnMnd cpbYOv sc-eKBdFk cnMDLq"
                 color="primary.main"
                 href="/?path=/story/core-breadcrumbs--default"
                 style="display: inherit;"
@@ -105,13 +105,13 @@ exports[`Storyshots Core/Breadcrumbs Default 1`] = `
             class="sc-gKXOVf QRSBg sc-iBkjds gNjzDq sc-hHLeRK liHVdE"
           >
             <div
-              class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-jWEIYm iKIurY bFtnjU"
+              class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-ESujJ iKIurY IUhdi"
             />
             <div
               class="sc-gKXOVf QRSBg sc-iBkjds dqCdat sc-hHLeRK iKIurY"
             >
               <a
-                class="sc-eKBdFk eDgBSD sc-bUbCnL jeJqf"
+                class="sc-hlnMnd cpbYOv sc-eKBdFk cnMDLq"
                 color="primary.main"
                 href="/?path=/story/core-breadcrumbs--default"
                 style="display: inherit;"
@@ -157,7 +157,7 @@ exports[`Storyshots Core/Breadcrumbs Default 1`] = `
 exports[`Storyshots Core/Breadcrumbs Wrapped 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="sc-gKXOVf QRSBg sc-iBkjds bnIlLs sc-hHLeRK iKIurY"
@@ -176,13 +176,13 @@ exports[`Storyshots Core/Breadcrumbs Wrapped 1`] = `
               class="sc-gKXOVf QRSBg sc-iBkjds gNjzDq sc-hHLeRK liHVdE"
             >
               <div
-                class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-jWEIYm iKIurY iWCKqs"
+                class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-ESujJ iKIurY iPkcIm"
               />
               <div
                 class="sc-gKXOVf QRSBg sc-iBkjds dqCdat sc-hHLeRK iKIurY"
               >
                 <a
-                  class="sc-eKBdFk eDgBSD sc-bUbCnL jeJqf"
+                  class="sc-hlnMnd cpbYOv sc-eKBdFk cnMDLq"
                   color="primary.main"
                   href="/?path=/story/core-breadcrumbs--default"
                   style="display: inherit;"
@@ -219,13 +219,13 @@ exports[`Storyshots Core/Breadcrumbs Wrapped 1`] = `
               class="sc-gKXOVf QRSBg sc-iBkjds gNjzDq sc-hHLeRK liHVdE"
             >
               <div
-                class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-jWEIYm iKIurY iWCKqs"
+                class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-ESujJ iKIurY iPkcIm"
               />
               <div
                 class="sc-gKXOVf QRSBg sc-iBkjds dqCdat sc-hHLeRK iKIurY"
               >
                 <a
-                  class="sc-eKBdFk eDgBSD sc-bUbCnL jeJqf"
+                  class="sc-hlnMnd cpbYOv sc-eKBdFk cnMDLq"
                   color="primary.main"
                   href="/?path=/story/core-breadcrumbs--default"
                   style="display: inherit;"
@@ -262,13 +262,13 @@ exports[`Storyshots Core/Breadcrumbs Wrapped 1`] = `
               class="sc-gKXOVf QRSBg sc-iBkjds gNjzDq sc-hHLeRK liHVdE"
             >
               <div
-                class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-jWEIYm iKIurY bFtnjU"
+                class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-ESujJ iKIurY IUhdi"
               />
               <div
                 class="sc-gKXOVf QRSBg sc-iBkjds dqCdat sc-hHLeRK iKIurY"
               >
                 <a
-                  class="sc-eKBdFk eDgBSD sc-bUbCnL jeJqf"
+                  class="sc-hlnMnd cpbYOv sc-eKBdFk cnMDLq"
                   color="primary.main"
                   href="/?path=/story/core-breadcrumbs--default"
                   style="display: inherit;"

--- a/src/components/Button/__snapshots__/Button.stories.storyshot
+++ b/src/components/Button/__snapshots__/Button.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/Button Active 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <button
       class="StyledButton-sc-323bzc-0 jmneFO sc-breuTD sc-ksZaOG Krizp gsTBap sc-dIouRR kAoSkv"
@@ -18,7 +18,7 @@ exports[`Storyshots Core/Button Active 1`] = `
 exports[`Storyshots Core/Button Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <button
       class="StyledButton-sc-323bzc-0 feSBMv sc-breuTD sc-hAZoDl Krizp gjEvOJ sc-dIouRR kAoSkv"
@@ -33,7 +33,7 @@ exports[`Storyshots Core/Button Default 1`] = `
 exports[`Storyshots Core/Button Disabled 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <button
       class="StyledButton-sc-323bzc-0 cXcrjt sc-breuTD sc-hAZoDl Krizp gjEvOJ sc-dIouRR kAoSkv"
@@ -49,7 +49,7 @@ exports[`Storyshots Core/Button Disabled 1`] = `
 exports[`Storyshots Core/Button Icon Only 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <button
       class="StyledButton-sc-323bzc-0 jllRpX sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv"
@@ -78,7 +78,7 @@ exports[`Storyshots Core/Button Icon Only 1`] = `
 exports[`Storyshots Core/Button Link 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <a
       class="StyledButton-sc-323bzc-0 feSBMv sc-breuTD sc-hAZoDl Krizp gjEvOJ sc-dIouRR kAoSkv"
@@ -93,7 +93,7 @@ exports[`Storyshots Core/Button Link 1`] = `
 exports[`Storyshots Core/Button Outlined 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <button
       class="StyledButton-sc-323bzc-0 feSBMv sc-breuTD sc-hAZoDl Krizp gjEvOJ sc-dIouRR kAoSkv"
@@ -108,7 +108,7 @@ exports[`Storyshots Core/Button Outlined 1`] = `
 exports[`Storyshots Core/Button Plain 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <button
       class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv"
@@ -123,7 +123,7 @@ exports[`Storyshots Core/Button Plain 1`] = `
 exports[`Storyshots Core/Button Primary 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <button
       class="StyledButton-sc-323bzc-0 gvCdQt sc-breuTD sc-ksZaOG Krizp jFzPEx sc-dIouRR kAoSkv"
@@ -138,7 +138,7 @@ exports[`Storyshots Core/Button Primary 1`] = `
 exports[`Storyshots Core/Button Underlined 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <button
       class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL sc-idiyUo Krizp gOoGXe hvtBsx sc-dIouRR kAoSkv"
@@ -153,7 +153,7 @@ exports[`Storyshots Core/Button Underlined 1`] = `
 exports[`Storyshots Core/Button With Confirmation 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <button
       class="StyledButton-sc-323bzc-0 iSYCWd sc-breuTD sc-ksZaOG Krizp jljCjl sc-dIouRR kAoSkv"
@@ -168,7 +168,7 @@ exports[`Storyshots Core/Button With Confirmation 1`] = `
 exports[`Storyshots Core/Button With Icon 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <button
       class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv"

--- a/src/components/ButtonGroup/__snapshots__/ButtonGroup.stories.storyshot
+++ b/src/components/ButtonGroup/__snapshots__/ButtonGroup.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/ButtonGroup Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-jIZahH iKIurY kPjfux"
@@ -34,7 +34,7 @@ exports[`Storyshots Core/ButtonGroup Default 1`] = `
 exports[`Storyshots Core/ButtonGroup Group Select 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-jIZahH liHVdE gNofWH"
@@ -66,7 +66,7 @@ exports[`Storyshots Core/ButtonGroup Group Select 1`] = `
 exports[`Storyshots Core/ButtonGroup With Icon Button 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-jIZahH iKIurY kPjfux"

--- a/src/components/Card/__snapshots__/Card.stories.storyshot
+++ b/src/components/Card/__snapshots__/Card.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/Card Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       style="width: 400px; height: 400px;"
@@ -27,7 +27,7 @@ exports[`Storyshots Core/Card Default 1`] = `
 exports[`Storyshots Core/Card Small 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       style="width: 400px; height: 400px;"
@@ -51,7 +51,7 @@ exports[`Storyshots Core/Card Small 1`] = `
 exports[`Storyshots Core/Card With Header 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       style="width: 400px; height: 400px;"
@@ -93,7 +93,7 @@ exports[`Storyshots Core/Card With Header 1`] = `
 exports[`Storyshots Core/Card With Rows 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       style="width: 400px; height: 400px;"
@@ -110,7 +110,7 @@ exports[`Storyshots Core/Card With Rows 1`] = `
             Card with Button
           </h5>
           <a
-            class="sc-eKBdFk eDgBSD sc-bUbCnL aUvHI"
+            class="sc-hlnMnd cpbYOv sc-eKBdFk cTggPd"
             color="primary.main"
             href="https://balena.io"
           >
@@ -134,7 +134,7 @@ exports[`Storyshots Core/Card With Rows 1`] = `
             class="sc-himrzO dDBpFK sc-cCsOjp lhBdCS"
           />
           <a
-            class="sc-eKBdFk eDgBSD sc-bUbCnL aUvHI"
+            class="sc-hlnMnd cpbYOv sc-eKBdFk cTggPd"
             color="primary.main"
             href="www.balena.io"
           >

--- a/src/components/Checkbox/__snapshots__/Checkbox.stories.storyshot
+++ b/src/components/Checkbox/__snapshots__/Checkbox.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/Checkbox Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="sc-cOFTSb eAnjwB sc-BeQoi dmAMvw"
@@ -31,7 +31,7 @@ exports[`Storyshots Core/Checkbox Default 1`] = `
 exports[`Storyshots Core/Checkbox Disabled 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="sc-cOFTSb eAnjwB sc-BeQoi dmAMvw"
@@ -66,7 +66,7 @@ exports[`Storyshots Core/Checkbox Disabled 1`] = `
 exports[`Storyshots Core/Checkbox Reversed Label 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="sc-cOFTSb eAnjwB sc-BeQoi dmAMvw"
@@ -97,7 +97,7 @@ exports[`Storyshots Core/Checkbox Reversed Label 1`] = `
 exports[`Storyshots Core/Checkbox Toggle 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="sc-cOFTSb eAnjwB sc-BeQoi dmAMvw"
@@ -132,7 +132,7 @@ exports[`Storyshots Core/Checkbox Toggle 1`] = `
 exports[`Storyshots Core/Checkbox With Label 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="sc-cOFTSb eAnjwB sc-BeQoi dmAMvw"

--- a/src/components/Container/__snapshots__/Container.stories.storyshot
+++ b/src/components/Container/__snapshots__/Container.stories.storyshot
@@ -3,10 +3,10 @@
 exports[`Storyshots Core/Container Centered Content 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
-      class="sc-gKXOVf QRSBg sc-iBkjds bkEkLP sc-tQuYZ lpiIIT sc-dSuTWQ gvFvHw"
+      class="sc-gKXOVf QRSBg sc-iBkjds bkEkLP sc-bTMaZy kZGhGV sc-tQuYZ AZKVT"
     >
       <h3
         class="sc-ciZhAO btUqKl sc-jdAMXn iwAvbM"
@@ -21,10 +21,10 @@ exports[`Storyshots Core/Container Centered Content 1`] = `
 exports[`Storyshots Core/Container Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
-      class="sc-gKXOVf QRSBg sc-iBkjds bkEkLP sc-tQuYZ iejtYQ sc-dSuTWQ gvFvHw"
+      class="sc-gKXOVf QRSBg sc-iBkjds bkEkLP sc-bTMaZy iSKKFC sc-tQuYZ AZKVT"
     >
       <h3
         class="sc-ciZhAO btUqKl sc-jdAMXn iwAvbM"

--- a/src/components/Copy/__snapshots__/Copy.stories.storyshot
+++ b/src/components/Copy/__snapshots__/Copy.stories.storyshot
@@ -3,22 +3,22 @@
 exports[`Storyshots Core/Copy Always Show 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-bBrHrO HodyL"
     >
       <div
-        class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-kngDgl iKIurY kdKlCZ"
+        class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-afnQL iKIurY eFWjlE"
       >
         <div
           class="sc-gKXOVf ckXSHX sc-iBkjds gNjzDq sc-hHLeRK eTSHtc"
         >
           <div
-            class="sc-iqGgem lbaJJA"
+            class="sc-iFwKgL cqyvps"
           >
             <div
-              class="sc-eVQfli lbmlHZ sc-dkSuNL bzbeQN"
+              class="sc-iqGgem lyCqM sc-cwpsFg cwqlwQ"
             >
               <div
                 data-display="table-head"
@@ -109,7 +109,7 @@ exports[`Storyshots Core/Copy Always Show 1`] = `
 exports[`Storyshots Core/Copy Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-bBrHrO HodyL"
@@ -146,7 +146,7 @@ exports[`Storyshots Core/Copy Default 1`] = `
 exports[`Storyshots Core/Copy Icon Only 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="sc-gKXOVf QRSBg sc-iBkjds heXUfd"
@@ -183,16 +183,16 @@ exports[`Storyshots Core/Copy Icon Only 1`] = `
 exports[`Storyshots Core/Copy With Tag 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-bBrHrO HodyL"
     >
       <div
-        class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY sc-eFWqGp gPSCbK"
+        class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY sc-bWXABl jdyMoq"
       >
         <div
-          class="sc-gKXOVf QRSBg sc-iBkjds eecmTK sc-hHLeRK sc-grREDI iKIurY coRGQK"
+          class="sc-gKXOVf QRSBg sc-iBkjds eecmTK sc-hHLeRK sc-HzFiz iKIurY fECpVO"
         >
           <div
             class="sc-ivTmOn qStAn sc-cxabCf ecsbJB"

--- a/src/components/DataGrid/__snapshots__/DataGrid.stories.storyshot
+++ b/src/components/DataGrid/__snapshots__/DataGrid.stories.storyshot
@@ -3,13 +3,13 @@
 exports[`Storyshots Core/DataGrid Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
-      class="sc-dWINGa ddhDdv"
+      class="sc-yeoIj dcBaqd"
     >
       <div
-        class="sc-jGprRt kYCtDn"
+        class="sc-dWINGa dwlWPM"
       >
         <div
           class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-dmRaPn kknPZA coYthk sc-dPyBCJ fjeYNJ sc-bBXxYQ hqGdPE"
@@ -26,7 +26,7 @@ exports[`Storyshots Core/DataGrid Default 1`] = `
         </div>
       </div>
       <div
-        class="sc-jGprRt kYCtDn"
+        class="sc-dWINGa dwlWPM"
       >
         <div
           class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-dmRaPn kknPZA coYthk sc-dPyBCJ fjeYNJ sc-bBXxYQ hqGdPE"
@@ -43,7 +43,7 @@ exports[`Storyshots Core/DataGrid Default 1`] = `
         </div>
       </div>
       <div
-        class="sc-jGprRt kYCtDn"
+        class="sc-dWINGa dwlWPM"
       >
         <div
           class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-dmRaPn kknPZA coYthk sc-dPyBCJ fjeYNJ sc-bBXxYQ hqGdPE"
@@ -60,7 +60,7 @@ exports[`Storyshots Core/DataGrid Default 1`] = `
         </div>
       </div>
       <div
-        class="sc-jGprRt kYCtDn"
+        class="sc-dWINGa dwlWPM"
       >
         <div
           class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-dmRaPn kknPZA coYthk sc-dPyBCJ fjeYNJ sc-bBXxYQ hqGdPE"
@@ -77,7 +77,7 @@ exports[`Storyshots Core/DataGrid Default 1`] = `
         </div>
       </div>
       <div
-        class="sc-jGprRt kYCtDn"
+        class="sc-dWINGa dwlWPM"
       >
         <div
           class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-dmRaPn kknPZA coYthk sc-dPyBCJ fjeYNJ sc-bBXxYQ hqGdPE"
@@ -94,7 +94,7 @@ exports[`Storyshots Core/DataGrid Default 1`] = `
         </div>
       </div>
       <div
-        class="sc-jGprRt kYCtDn"
+        class="sc-dWINGa dwlWPM"
       >
         <div
           class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-dmRaPn kknPZA coYthk sc-dPyBCJ fjeYNJ sc-bBXxYQ hqGdPE"

--- a/src/components/Divider/__snapshots__/Divider.stories.storyshot
+++ b/src/components/Divider/__snapshots__/Divider.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/Divider Dashed 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <hr
       class="sc-himrzO kVxDcQ sc-cCsOjp lhBdCS"
@@ -16,7 +16,7 @@ exports[`Storyshots Core/Divider Dashed 1`] = `
 exports[`Storyshots Core/Divider Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <hr
       class="sc-himrzO dDBpFK sc-cCsOjp lhBdCS"
@@ -28,7 +28,7 @@ exports[`Storyshots Core/Divider Default 1`] = `
 exports[`Storyshots Core/Divider With Custom Color 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <hr
       class="sc-himrzO dCLeSr sc-cCsOjp gBFNXm"
@@ -41,7 +41,7 @@ exports[`Storyshots Core/Divider With Custom Color 1`] = `
 exports[`Storyshots Core/Divider With Text Content 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="sc-gKXOVf QRSBg sc-iBkjds gNjzDq sc-hHLeRK qjMas sc-cCsOjp lhBdCS"

--- a/src/components/DropDownButton/__snapshots__/DropDownButton.stories.storyshot
+++ b/src/components/DropDownButton/__snapshots__/DropDownButton.stories.storyshot
@@ -3,20 +3,20 @@
 exports[`Storyshots Core/DropDownButton Bordered List 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
-      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-fXynhf ifKwFV sc-jIAOiI bpUFTZ"
+      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-GVOUr bFSVuL sc-TRNrF kulTqM"
     >
       <span>
         <button
-          class="StyledButton-sc-323bzc-0 feSBMv sc-breuTD sc-hAZoDl Krizp gjEvOJ sc-dIouRR kAoSkv sc-fbPSWO fpENtd"
+          class="StyledButton-sc-323bzc-0 feSBMv sc-breuTD sc-hAZoDl Krizp gjEvOJ sc-dIouRR kAoSkv sc-ckMVTt hkTCeZ"
           type="button"
         >
           Dropdown
         </button>
         <button
-          class="StyledButton-sc-323bzc-0 iPrszx sc-breuTD sc-hAZoDl Krizp gjEvOJ sc-dIouRR kAoSkv sc-ckMVTt gAKBUg"
+          class="StyledButton-sc-323bzc-0 iPrszx sc-breuTD sc-hAZoDl Krizp gjEvOJ sc-dIouRR kAoSkv sc-gFGZVQ jLwVhQ"
           type="button"
         >
           <svg
@@ -44,20 +44,20 @@ exports[`Storyshots Core/DropDownButton Bordered List 1`] = `
 exports[`Storyshots Core/DropDownButton Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
-      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-fXynhf ifKwFV sc-jIAOiI bpUFTZ"
+      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-GVOUr bFSVuL sc-TRNrF kulTqM"
     >
       <span>
         <button
-          class="StyledButton-sc-323bzc-0 feSBMv sc-breuTD sc-hAZoDl Krizp gjEvOJ sc-dIouRR kAoSkv sc-fbPSWO fpENtd"
+          class="StyledButton-sc-323bzc-0 feSBMv sc-breuTD sc-hAZoDl Krizp gjEvOJ sc-dIouRR kAoSkv sc-ckMVTt hkTCeZ"
           type="button"
         >
           Dropdown
         </button>
         <button
-          class="StyledButton-sc-323bzc-0 iPrszx sc-breuTD sc-hAZoDl Krizp gjEvOJ sc-dIouRR kAoSkv sc-ckMVTt gAKBUg"
+          class="StyledButton-sc-323bzc-0 iPrszx sc-breuTD sc-hAZoDl Krizp gjEvOJ sc-dIouRR kAoSkv sc-gFGZVQ jLwVhQ"
           type="button"
         >
           <svg
@@ -85,23 +85,23 @@ exports[`Storyshots Core/DropDownButton Default 1`] = `
 exports[`Storyshots Core/DropDownButton Drop Up 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="sc-gKXOVf QRSBg sc-iBkjds hitktz"
     >
       <div
-        class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-fXynhf ifKwFV sc-jIAOiI bpUFTZ"
+        class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-GVOUr bFSVuL sc-TRNrF kulTqM"
       >
         <span>
           <button
-            class="StyledButton-sc-323bzc-0 feSBMv sc-breuTD sc-hAZoDl Krizp gjEvOJ sc-dIouRR kAoSkv sc-fbPSWO fpENtd"
+            class="StyledButton-sc-323bzc-0 feSBMv sc-breuTD sc-hAZoDl Krizp gjEvOJ sc-dIouRR kAoSkv sc-ckMVTt hkTCeZ"
             type="button"
           >
             Dropdown
           </button>
           <button
-            class="StyledButton-sc-323bzc-0 iPrszx sc-breuTD sc-hAZoDl Krizp gjEvOJ sc-dIouRR kAoSkv sc-ckMVTt gAKBUg"
+            class="StyledButton-sc-323bzc-0 iPrszx sc-breuTD sc-hAZoDl Krizp gjEvOJ sc-dIouRR kAoSkv sc-gFGZVQ jLwVhQ"
             type="button"
           >
             <svg
@@ -130,13 +130,13 @@ exports[`Storyshots Core/DropDownButton Drop Up 1`] = `
 exports[`Storyshots Core/DropDownButton Icon Only 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
-      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-fXynhf ifKwFV sc-jIAOiI bpUFTZ"
+      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-GVOUr bFSVuL sc-TRNrF kulTqM"
     >
       <button
-        class="StyledButton-sc-323bzc-0 jBNLlX sc-breuTD sc-ksZaOG Krizp jFzPEx sc-dIouRR kAoSkv sc-TRNrF eEcMpL"
+        class="StyledButton-sc-323bzc-0 jBNLlX sc-breuTD sc-ksZaOG Krizp jFzPEx sc-dIouRR kAoSkv sc-dwLEzm yrxfS"
         type="button"
       >
         <svg
@@ -164,13 +164,13 @@ exports[`Storyshots Core/DropDownButton Icon Only 1`] = `
 exports[`Storyshots Core/DropDownButton Joined 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
-      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-fXynhf ifKwFV sc-jIAOiI bpUFTZ"
+      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-GVOUr bFSVuL sc-TRNrF kulTqM"
     >
       <button
-        class="StyledButton-sc-323bzc-0 feSBMv sc-breuTD sc-hAZoDl Krizp gjEvOJ sc-dIouRR kAoSkv sc-TRNrF eEcMpL"
+        class="StyledButton-sc-323bzc-0 feSBMv sc-breuTD sc-hAZoDl Krizp gjEvOJ sc-dIouRR kAoSkv sc-dwLEzm yrxfS"
         type="button"
       >
         <div
@@ -206,18 +206,18 @@ exports[`Storyshots Core/DropDownButton Joined 1`] = `
 exports[`Storyshots Core/DropDownButton No List Formatting 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
-      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-fXynhf ifKwFV sc-jIAOiI bpUFTZ"
+      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-GVOUr bFSVuL sc-TRNrF kulTqM"
     >
       <span>
         <button
-          class="StyledButton-sc-323bzc-0 gvCdQt sc-breuTD sc-ksZaOG Krizp jFzPEx sc-dIouRR kAoSkv sc-fbPSWO fpENtd"
+          class="StyledButton-sc-323bzc-0 gvCdQt sc-breuTD sc-ksZaOG Krizp jFzPEx sc-dIouRR kAoSkv sc-ckMVTt hkTCeZ"
           type="button"
         />
         <button
-          class="StyledButton-sc-323bzc-0 jBNLlX sc-breuTD sc-ksZaOG Krizp jFzPEx sc-dIouRR kAoSkv sc-ckMVTt gAKBUg"
+          class="StyledButton-sc-323bzc-0 jBNLlX sc-breuTD sc-ksZaOG Krizp jFzPEx sc-dIouRR kAoSkv sc-gFGZVQ jLwVhQ"
           type="button"
         >
           <svg
@@ -246,13 +246,13 @@ exports[`Storyshots Core/DropDownButton No List Formatting 1`] = `
 exports[`Storyshots Core/DropDownButton With Primary Button 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
-      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-fXynhf ifKwFV sc-jIAOiI bpUFTZ"
+      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-GVOUr bFSVuL sc-TRNrF kulTqM"
     >
       <button
-        class="StyledButton-sc-323bzc-0 gvCdQt sc-breuTD sc-ksZaOG Krizp jFzPEx sc-dIouRR kAoSkv sc-TRNrF eEcMpL"
+        class="StyledButton-sc-323bzc-0 gvCdQt sc-breuTD sc-ksZaOG Krizp jFzPEx sc-dIouRR kAoSkv sc-dwLEzm yrxfS"
         type="button"
       >
         <div

--- a/src/components/Filters/__snapshots__/Filters.stories.storyshot
+++ b/src/components/Filters/__snapshots__/Filters.stories.storyshot
@@ -3,17 +3,17 @@
 exports[`Storyshots Core/Filters Button Props 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div>
       <div
-        class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-yeoIj gpSmxc"
+        class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-kYWVYA ikOJWL"
       >
         <div
           class="sc-gKXOVf QRSBg sc-iBkjds diGonb sc-hHLeRK eccixI"
         >
           <div
-            class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-kYWVYA jBjBTq"
+            class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hAsxaJ cmyIYE"
           >
             <div
               class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-kgUAyh iKIurY kCkpfb sc-hTtwUo eWqTFt"
@@ -70,10 +70,10 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
             </div>
           </button>
           <div
-            class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-fXynhf ifKwFV sc-jIAOiI fgCpgz"
+            class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-GVOUr bFSVuL sc-TRNrF bVFqNe"
           >
             <button
-              class="StyledButton-sc-323bzc-0 eBMyPP sc-breuTD sc-hAZoDl Krizp eagAYV sc-dIouRR kAoSkv sc-TRNrF eEcMpL"
+              class="StyledButton-sc-323bzc-0 eBMyPP sc-breuTD sc-hAZoDl Krizp eagAYV sc-dIouRR kAoSkv sc-dwLEzm yrxfS"
               type="button"
             >
               <div
@@ -131,7 +131,7 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
           Bulbasaur
         </h2>
         <table
-          class="sc-kGhOqx kCTKYD"
+          class="sc-chKnlQ klBmRy"
         >
           <tbody>
             <tr>
@@ -221,7 +221,7 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
           Ivysaur
         </h2>
         <table
-          class="sc-kGhOqx kCTKYD"
+          class="sc-chKnlQ klBmRy"
         >
           <tbody>
             <tr>
@@ -311,7 +311,7 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
           Venusaur
         </h2>
         <table
-          class="sc-kGhOqx kCTKYD"
+          class="sc-chKnlQ klBmRy"
         >
           <tbody>
             <tr>
@@ -401,7 +401,7 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
           Charmander
         </h2>
         <table
-          class="sc-kGhOqx kCTKYD"
+          class="sc-chKnlQ klBmRy"
         >
           <tbody>
             <tr>
@@ -491,7 +491,7 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
           Charmeleon
         </h2>
         <table
-          class="sc-kGhOqx kCTKYD"
+          class="sc-chKnlQ klBmRy"
         >
           <tbody>
             <tr>
@@ -583,7 +583,7 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
           Charizard
         </h2>
         <table
-          class="sc-kGhOqx kCTKYD"
+          class="sc-chKnlQ klBmRy"
         >
           <tbody>
             <tr>
@@ -664,10 +664,10 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
               </td>
               <td>
                 <div
-                  class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY sc-eFWqGp gPSCbK"
+                  class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY sc-bWXABl jdyMoq"
                 >
                   <div
-                    class="sc-gKXOVf QRSBg sc-iBkjds eecmTK sc-hHLeRK sc-grREDI iKIurY coRGQK"
+                    class="sc-gKXOVf QRSBg sc-iBkjds eecmTK sc-hHLeRK sc-HzFiz iKIurY fECpVO"
                   >
                     <div
                       class="sc-ivTmOn fSbxau sc-cxabCf ecsbJB"
@@ -677,10 +677,10 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY sc-eFWqGp gPSCbK"
+                  class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY sc-bWXABl jdyMoq"
                 >
                   <div
-                    class="sc-gKXOVf QRSBg sc-iBkjds eecmTK sc-hHLeRK sc-grREDI iKIurY coRGQK"
+                    class="sc-gKXOVf QRSBg sc-iBkjds eecmTK sc-hHLeRK sc-HzFiz iKIurY fECpVO"
                   >
                     <div
                       class="sc-ivTmOn fSbxau sc-cxabCf ecsbJB"
@@ -702,7 +702,7 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
           Squirtle
         </h2>
         <table
-          class="sc-kGhOqx kCTKYD"
+          class="sc-chKnlQ klBmRy"
         >
           <tbody>
             <tr>
@@ -783,10 +783,10 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
               </td>
               <td>
                 <div
-                  class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY sc-eFWqGp gPSCbK"
+                  class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY sc-bWXABl jdyMoq"
                 >
                   <div
-                    class="sc-gKXOVf QRSBg sc-iBkjds eecmTK sc-hHLeRK sc-grREDI iKIurY coRGQK"
+                    class="sc-gKXOVf QRSBg sc-iBkjds eecmTK sc-hHLeRK sc-HzFiz iKIurY fECpVO"
                   >
                     <div
                       class="sc-ivTmOn fSbxau sc-cxabCf ecsbJB"
@@ -796,10 +796,10 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY sc-eFWqGp gPSCbK"
+                  class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY sc-bWXABl jdyMoq"
                 >
                   <div
-                    class="sc-gKXOVf QRSBg sc-iBkjds eecmTK sc-hHLeRK sc-grREDI iKIurY coRGQK"
+                    class="sc-gKXOVf QRSBg sc-iBkjds eecmTK sc-hHLeRK sc-HzFiz iKIurY fECpVO"
                   >
                     <div
                       class="sc-ivTmOn fSbxau sc-cxabCf ecsbJB"
@@ -821,7 +821,7 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
           Wartortle
         </h2>
         <table
-          class="sc-kGhOqx kCTKYD"
+          class="sc-chKnlQ klBmRy"
         >
           <tbody>
             <tr>
@@ -911,7 +911,7 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
           Blastoise
         </h2>
         <table
-          class="sc-kGhOqx kCTKYD"
+          class="sc-chKnlQ klBmRy"
         >
           <tbody>
             <tr>
@@ -1001,7 +1001,7 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
           Caterpie
         </h2>
         <table
-          class="sc-kGhOqx kCTKYD"
+          class="sc-chKnlQ klBmRy"
         >
           <tbody>
             <tr>
@@ -1091,7 +1091,7 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
           Staryu
         </h2>
         <table
-          class="sc-kGhOqx kCTKYD"
+          class="sc-chKnlQ klBmRy"
         >
           <tbody>
             <tr>
@@ -1184,17 +1184,17 @@ exports[`Storyshots Core/Filters Button Props 1`] = `
 exports[`Storyshots Core/Filters Compact 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div>
       <div
-        class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-yeoIj gpSmxc"
+        class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-kYWVYA ikOJWL"
       >
         <div
           class="sc-gKXOVf QRSBg sc-iBkjds diGonb sc-hHLeRK eccixI"
         >
           <div
-            class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-kYWVYA jBjBTq"
+            class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hAsxaJ cmyIYE"
           >
             <div
               class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-kgUAyh iKIurY kCkpfb sc-hTtwUo eWqTFt"
@@ -1242,10 +1242,10 @@ exports[`Storyshots Core/Filters Compact 1`] = `
             </svg>
           </button>
           <div
-            class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-fXynhf ifKwFV sc-jIAOiI dwhOCm"
+            class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-GVOUr bFSVuL sc-TRNrF kXUaZr"
           >
             <button
-              class="StyledButton-sc-323bzc-0 eBMyPP sc-breuTD sc-hAZoDl Krizp eagAYV sc-dIouRR kAoSkv sc-TRNrF eEcMpL"
+              class="StyledButton-sc-323bzc-0 eBMyPP sc-breuTD sc-hAZoDl Krizp eagAYV sc-dIouRR kAoSkv sc-dwLEzm yrxfS"
               type="button"
             >
               <div
@@ -1298,7 +1298,7 @@ exports[`Storyshots Core/Filters Compact 1`] = `
           Bulbasaur
         </h2>
         <table
-          class="sc-kGhOqx kCTKYD"
+          class="sc-chKnlQ klBmRy"
         >
           <tbody>
             <tr>
@@ -1388,7 +1388,7 @@ exports[`Storyshots Core/Filters Compact 1`] = `
           Ivysaur
         </h2>
         <table
-          class="sc-kGhOqx kCTKYD"
+          class="sc-chKnlQ klBmRy"
         >
           <tbody>
             <tr>
@@ -1478,7 +1478,7 @@ exports[`Storyshots Core/Filters Compact 1`] = `
           Venusaur
         </h2>
         <table
-          class="sc-kGhOqx kCTKYD"
+          class="sc-chKnlQ klBmRy"
         >
           <tbody>
             <tr>
@@ -1568,7 +1568,7 @@ exports[`Storyshots Core/Filters Compact 1`] = `
           Charmander
         </h2>
         <table
-          class="sc-kGhOqx kCTKYD"
+          class="sc-chKnlQ klBmRy"
         >
           <tbody>
             <tr>
@@ -1658,7 +1658,7 @@ exports[`Storyshots Core/Filters Compact 1`] = `
           Charmeleon
         </h2>
         <table
-          class="sc-kGhOqx kCTKYD"
+          class="sc-chKnlQ klBmRy"
         >
           <tbody>
             <tr>
@@ -1750,7 +1750,7 @@ exports[`Storyshots Core/Filters Compact 1`] = `
           Charizard
         </h2>
         <table
-          class="sc-kGhOqx kCTKYD"
+          class="sc-chKnlQ klBmRy"
         >
           <tbody>
             <tr>
@@ -1831,10 +1831,10 @@ exports[`Storyshots Core/Filters Compact 1`] = `
               </td>
               <td>
                 <div
-                  class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY sc-eFWqGp gPSCbK"
+                  class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY sc-bWXABl jdyMoq"
                 >
                   <div
-                    class="sc-gKXOVf QRSBg sc-iBkjds eecmTK sc-hHLeRK sc-grREDI iKIurY coRGQK"
+                    class="sc-gKXOVf QRSBg sc-iBkjds eecmTK sc-hHLeRK sc-HzFiz iKIurY fECpVO"
                   >
                     <div
                       class="sc-ivTmOn fSbxau sc-cxabCf ecsbJB"
@@ -1844,10 +1844,10 @@ exports[`Storyshots Core/Filters Compact 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY sc-eFWqGp gPSCbK"
+                  class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY sc-bWXABl jdyMoq"
                 >
                   <div
-                    class="sc-gKXOVf QRSBg sc-iBkjds eecmTK sc-hHLeRK sc-grREDI iKIurY coRGQK"
+                    class="sc-gKXOVf QRSBg sc-iBkjds eecmTK sc-hHLeRK sc-HzFiz iKIurY fECpVO"
                   >
                     <div
                       class="sc-ivTmOn fSbxau sc-cxabCf ecsbJB"
@@ -1869,7 +1869,7 @@ exports[`Storyshots Core/Filters Compact 1`] = `
           Squirtle
         </h2>
         <table
-          class="sc-kGhOqx kCTKYD"
+          class="sc-chKnlQ klBmRy"
         >
           <tbody>
             <tr>
@@ -1950,10 +1950,10 @@ exports[`Storyshots Core/Filters Compact 1`] = `
               </td>
               <td>
                 <div
-                  class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY sc-eFWqGp gPSCbK"
+                  class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY sc-bWXABl jdyMoq"
                 >
                   <div
-                    class="sc-gKXOVf QRSBg sc-iBkjds eecmTK sc-hHLeRK sc-grREDI iKIurY coRGQK"
+                    class="sc-gKXOVf QRSBg sc-iBkjds eecmTK sc-hHLeRK sc-HzFiz iKIurY fECpVO"
                   >
                     <div
                       class="sc-ivTmOn fSbxau sc-cxabCf ecsbJB"
@@ -1963,10 +1963,10 @@ exports[`Storyshots Core/Filters Compact 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY sc-eFWqGp gPSCbK"
+                  class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY sc-bWXABl jdyMoq"
                 >
                   <div
-                    class="sc-gKXOVf QRSBg sc-iBkjds eecmTK sc-hHLeRK sc-grREDI iKIurY coRGQK"
+                    class="sc-gKXOVf QRSBg sc-iBkjds eecmTK sc-hHLeRK sc-HzFiz iKIurY fECpVO"
                   >
                     <div
                       class="sc-ivTmOn fSbxau sc-cxabCf ecsbJB"
@@ -1988,7 +1988,7 @@ exports[`Storyshots Core/Filters Compact 1`] = `
           Wartortle
         </h2>
         <table
-          class="sc-kGhOqx kCTKYD"
+          class="sc-chKnlQ klBmRy"
         >
           <tbody>
             <tr>
@@ -2078,7 +2078,7 @@ exports[`Storyshots Core/Filters Compact 1`] = `
           Blastoise
         </h2>
         <table
-          class="sc-kGhOqx kCTKYD"
+          class="sc-chKnlQ klBmRy"
         >
           <tbody>
             <tr>
@@ -2168,7 +2168,7 @@ exports[`Storyshots Core/Filters Compact 1`] = `
           Caterpie
         </h2>
         <table
-          class="sc-kGhOqx kCTKYD"
+          class="sc-chKnlQ klBmRy"
         >
           <tbody>
             <tr>
@@ -2258,7 +2258,7 @@ exports[`Storyshots Core/Filters Compact 1`] = `
           Staryu
         </h2>
         <table
-          class="sc-kGhOqx kCTKYD"
+          class="sc-chKnlQ klBmRy"
         >
           <tbody>
             <tr>
@@ -2351,17 +2351,17 @@ exports[`Storyshots Core/Filters Compact 1`] = `
 exports[`Storyshots Core/Filters Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div>
       <div
-        class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-yeoIj gpSmxc"
+        class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-kYWVYA ikOJWL"
       >
         <div
           class="sc-gKXOVf QRSBg sc-iBkjds diGonb sc-hHLeRK eccixI"
         >
           <div
-            class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-kYWVYA jBjBTq"
+            class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hAsxaJ cmyIYE"
           >
             <div
               class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-kgUAyh iKIurY kCkpfb sc-hTtwUo eWqTFt"
@@ -2417,10 +2417,10 @@ exports[`Storyshots Core/Filters Default 1`] = `
             </div>
           </button>
           <div
-            class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-fXynhf ifKwFV sc-jIAOiI dwhOCm"
+            class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-GVOUr bFSVuL sc-TRNrF kXUaZr"
           >
             <button
-              class="StyledButton-sc-323bzc-0 eBMyPP sc-breuTD sc-hAZoDl Krizp eagAYV sc-dIouRR kAoSkv sc-TRNrF eEcMpL"
+              class="StyledButton-sc-323bzc-0 eBMyPP sc-breuTD sc-hAZoDl Krizp eagAYV sc-dIouRR kAoSkv sc-dwLEzm yrxfS"
               type="button"
             >
               <div
@@ -2478,7 +2478,7 @@ exports[`Storyshots Core/Filters Default 1`] = `
           Bulbasaur
         </h2>
         <table
-          class="sc-kGhOqx kCTKYD"
+          class="sc-chKnlQ klBmRy"
         >
           <tbody>
             <tr>
@@ -2568,7 +2568,7 @@ exports[`Storyshots Core/Filters Default 1`] = `
           Ivysaur
         </h2>
         <table
-          class="sc-kGhOqx kCTKYD"
+          class="sc-chKnlQ klBmRy"
         >
           <tbody>
             <tr>
@@ -2658,7 +2658,7 @@ exports[`Storyshots Core/Filters Default 1`] = `
           Venusaur
         </h2>
         <table
-          class="sc-kGhOqx kCTKYD"
+          class="sc-chKnlQ klBmRy"
         >
           <tbody>
             <tr>
@@ -2748,7 +2748,7 @@ exports[`Storyshots Core/Filters Default 1`] = `
           Charmander
         </h2>
         <table
-          class="sc-kGhOqx kCTKYD"
+          class="sc-chKnlQ klBmRy"
         >
           <tbody>
             <tr>
@@ -2838,7 +2838,7 @@ exports[`Storyshots Core/Filters Default 1`] = `
           Charmeleon
         </h2>
         <table
-          class="sc-kGhOqx kCTKYD"
+          class="sc-chKnlQ klBmRy"
         >
           <tbody>
             <tr>
@@ -2930,7 +2930,7 @@ exports[`Storyshots Core/Filters Default 1`] = `
           Charizard
         </h2>
         <table
-          class="sc-kGhOqx kCTKYD"
+          class="sc-chKnlQ klBmRy"
         >
           <tbody>
             <tr>
@@ -3011,10 +3011,10 @@ exports[`Storyshots Core/Filters Default 1`] = `
               </td>
               <td>
                 <div
-                  class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY sc-eFWqGp gPSCbK"
+                  class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY sc-bWXABl jdyMoq"
                 >
                   <div
-                    class="sc-gKXOVf QRSBg sc-iBkjds eecmTK sc-hHLeRK sc-grREDI iKIurY coRGQK"
+                    class="sc-gKXOVf QRSBg sc-iBkjds eecmTK sc-hHLeRK sc-HzFiz iKIurY fECpVO"
                   >
                     <div
                       class="sc-ivTmOn fSbxau sc-cxabCf ecsbJB"
@@ -3024,10 +3024,10 @@ exports[`Storyshots Core/Filters Default 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY sc-eFWqGp gPSCbK"
+                  class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY sc-bWXABl jdyMoq"
                 >
                   <div
-                    class="sc-gKXOVf QRSBg sc-iBkjds eecmTK sc-hHLeRK sc-grREDI iKIurY coRGQK"
+                    class="sc-gKXOVf QRSBg sc-iBkjds eecmTK sc-hHLeRK sc-HzFiz iKIurY fECpVO"
                   >
                     <div
                       class="sc-ivTmOn fSbxau sc-cxabCf ecsbJB"
@@ -3049,7 +3049,7 @@ exports[`Storyshots Core/Filters Default 1`] = `
           Squirtle
         </h2>
         <table
-          class="sc-kGhOqx kCTKYD"
+          class="sc-chKnlQ klBmRy"
         >
           <tbody>
             <tr>
@@ -3130,10 +3130,10 @@ exports[`Storyshots Core/Filters Default 1`] = `
               </td>
               <td>
                 <div
-                  class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY sc-eFWqGp gPSCbK"
+                  class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY sc-bWXABl jdyMoq"
                 >
                   <div
-                    class="sc-gKXOVf QRSBg sc-iBkjds eecmTK sc-hHLeRK sc-grREDI iKIurY coRGQK"
+                    class="sc-gKXOVf QRSBg sc-iBkjds eecmTK sc-hHLeRK sc-HzFiz iKIurY fECpVO"
                   >
                     <div
                       class="sc-ivTmOn fSbxau sc-cxabCf ecsbJB"
@@ -3143,10 +3143,10 @@ exports[`Storyshots Core/Filters Default 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY sc-eFWqGp gPSCbK"
+                  class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY sc-bWXABl jdyMoq"
                 >
                   <div
-                    class="sc-gKXOVf QRSBg sc-iBkjds eecmTK sc-hHLeRK sc-grREDI iKIurY coRGQK"
+                    class="sc-gKXOVf QRSBg sc-iBkjds eecmTK sc-hHLeRK sc-HzFiz iKIurY fECpVO"
                   >
                     <div
                       class="sc-ivTmOn fSbxau sc-cxabCf ecsbJB"
@@ -3168,7 +3168,7 @@ exports[`Storyshots Core/Filters Default 1`] = `
           Wartortle
         </h2>
         <table
-          class="sc-kGhOqx kCTKYD"
+          class="sc-chKnlQ klBmRy"
         >
           <tbody>
             <tr>
@@ -3258,7 +3258,7 @@ exports[`Storyshots Core/Filters Default 1`] = `
           Blastoise
         </h2>
         <table
-          class="sc-kGhOqx kCTKYD"
+          class="sc-chKnlQ klBmRy"
         >
           <tbody>
             <tr>
@@ -3348,7 +3348,7 @@ exports[`Storyshots Core/Filters Default 1`] = `
           Caterpie
         </h2>
         <table
-          class="sc-kGhOqx kCTKYD"
+          class="sc-chKnlQ klBmRy"
         >
           <tbody>
             <tr>
@@ -3438,7 +3438,7 @@ exports[`Storyshots Core/Filters Default 1`] = `
           Staryu
         </h2>
         <table
-          class="sc-kGhOqx kCTKYD"
+          class="sc-chKnlQ klBmRy"
         >
           <tbody>
             <tr>
@@ -3531,17 +3531,17 @@ exports[`Storyshots Core/Filters Default 1`] = `
 exports[`Storyshots Core/Filters Disabled 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div>
       <div
-        class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-yeoIj gpSmxc"
+        class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-kYWVYA ikOJWL"
       >
         <div
           class="sc-gKXOVf QRSBg sc-iBkjds diGonb sc-hHLeRK eccixI"
         >
           <div
-            class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-kYWVYA jBjBTq"
+            class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hAsxaJ cmyIYE"
           >
             <div
               class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-kgUAyh iKIurY kCkpfb sc-hTtwUo eWqTFt"
@@ -3599,11 +3599,11 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
             </div>
           </button>
           <div
-            class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-fXynhf ifKwFV sc-jIAOiI dwhOCm"
+            class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-GVOUr bFSVuL sc-TRNrF kXUaZr"
             disabled=""
           >
             <button
-              class="StyledButton-sc-323bzc-0 kyINdh sc-breuTD sc-hAZoDl Krizp eagAYV sc-dIouRR kAoSkv sc-TRNrF eEcMpL"
+              class="StyledButton-sc-323bzc-0 kyINdh sc-breuTD sc-hAZoDl Krizp eagAYV sc-dIouRR kAoSkv sc-dwLEzm yrxfS"
               disabled=""
               type="button"
             >
@@ -3662,7 +3662,7 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
           Bulbasaur
         </h2>
         <table
-          class="sc-kGhOqx kCTKYD"
+          class="sc-chKnlQ klBmRy"
         >
           <tbody>
             <tr>
@@ -3752,7 +3752,7 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
           Ivysaur
         </h2>
         <table
-          class="sc-kGhOqx kCTKYD"
+          class="sc-chKnlQ klBmRy"
         >
           <tbody>
             <tr>
@@ -3842,7 +3842,7 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
           Venusaur
         </h2>
         <table
-          class="sc-kGhOqx kCTKYD"
+          class="sc-chKnlQ klBmRy"
         >
           <tbody>
             <tr>
@@ -3932,7 +3932,7 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
           Charmander
         </h2>
         <table
-          class="sc-kGhOqx kCTKYD"
+          class="sc-chKnlQ klBmRy"
         >
           <tbody>
             <tr>
@@ -4022,7 +4022,7 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
           Charmeleon
         </h2>
         <table
-          class="sc-kGhOqx kCTKYD"
+          class="sc-chKnlQ klBmRy"
         >
           <tbody>
             <tr>
@@ -4114,7 +4114,7 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
           Charizard
         </h2>
         <table
-          class="sc-kGhOqx kCTKYD"
+          class="sc-chKnlQ klBmRy"
         >
           <tbody>
             <tr>
@@ -4195,10 +4195,10 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
               </td>
               <td>
                 <div
-                  class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY sc-eFWqGp gPSCbK"
+                  class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY sc-bWXABl jdyMoq"
                 >
                   <div
-                    class="sc-gKXOVf QRSBg sc-iBkjds eecmTK sc-hHLeRK sc-grREDI iKIurY coRGQK"
+                    class="sc-gKXOVf QRSBg sc-iBkjds eecmTK sc-hHLeRK sc-HzFiz iKIurY fECpVO"
                   >
                     <div
                       class="sc-ivTmOn fSbxau sc-cxabCf ecsbJB"
@@ -4208,10 +4208,10 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY sc-eFWqGp gPSCbK"
+                  class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY sc-bWXABl jdyMoq"
                 >
                   <div
-                    class="sc-gKXOVf QRSBg sc-iBkjds eecmTK sc-hHLeRK sc-grREDI iKIurY coRGQK"
+                    class="sc-gKXOVf QRSBg sc-iBkjds eecmTK sc-hHLeRK sc-HzFiz iKIurY fECpVO"
                   >
                     <div
                       class="sc-ivTmOn fSbxau sc-cxabCf ecsbJB"
@@ -4233,7 +4233,7 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
           Squirtle
         </h2>
         <table
-          class="sc-kGhOqx kCTKYD"
+          class="sc-chKnlQ klBmRy"
         >
           <tbody>
             <tr>
@@ -4314,10 +4314,10 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
               </td>
               <td>
                 <div
-                  class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY sc-eFWqGp gPSCbK"
+                  class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY sc-bWXABl jdyMoq"
                 >
                   <div
-                    class="sc-gKXOVf QRSBg sc-iBkjds eecmTK sc-hHLeRK sc-grREDI iKIurY coRGQK"
+                    class="sc-gKXOVf QRSBg sc-iBkjds eecmTK sc-hHLeRK sc-HzFiz iKIurY fECpVO"
                   >
                     <div
                       class="sc-ivTmOn fSbxau sc-cxabCf ecsbJB"
@@ -4327,10 +4327,10 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY sc-eFWqGp gPSCbK"
+                  class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY sc-bWXABl jdyMoq"
                 >
                   <div
-                    class="sc-gKXOVf QRSBg sc-iBkjds eecmTK sc-hHLeRK sc-grREDI iKIurY coRGQK"
+                    class="sc-gKXOVf QRSBg sc-iBkjds eecmTK sc-hHLeRK sc-HzFiz iKIurY fECpVO"
                   >
                     <div
                       class="sc-ivTmOn fSbxau sc-cxabCf ecsbJB"
@@ -4352,7 +4352,7 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
           Wartortle
         </h2>
         <table
-          class="sc-kGhOqx kCTKYD"
+          class="sc-chKnlQ klBmRy"
         >
           <tbody>
             <tr>
@@ -4442,7 +4442,7 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
           Blastoise
         </h2>
         <table
-          class="sc-kGhOqx kCTKYD"
+          class="sc-chKnlQ klBmRy"
         >
           <tbody>
             <tr>
@@ -4532,7 +4532,7 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
           Caterpie
         </h2>
         <table
-          class="sc-kGhOqx kCTKYD"
+          class="sc-chKnlQ klBmRy"
         >
           <tbody>
             <tr>
@@ -4622,7 +4622,7 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
           Staryu
         </h2>
         <table
-          class="sc-kGhOqx kCTKYD"
+          class="sc-chKnlQ klBmRy"
         >
           <tbody>
             <tr>
@@ -4715,11 +4715,11 @@ exports[`Storyshots Core/Filters Disabled 1`] = `
 exports[`Storyshots Core/Filters Render Modes 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div>
       <div
-        class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-yeoIj gpSmxc"
+        class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-kYWVYA ikOJWL"
       >
         <div
           class="sc-gKXOVf QRSBg sc-iBkjds diGonb sc-hHLeRK eccixI"
@@ -4753,10 +4753,10 @@ exports[`Storyshots Core/Filters Render Modes 1`] = `
             </div>
           </button>
           <div
-            class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-fXynhf ifKwFV sc-jIAOiI dwhOCm"
+            class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-GVOUr bFSVuL sc-TRNrF kXUaZr"
           >
             <button
-              class="StyledButton-sc-323bzc-0 eBMyPP sc-breuTD sc-hAZoDl Krizp eagAYV sc-dIouRR kAoSkv sc-TRNrF eEcMpL"
+              class="StyledButton-sc-323bzc-0 eBMyPP sc-breuTD sc-hAZoDl Krizp eagAYV sc-dIouRR kAoSkv sc-dwLEzm yrxfS"
               type="button"
             >
               <div
@@ -4869,14 +4869,14 @@ exports[`Storyshots Core/Filters Render Modes 1`] = `
             class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK cINHHz"
           >
             <div
-              class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY sc-eFWqGp fxSWNL"
+              class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY sc-bWXABl jYkNYP"
             >
               <button
                 class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv"
                 type="button"
               >
                 <div
-                  class="sc-gKXOVf QRSBg sc-iBkjds eecmTK sc-hHLeRK sc-grREDI iKIurY coRGQK"
+                  class="sc-gKXOVf QRSBg sc-iBkjds eecmTK sc-hHLeRK sc-HzFiz iKIurY fECpVO"
                 >
                   <div
                     class="sc-ivTmOn qStAn sc-cxabCf ecsbJB"
@@ -4906,7 +4906,7 @@ exports[`Storyshots Core/Filters Render Modes 1`] = `
                 </div>
               </button>
               <button
-                class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR bXRmqK sc-bWXABl cmijpj"
+                class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR bXRmqK sc-grREDI bSUine"
                 type="button"
               >
                 <svg
@@ -4934,7 +4934,7 @@ exports[`Storyshots Core/Filters Render Modes 1`] = `
           Squirtle
         </h2>
         <table
-          class="sc-kGhOqx kCTKYD"
+          class="sc-chKnlQ klBmRy"
         >
           <tbody>
             <tr>
@@ -5015,10 +5015,10 @@ exports[`Storyshots Core/Filters Render Modes 1`] = `
               </td>
               <td>
                 <div
-                  class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY sc-eFWqGp gPSCbK"
+                  class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY sc-bWXABl jdyMoq"
                 >
                   <div
-                    class="sc-gKXOVf QRSBg sc-iBkjds eecmTK sc-hHLeRK sc-grREDI iKIurY coRGQK"
+                    class="sc-gKXOVf QRSBg sc-iBkjds eecmTK sc-hHLeRK sc-HzFiz iKIurY fECpVO"
                   >
                     <div
                       class="sc-ivTmOn fSbxau sc-cxabCf ecsbJB"
@@ -5028,10 +5028,10 @@ exports[`Storyshots Core/Filters Render Modes 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY sc-eFWqGp gPSCbK"
+                  class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY sc-bWXABl jdyMoq"
                 >
                   <div
-                    class="sc-gKXOVf QRSBg sc-iBkjds eecmTK sc-hHLeRK sc-grREDI iKIurY coRGQK"
+                    class="sc-gKXOVf QRSBg sc-iBkjds eecmTK sc-hHLeRK sc-HzFiz iKIurY fECpVO"
                   >
                     <div
                       class="sc-ivTmOn fSbxau sc-cxabCf ecsbJB"

--- a/src/components/Fixed/__snapshots__/Fixed.stories.storyshot
+++ b/src/components/Fixed/__snapshots__/Fixed.stories.storyshot
@@ -3,10 +3,10 @@
 exports[`Storyshots Core/Fixed Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
-      class="sc-lbOyJj kOguap sc-gFGZVQ hEzhxc"
+      class="sc-ehmTmK fUhDFP sc-lbOyJj gkWBlr"
     />
   </div>
 </div>

--- a/src/components/Flex/__snapshots__/Flex.stories.storyshot
+++ b/src/components/Flex/__snapshots__/Flex.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/Flex Column Direction 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK eTSHtc"
@@ -28,7 +28,7 @@ exports[`Storyshots Core/Flex Column Direction 1`] = `
 exports[`Storyshots Core/Flex Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY"
@@ -53,7 +53,7 @@ exports[`Storyshots Core/Flex Default 1`] = `
 exports[`Storyshots Core/Flex Flex On Children 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK cINHHz"
@@ -86,7 +86,7 @@ exports[`Storyshots Core/Flex Flex On Children 1`] = `
 exports[`Storyshots Core/Flex Justified 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK eccixI"
@@ -111,7 +111,7 @@ exports[`Storyshots Core/Flex Justified 1`] = `
 exports[`Storyshots Core/Flex Wrap 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK cINHHz"

--- a/src/components/Form/__snapshots__/Form.stories.storyshot
+++ b/src/components/Form/__snapshots__/Form.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/Form Custom Submit Text 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY"
@@ -12,7 +12,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
         class="sc-gKXOVf ckXSHX sc-iBkjds bUOvBx"
       >
         <div
-          class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-ikjQzJ cjgMSN"
+          class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-WCkqM hiazeD"
         >
           <form
             class="rjsf"
@@ -22,7 +22,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
             >
               <section>
                 <legend
-                  class="sc-brCFrO jgvKuH"
+                  class="sc-dFdIVH kFYeai"
                   id="root__title"
                 >
                   Pokèmon
@@ -37,7 +37,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-string rendition-form__field--root_Name"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_Name"
                       >
                         Name
@@ -48,7 +48,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                         
                         <input
                           autocomplete="off"
-                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL fnlgoU sc-olbas cYXHg"
+                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi bMvozQ sc-eKszNL kpyrby"
                           id="root_Name"
                           label="Name"
                           list="dummy-datalist"
@@ -69,7 +69,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-number rendition-form__field--root_Height"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_Height"
                       >
                         Height
@@ -79,7 +79,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL fnlgoU sc-olbas cYXHg"
+                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi bMvozQ sc-eKszNL kpyrby"
                           id="root_Height"
                           label="Height"
                           placeholder=""
@@ -96,7 +96,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-number rendition-form__field--root_Weight"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_Weight"
                       >
                         Weight
@@ -106,7 +106,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL fnlgoU sc-olbas cYXHg"
+                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi bMvozQ sc-eKszNL kpyrby"
                           id="root_Weight"
                           label="Weight"
                           placeholder=""
@@ -123,7 +123,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-string rendition-form__field--root_Description"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_Description"
                       >
                         Description
@@ -133,7 +133,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL fnlgoU sc-olbas cYXHg"
+                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi bMvozQ sc-eKszNL kpyrby"
                           id="root_Description"
                           label="Description"
                           placeholder=""
@@ -150,7 +150,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-string rendition-form__field--root_Category"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_Category"
                       >
                         Category
@@ -160,7 +160,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL fnlgoU sc-olbas cYXHg"
+                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi bMvozQ sc-eKszNL kpyrby"
                           id="root_Category"
                           label="Category"
                           placeholder=""
@@ -177,7 +177,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-string rendition-form__field--root_Abilities"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_Abilities"
                       >
                         Abilities
@@ -187,7 +187,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL fnlgoU sc-olbas cYXHg"
+                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi bMvozQ sc-eKszNL kpyrby"
                           id="root_Abilities"
                           label="Abilities"
                           placeholder=""
@@ -204,7 +204,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-number rendition-form__field--root_pokedex_number"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_pokedex_number"
                       >
                         National Pokèdex Number
@@ -214,7 +214,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL fnlgoU sc-olbas cYXHg"
+                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi bMvozQ sc-eKszNL kpyrby"
                           id="root_pokedex_number"
                           label="National Pokèdex Number"
                           placeholder=""
@@ -252,17 +252,17 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-string rendition-form__field--root_first_seen"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_first_seen"
                       >
                         First seen
                       </label>
                       <div
-                        class="sc-gKXOVf QRSBg sc-iBkjds QRvXl sc-hHLeRK dzJWYl sc-dFdIVH fxOFjV rendition-form-description"
+                        class="sc-gKXOVf QRSBg sc-iBkjds QRvXl sc-hHLeRK dzJWYl sc-csvncw bswcwg rendition-form-description"
                         id="root_first_seen__description"
                       >
                         <div
-                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-chKnlQ jMOuPF"
+                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-kIZKsT geXume"
                         >
                           <div>
                             <p
@@ -278,7 +278,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL fnlgoU sc-olbas cYXHg"
+                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi bMvozQ sc-eKszNL kpyrby"
                           id="root_first_seen"
                           label="First seen"
                           placeholder=""
@@ -295,17 +295,17 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-string rendition-form__field--root_poke_password"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_poke_password"
                       >
                         Poke Password
                       </label>
                       <div
-                        class="sc-gKXOVf QRSBg sc-iBkjds QRvXl sc-hHLeRK dzJWYl sc-dFdIVH fxOFjV rendition-form-description"
+                        class="sc-gKXOVf QRSBg sc-iBkjds QRvXl sc-hHLeRK dzJWYl sc-csvncw bswcwg rendition-form-description"
                         id="root_poke_password__description"
                       >
                         <div
-                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-chKnlQ jMOuPF"
+                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-kIZKsT geXume"
                         >
                           <div>
                             <p
@@ -321,7 +321,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL fnlgoU sc-olbas cYXHg"
+                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi bMvozQ sc-eKszNL kpyrby"
                           id="root_poke_password"
                           label="Poke Password"
                           placeholder=""
@@ -338,13 +338,13 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-string rendition-form__field--root_environment"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_environment"
                       >
                         environment
                       </label>
                       <div
-                        class="sc-iNWwEs iFVTvX sc-jfmDQi byZsiK"
+                        class="sc-lbxAil pYSLc sc-iNWwEs bpgSQG"
                       >
                         <button
                           aria-label="Open Drop"
@@ -363,7 +363,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                               >
                                 <input
                                   autocomplete="off"
-                                  class="StyledTextInput-sc-1x30a0s-0 ewHtlx Select__SelectTextInput-sc-17idtfo-0 bQAqdj sc-lbxAil gvSMeT"
+                                  class="StyledTextInput-sc-1x30a0s-0 ewHtlx Select__SelectTextInput-sc-17idtfo-0 bQAqdj sc-gSAPjG hCdWnJ"
                                   id="root_environment__input"
                                   readonly=""
                                   tabindex="-1"
@@ -402,17 +402,17 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
                     >
                       <div>
                         <legend
-                          class="sc-brCFrO jgvKuH"
+                          class="sc-dFdIVH kFYeai"
                           id="root_tags__title"
                         >
                           Tags
                         </legend>
                         <div
-                          class="sc-gKXOVf QRSBg sc-iBkjds QRvXl sc-hHLeRK dzJWYl sc-dFdIVH fxOFjV rendition-form-description"
+                          class="sc-gKXOVf QRSBg sc-iBkjds QRvXl sc-hHLeRK dzJWYl sc-csvncw bswcwg rendition-form-description"
                           id="root_tags__description"
                         >
                           <div
-                            class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-chKnlQ jMOuPF"
+                            class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-kIZKsT geXume"
                           >
                             <div>
                               <p
@@ -485,7 +485,7 @@ exports[`Storyshots Core/Form Custom Submit Text 1`] = `
 exports[`Storyshots Core/Form Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY"
@@ -494,7 +494,7 @@ exports[`Storyshots Core/Form Default 1`] = `
         class="sc-gKXOVf ckXSHX sc-iBkjds bUOvBx"
       >
         <div
-          class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-ikjQzJ cjgMSN"
+          class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-WCkqM hiazeD"
         >
           <form
             class="rjsf"
@@ -504,7 +504,7 @@ exports[`Storyshots Core/Form Default 1`] = `
             >
               <section>
                 <legend
-                  class="sc-brCFrO jgvKuH"
+                  class="sc-dFdIVH kFYeai"
                   id="root__title"
                 >
                   Pokèmon
@@ -519,7 +519,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-string rendition-form__field--root_Name"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_Name"
                       >
                         Name
@@ -530,7 +530,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                         
                         <input
                           autocomplete="off"
-                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL fnlgoU sc-olbas cYXHg"
+                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi bMvozQ sc-eKszNL kpyrby"
                           id="root_Name"
                           label="Name"
                           list="dummy-datalist"
@@ -551,7 +551,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-number rendition-form__field--root_Height"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_Height"
                       >
                         Height
@@ -561,7 +561,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL fnlgoU sc-olbas cYXHg"
+                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi bMvozQ sc-eKszNL kpyrby"
                           id="root_Height"
                           label="Height"
                           placeholder=""
@@ -578,7 +578,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-number rendition-form__field--root_Weight"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_Weight"
                       >
                         Weight
@@ -588,7 +588,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL fnlgoU sc-olbas cYXHg"
+                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi bMvozQ sc-eKszNL kpyrby"
                           id="root_Weight"
                           label="Weight"
                           placeholder=""
@@ -605,7 +605,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-string rendition-form__field--root_Description"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_Description"
                       >
                         Description
@@ -615,7 +615,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL fnlgoU sc-olbas cYXHg"
+                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi bMvozQ sc-eKszNL kpyrby"
                           id="root_Description"
                           label="Description"
                           placeholder=""
@@ -632,7 +632,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-string rendition-form__field--root_Category"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_Category"
                       >
                         Category
@@ -642,7 +642,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL fnlgoU sc-olbas cYXHg"
+                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi bMvozQ sc-eKszNL kpyrby"
                           id="root_Category"
                           label="Category"
                           placeholder=""
@@ -659,7 +659,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-string rendition-form__field--root_Abilities"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_Abilities"
                       >
                         Abilities
@@ -669,7 +669,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL fnlgoU sc-olbas cYXHg"
+                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi bMvozQ sc-eKszNL kpyrby"
                           id="root_Abilities"
                           label="Abilities"
                           placeholder=""
@@ -686,7 +686,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-number rendition-form__field--root_pokedex_number"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_pokedex_number"
                       >
                         National Pokèdex Number
@@ -696,7 +696,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL fnlgoU sc-olbas cYXHg"
+                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi bMvozQ sc-eKszNL kpyrby"
                           id="root_pokedex_number"
                           label="National Pokèdex Number"
                           placeholder=""
@@ -734,17 +734,17 @@ exports[`Storyshots Core/Form Default 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-string rendition-form__field--root_first_seen"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_first_seen"
                       >
                         First seen
                       </label>
                       <div
-                        class="sc-gKXOVf QRSBg sc-iBkjds QRvXl sc-hHLeRK dzJWYl sc-dFdIVH fxOFjV rendition-form-description"
+                        class="sc-gKXOVf QRSBg sc-iBkjds QRvXl sc-hHLeRK dzJWYl sc-csvncw bswcwg rendition-form-description"
                         id="root_first_seen__description"
                       >
                         <div
-                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-chKnlQ jMOuPF"
+                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-kIZKsT geXume"
                         >
                           <div>
                             <p
@@ -760,7 +760,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL fnlgoU sc-olbas cYXHg"
+                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi bMvozQ sc-eKszNL kpyrby"
                           id="root_first_seen"
                           label="First seen"
                           placeholder=""
@@ -777,17 +777,17 @@ exports[`Storyshots Core/Form Default 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-string rendition-form__field--root_poke_password"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_poke_password"
                       >
                         Poke Password
                       </label>
                       <div
-                        class="sc-gKXOVf QRSBg sc-iBkjds QRvXl sc-hHLeRK dzJWYl sc-dFdIVH fxOFjV rendition-form-description"
+                        class="sc-gKXOVf QRSBg sc-iBkjds QRvXl sc-hHLeRK dzJWYl sc-csvncw bswcwg rendition-form-description"
                         id="root_poke_password__description"
                       >
                         <div
-                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-chKnlQ jMOuPF"
+                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-kIZKsT geXume"
                         >
                           <div>
                             <p
@@ -803,7 +803,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL fnlgoU sc-olbas cYXHg"
+                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi bMvozQ sc-eKszNL kpyrby"
                           id="root_poke_password"
                           label="Poke Password"
                           placeholder=""
@@ -820,13 +820,13 @@ exports[`Storyshots Core/Form Default 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-string rendition-form__field--root_environment"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_environment"
                       >
                         environment
                       </label>
                       <div
-                        class="sc-iNWwEs iFVTvX sc-jfmDQi byZsiK"
+                        class="sc-lbxAil pYSLc sc-iNWwEs bpgSQG"
                       >
                         <button
                           aria-label="Open Drop"
@@ -845,7 +845,7 @@ exports[`Storyshots Core/Form Default 1`] = `
                               >
                                 <input
                                   autocomplete="off"
-                                  class="StyledTextInput-sc-1x30a0s-0 ewHtlx Select__SelectTextInput-sc-17idtfo-0 bQAqdj sc-lbxAil gvSMeT"
+                                  class="StyledTextInput-sc-1x30a0s-0 ewHtlx Select__SelectTextInput-sc-17idtfo-0 bQAqdj sc-gSAPjG hCdWnJ"
                                   id="root_environment__input"
                                   readonly=""
                                   tabindex="-1"
@@ -884,17 +884,17 @@ exports[`Storyshots Core/Form Default 1`] = `
                     >
                       <div>
                         <legend
-                          class="sc-brCFrO jgvKuH"
+                          class="sc-dFdIVH kFYeai"
                           id="root_tags__title"
                         >
                           Tags
                         </legend>
                         <div
-                          class="sc-gKXOVf QRSBg sc-iBkjds QRvXl sc-hHLeRK dzJWYl sc-dFdIVH fxOFjV rendition-form-description"
+                          class="sc-gKXOVf QRSBg sc-iBkjds QRvXl sc-hHLeRK dzJWYl sc-csvncw bswcwg rendition-form-description"
                           id="root_tags__description"
                         >
                           <div
-                            class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-chKnlQ jMOuPF"
+                            class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-kIZKsT geXume"
                           >
                             <div>
                               <p
@@ -967,7 +967,7 @@ exports[`Storyshots Core/Form Default 1`] = `
 exports[`Storyshots Core/Form Disabled 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY"
@@ -976,7 +976,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
         class="sc-gKXOVf ckXSHX sc-iBkjds bUOvBx"
       >
         <div
-          class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-ikjQzJ cjgMSN"
+          class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-WCkqM hiazeD"
         >
           <form
             class="rjsf"
@@ -986,7 +986,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
             >
               <section>
                 <legend
-                  class="sc-brCFrO jgvKuH"
+                  class="sc-dFdIVH kFYeai"
                   id="root__title"
                 >
                   Pokèmon
@@ -1001,7 +1001,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-string rendition-form__field--root_Name"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_Name"
                       >
                         Name
@@ -1012,7 +1012,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                         
                         <input
                           autocomplete="off"
-                          class="StyledTextInput-sc-1x30a0s-0 wCJnS sc-eKszNL cmzDnv sc-olbas cYXHg"
+                          class="StyledTextInput-sc-1x30a0s-0 wCJnS sc-jfmDQi gsojrT sc-eKszNL kpyrby"
                           disabled=""
                           id="root_Name"
                           label="Name"
@@ -1034,7 +1034,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-number rendition-form__field--root_Height"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_Height"
                       >
                         Height
@@ -1044,7 +1044,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 wCJnS sc-eKszNL cmzDnv sc-olbas cYXHg"
+                          class="StyledTextInput-sc-1x30a0s-0 wCJnS sc-jfmDQi gsojrT sc-eKszNL kpyrby"
                           disabled=""
                           id="root_Height"
                           label="Height"
@@ -1062,7 +1062,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-number rendition-form__field--root_Weight"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_Weight"
                       >
                         Weight
@@ -1072,7 +1072,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 wCJnS sc-eKszNL cmzDnv sc-olbas cYXHg"
+                          class="StyledTextInput-sc-1x30a0s-0 wCJnS sc-jfmDQi gsojrT sc-eKszNL kpyrby"
                           disabled=""
                           id="root_Weight"
                           label="Weight"
@@ -1090,7 +1090,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-string rendition-form__field--root_Description"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_Description"
                       >
                         Description
@@ -1100,7 +1100,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 wCJnS sc-eKszNL cmzDnv sc-olbas cYXHg"
+                          class="StyledTextInput-sc-1x30a0s-0 wCJnS sc-jfmDQi gsojrT sc-eKszNL kpyrby"
                           disabled=""
                           id="root_Description"
                           label="Description"
@@ -1118,7 +1118,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-string rendition-form__field--root_Category"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_Category"
                       >
                         Category
@@ -1128,7 +1128,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 wCJnS sc-eKszNL cmzDnv sc-olbas cYXHg"
+                          class="StyledTextInput-sc-1x30a0s-0 wCJnS sc-jfmDQi gsojrT sc-eKszNL kpyrby"
                           disabled=""
                           id="root_Category"
                           label="Category"
@@ -1146,7 +1146,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-string rendition-form__field--root_Abilities"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_Abilities"
                       >
                         Abilities
@@ -1156,7 +1156,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 wCJnS sc-eKszNL cmzDnv sc-olbas cYXHg"
+                          class="StyledTextInput-sc-1x30a0s-0 wCJnS sc-jfmDQi gsojrT sc-eKszNL kpyrby"
                           disabled=""
                           id="root_Abilities"
                           label="Abilities"
@@ -1174,7 +1174,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-number rendition-form__field--root_pokedex_number"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_pokedex_number"
                       >
                         National Pokèdex Number
@@ -1184,7 +1184,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 wCJnS sc-eKszNL cmzDnv sc-olbas cYXHg"
+                          class="StyledTextInput-sc-1x30a0s-0 wCJnS sc-jfmDQi gsojrT sc-eKszNL kpyrby"
                           disabled=""
                           id="root_pokedex_number"
                           label="National Pokèdex Number"
@@ -1224,17 +1224,17 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-string rendition-form__field--root_first_seen"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_first_seen"
                       >
                         First seen
                       </label>
                       <div
-                        class="sc-gKXOVf QRSBg sc-iBkjds QRvXl sc-hHLeRK dzJWYl sc-dFdIVH fxOFjV rendition-form-description"
+                        class="sc-gKXOVf QRSBg sc-iBkjds QRvXl sc-hHLeRK dzJWYl sc-csvncw bswcwg rendition-form-description"
                         id="root_first_seen__description"
                       >
                         <div
-                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-chKnlQ jMOuPF"
+                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-kIZKsT geXume"
                         >
                           <div>
                             <p
@@ -1250,7 +1250,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 wCJnS sc-eKszNL cmzDnv sc-olbas cYXHg"
+                          class="StyledTextInput-sc-1x30a0s-0 wCJnS sc-jfmDQi gsojrT sc-eKszNL kpyrby"
                           disabled=""
                           id="root_first_seen"
                           label="First seen"
@@ -1268,17 +1268,17 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-string rendition-form__field--root_poke_password"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_poke_password"
                       >
                         Poke Password
                       </label>
                       <div
-                        class="sc-gKXOVf QRSBg sc-iBkjds QRvXl sc-hHLeRK dzJWYl sc-dFdIVH fxOFjV rendition-form-description"
+                        class="sc-gKXOVf QRSBg sc-iBkjds QRvXl sc-hHLeRK dzJWYl sc-csvncw bswcwg rendition-form-description"
                         id="root_poke_password__description"
                       >
                         <div
-                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-chKnlQ jMOuPF"
+                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-kIZKsT geXume"
                         >
                           <div>
                             <p
@@ -1294,7 +1294,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 wCJnS sc-eKszNL cmzDnv sc-olbas cYXHg"
+                          class="StyledTextInput-sc-1x30a0s-0 wCJnS sc-jfmDQi gsojrT sc-eKszNL kpyrby"
                           disabled=""
                           id="root_poke_password"
                           label="Poke Password"
@@ -1312,13 +1312,13 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-string rendition-form__field--root_environment"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_environment"
                       >
                         environment
                       </label>
                       <div
-                        class="sc-iNWwEs iFVTvX sc-jfmDQi byZsiK"
+                        class="sc-lbxAil pYSLc sc-iNWwEs bpgSQG"
                       >
                         <button
                           aria-label="Open Drop"
@@ -1338,7 +1338,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                               >
                                 <input
                                   autocomplete="off"
-                                  class="StyledTextInput-sc-1x30a0s-0 ewHtlx Select__SelectTextInput-sc-17idtfo-0 fDnYDX sc-lbxAil gvSMeT"
+                                  class="StyledTextInput-sc-1x30a0s-0 ewHtlx Select__SelectTextInput-sc-17idtfo-0 fDnYDX sc-gSAPjG hCdWnJ"
                                   id="root_environment__input"
                                   readonly=""
                                   tabindex="-1"
@@ -1377,17 +1377,17 @@ exports[`Storyshots Core/Form Disabled 1`] = `
                     >
                       <div>
                         <legend
-                          class="sc-brCFrO jgvKuH"
+                          class="sc-dFdIVH kFYeai"
                           id="root_tags__title"
                         >
                           Tags
                         </legend>
                         <div
-                          class="sc-gKXOVf QRSBg sc-iBkjds QRvXl sc-hHLeRK dzJWYl sc-dFdIVH fxOFjV rendition-form-description"
+                          class="sc-gKXOVf QRSBg sc-iBkjds QRvXl sc-hHLeRK dzJWYl sc-csvncw bswcwg rendition-form-description"
                           id="root_tags__description"
                         >
                           <div
-                            class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-chKnlQ jMOuPF"
+                            class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-kIZKsT geXume"
                           >
                             <div>
                               <p
@@ -1460,7 +1460,7 @@ exports[`Storyshots Core/Form Disabled 1`] = `
 exports[`Storyshots Core/Form Hidden Submit 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY"
@@ -1469,7 +1469,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
         class="sc-gKXOVf ckXSHX sc-iBkjds bUOvBx"
       >
         <div
-          class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-ikjQzJ cjgMSN"
+          class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-WCkqM hiazeD"
         >
           <form
             class="rjsf"
@@ -1479,7 +1479,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
             >
               <section>
                 <legend
-                  class="sc-brCFrO jgvKuH"
+                  class="sc-dFdIVH kFYeai"
                   id="root__title"
                 >
                   Pokèmon
@@ -1494,7 +1494,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-string rendition-form__field--root_Name"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_Name"
                       >
                         Name
@@ -1505,7 +1505,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                         
                         <input
                           autocomplete="off"
-                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL fnlgoU sc-olbas cYXHg"
+                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi bMvozQ sc-eKszNL kpyrby"
                           id="root_Name"
                           label="Name"
                           list="dummy-datalist"
@@ -1526,7 +1526,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-number rendition-form__field--root_Height"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_Height"
                       >
                         Height
@@ -1536,7 +1536,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL fnlgoU sc-olbas cYXHg"
+                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi bMvozQ sc-eKszNL kpyrby"
                           id="root_Height"
                           label="Height"
                           placeholder=""
@@ -1553,7 +1553,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-number rendition-form__field--root_Weight"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_Weight"
                       >
                         Weight
@@ -1563,7 +1563,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL fnlgoU sc-olbas cYXHg"
+                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi bMvozQ sc-eKszNL kpyrby"
                           id="root_Weight"
                           label="Weight"
                           placeholder=""
@@ -1580,7 +1580,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-string rendition-form__field--root_Description"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_Description"
                       >
                         Description
@@ -1590,7 +1590,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL fnlgoU sc-olbas cYXHg"
+                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi bMvozQ sc-eKszNL kpyrby"
                           id="root_Description"
                           label="Description"
                           placeholder=""
@@ -1607,7 +1607,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-string rendition-form__field--root_Category"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_Category"
                       >
                         Category
@@ -1617,7 +1617,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL fnlgoU sc-olbas cYXHg"
+                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi bMvozQ sc-eKszNL kpyrby"
                           id="root_Category"
                           label="Category"
                           placeholder=""
@@ -1634,7 +1634,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-string rendition-form__field--root_Abilities"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_Abilities"
                       >
                         Abilities
@@ -1644,7 +1644,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL fnlgoU sc-olbas cYXHg"
+                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi bMvozQ sc-eKszNL kpyrby"
                           id="root_Abilities"
                           label="Abilities"
                           placeholder=""
@@ -1661,7 +1661,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-number rendition-form__field--root_pokedex_number"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_pokedex_number"
                       >
                         National Pokèdex Number
@@ -1671,7 +1671,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL fnlgoU sc-olbas cYXHg"
+                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi bMvozQ sc-eKszNL kpyrby"
                           id="root_pokedex_number"
                           label="National Pokèdex Number"
                           placeholder=""
@@ -1709,17 +1709,17 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-string rendition-form__field--root_first_seen"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_first_seen"
                       >
                         First seen
                       </label>
                       <div
-                        class="sc-gKXOVf QRSBg sc-iBkjds QRvXl sc-hHLeRK dzJWYl sc-dFdIVH fxOFjV rendition-form-description"
+                        class="sc-gKXOVf QRSBg sc-iBkjds QRvXl sc-hHLeRK dzJWYl sc-csvncw bswcwg rendition-form-description"
                         id="root_first_seen__description"
                       >
                         <div
-                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-chKnlQ jMOuPF"
+                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-kIZKsT geXume"
                         >
                           <div>
                             <p
@@ -1735,7 +1735,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL fnlgoU sc-olbas cYXHg"
+                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi bMvozQ sc-eKszNL kpyrby"
                           id="root_first_seen"
                           label="First seen"
                           placeholder=""
@@ -1752,17 +1752,17 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-string rendition-form__field--root_poke_password"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_poke_password"
                       >
                         Poke Password
                       </label>
                       <div
-                        class="sc-gKXOVf QRSBg sc-iBkjds QRvXl sc-hHLeRK dzJWYl sc-dFdIVH fxOFjV rendition-form-description"
+                        class="sc-gKXOVf QRSBg sc-iBkjds QRvXl sc-hHLeRK dzJWYl sc-csvncw bswcwg rendition-form-description"
                         id="root_poke_password__description"
                       >
                         <div
-                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-chKnlQ jMOuPF"
+                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-kIZKsT geXume"
                         >
                           <div>
                             <p
@@ -1778,7 +1778,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL fnlgoU sc-olbas cYXHg"
+                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi bMvozQ sc-eKszNL kpyrby"
                           id="root_poke_password"
                           label="Poke Password"
                           placeholder=""
@@ -1795,13 +1795,13 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-string rendition-form__field--root_environment"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_environment"
                       >
                         environment
                       </label>
                       <div
-                        class="sc-iNWwEs iFVTvX sc-jfmDQi byZsiK"
+                        class="sc-lbxAil pYSLc sc-iNWwEs bpgSQG"
                       >
                         <button
                           aria-label="Open Drop"
@@ -1820,7 +1820,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                               >
                                 <input
                                   autocomplete="off"
-                                  class="StyledTextInput-sc-1x30a0s-0 ewHtlx Select__SelectTextInput-sc-17idtfo-0 bQAqdj sc-lbxAil gvSMeT"
+                                  class="StyledTextInput-sc-1x30a0s-0 ewHtlx Select__SelectTextInput-sc-17idtfo-0 bQAqdj sc-gSAPjG hCdWnJ"
                                   id="root_environment__input"
                                   readonly=""
                                   tabindex="-1"
@@ -1859,17 +1859,17 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
                     >
                       <div>
                         <legend
-                          class="sc-brCFrO jgvKuH"
+                          class="sc-dFdIVH kFYeai"
                           id="root_tags__title"
                         >
                           Tags
                         </legend>
                         <div
-                          class="sc-gKXOVf QRSBg sc-iBkjds QRvXl sc-hHLeRK dzJWYl sc-dFdIVH fxOFjV rendition-form-description"
+                          class="sc-gKXOVf QRSBg sc-iBkjds QRvXl sc-hHLeRK dzJWYl sc-csvncw bswcwg rendition-form-description"
                           id="root_tags__description"
                         >
                           <div
-                            class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-chKnlQ jMOuPF"
+                            class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-kIZKsT geXume"
                           >
                             <div>
                               <p
@@ -1937,7 +1937,7 @@ exports[`Storyshots Core/Form Hidden Submit 1`] = `
 exports[`Storyshots Core/Form Secondary Action 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY"
@@ -1946,7 +1946,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
         class="sc-gKXOVf ckXSHX sc-iBkjds bUOvBx"
       >
         <div
-          class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-ikjQzJ cjgMSN"
+          class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-WCkqM hiazeD"
         >
           <form
             class="rjsf"
@@ -1956,7 +1956,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
             >
               <section>
                 <legend
-                  class="sc-brCFrO jgvKuH"
+                  class="sc-dFdIVH kFYeai"
                   id="root__title"
                 >
                   Pokèmon
@@ -1971,7 +1971,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-string rendition-form__field--root_Name"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_Name"
                       >
                         Name
@@ -1982,7 +1982,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                         
                         <input
                           autocomplete="off"
-                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL fnlgoU sc-olbas cYXHg"
+                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi bMvozQ sc-eKszNL kpyrby"
                           id="root_Name"
                           label="Name"
                           list="dummy-datalist"
@@ -2003,7 +2003,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-number rendition-form__field--root_Height"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_Height"
                       >
                         Height
@@ -2013,7 +2013,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL fnlgoU sc-olbas cYXHg"
+                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi bMvozQ sc-eKszNL kpyrby"
                           id="root_Height"
                           label="Height"
                           placeholder=""
@@ -2030,7 +2030,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-number rendition-form__field--root_Weight"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_Weight"
                       >
                         Weight
@@ -2040,7 +2040,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL fnlgoU sc-olbas cYXHg"
+                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi bMvozQ sc-eKszNL kpyrby"
                           id="root_Weight"
                           label="Weight"
                           placeholder=""
@@ -2057,7 +2057,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-string rendition-form__field--root_Description"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_Description"
                       >
                         Description
@@ -2067,7 +2067,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL fnlgoU sc-olbas cYXHg"
+                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi bMvozQ sc-eKszNL kpyrby"
                           id="root_Description"
                           label="Description"
                           placeholder=""
@@ -2084,7 +2084,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-string rendition-form__field--root_Category"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_Category"
                       >
                         Category
@@ -2094,7 +2094,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL fnlgoU sc-olbas cYXHg"
+                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi bMvozQ sc-eKszNL kpyrby"
                           id="root_Category"
                           label="Category"
                           placeholder=""
@@ -2111,7 +2111,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-string rendition-form__field--root_Abilities"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_Abilities"
                       >
                         Abilities
@@ -2121,7 +2121,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL fnlgoU sc-olbas cYXHg"
+                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi bMvozQ sc-eKszNL kpyrby"
                           id="root_Abilities"
                           label="Abilities"
                           placeholder=""
@@ -2138,7 +2138,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-number rendition-form__field--root_pokedex_number"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_pokedex_number"
                       >
                         National Pokèdex Number
@@ -2148,7 +2148,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL fnlgoU sc-olbas cYXHg"
+                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi bMvozQ sc-eKszNL kpyrby"
                           id="root_pokedex_number"
                           label="National Pokèdex Number"
                           placeholder=""
@@ -2186,17 +2186,17 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-string rendition-form__field--root_first_seen"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_first_seen"
                       >
                         First seen
                       </label>
                       <div
-                        class="sc-gKXOVf QRSBg sc-iBkjds QRvXl sc-hHLeRK dzJWYl sc-dFdIVH fxOFjV rendition-form-description"
+                        class="sc-gKXOVf QRSBg sc-iBkjds QRvXl sc-hHLeRK dzJWYl sc-csvncw bswcwg rendition-form-description"
                         id="root_first_seen__description"
                       >
                         <div
-                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-chKnlQ jMOuPF"
+                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-kIZKsT geXume"
                         >
                           <div>
                             <p
@@ -2212,7 +2212,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL fnlgoU sc-olbas cYXHg"
+                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi bMvozQ sc-eKszNL kpyrby"
                           id="root_first_seen"
                           label="First seen"
                           placeholder=""
@@ -2229,17 +2229,17 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-string rendition-form__field--root_poke_password"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_poke_password"
                       >
                         Poke Password
                       </label>
                       <div
-                        class="sc-gKXOVf QRSBg sc-iBkjds QRvXl sc-hHLeRK dzJWYl sc-dFdIVH fxOFjV rendition-form-description"
+                        class="sc-gKXOVf QRSBg sc-iBkjds QRvXl sc-hHLeRK dzJWYl sc-csvncw bswcwg rendition-form-description"
                         id="root_poke_password__description"
                       >
                         <div
-                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-chKnlQ jMOuPF"
+                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-kIZKsT geXume"
                         >
                           <div>
                             <p
@@ -2255,7 +2255,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL fnlgoU sc-olbas cYXHg"
+                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi bMvozQ sc-eKszNL kpyrby"
                           id="root_poke_password"
                           label="Poke Password"
                           placeholder=""
@@ -2272,13 +2272,13 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-string rendition-form__field--root_environment"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_environment"
                       >
                         environment
                       </label>
                       <div
-                        class="sc-iNWwEs iFVTvX sc-jfmDQi byZsiK"
+                        class="sc-lbxAil pYSLc sc-iNWwEs bpgSQG"
                       >
                         <button
                           aria-label="Open Drop"
@@ -2297,7 +2297,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                               >
                                 <input
                                   autocomplete="off"
-                                  class="StyledTextInput-sc-1x30a0s-0 ewHtlx Select__SelectTextInput-sc-17idtfo-0 bQAqdj sc-lbxAil gvSMeT"
+                                  class="StyledTextInput-sc-1x30a0s-0 ewHtlx Select__SelectTextInput-sc-17idtfo-0 bQAqdj sc-gSAPjG hCdWnJ"
                                   id="root_environment__input"
                                   readonly=""
                                   tabindex="-1"
@@ -2336,17 +2336,17 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
                     >
                       <div>
                         <legend
-                          class="sc-brCFrO jgvKuH"
+                          class="sc-dFdIVH kFYeai"
                           id="root_tags__title"
                         >
                           Tags
                         </legend>
                         <div
-                          class="sc-gKXOVf QRSBg sc-iBkjds QRvXl sc-hHLeRK dzJWYl sc-dFdIVH fxOFjV rendition-form-description"
+                          class="sc-gKXOVf QRSBg sc-iBkjds QRvXl sc-hHLeRK dzJWYl sc-csvncw bswcwg rendition-form-description"
                           id="root_tags__description"
                         >
                           <div
-                            class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-chKnlQ jMOuPF"
+                            class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-kIZKsT geXume"
                           >
                             <div>
                               <p
@@ -2425,7 +2425,7 @@ exports[`Storyshots Core/Form Secondary Action 1`] = `
 exports[`Storyshots Core/Form With Dependants 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY"
@@ -2434,7 +2434,7 @@ exports[`Storyshots Core/Form With Dependants 1`] = `
         class="sc-gKXOVf ckXSHX sc-iBkjds bUOvBx"
       >
         <div
-          class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-ikjQzJ cjgMSN"
+          class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-WCkqM hiazeD"
         >
           <form
             class="rjsf"
@@ -2454,7 +2454,7 @@ exports[`Storyshots Core/Form With Dependants 1`] = `
                     >
                       <div>
                         <legend
-                          class="sc-brCFrO jgvKuH"
+                          class="sc-dFdIVH kFYeai"
                           id="root_application_config_variable__title"
                         >
                           Application configuration variables
@@ -2498,7 +2498,7 @@ exports[`Storyshots Core/Form With Dependants 1`] = `
                     >
                       <div>
                         <legend
-                          class="sc-brCFrO jgvKuH"
+                          class="sc-dFdIVH kFYeai"
                           id="root_application_environment_variable__title"
                         >
                           Application environment variables
@@ -2565,13 +2565,13 @@ exports[`Storyshots Core/Form With Dependants 1`] = `
 exports[`Storyshots Core/Form With Extra Widgets 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="sc-gKXOVf QRSBg sc-iBkjds bBZNJf"
     >
       <div
-        class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-chKnlQ jMOuPF"
+        class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-kIZKsT geXume"
       >
         <div>
           <h1
@@ -2579,7 +2579,7 @@ exports[`Storyshots Core/Form With Extra Widgets 1`] = `
             id="user-content-extra-widgets"
           >
             <a
-              class="sc-eKBdFk eDgBSD sc-bUbCnL aUvHI heading-anchor-link"
+              class="sc-hlnMnd cpbYOv sc-eKBdFk cTggPd heading-anchor-link"
               color="primary.main"
               href="#extra-widgets"
             >
@@ -3328,7 +3328,7 @@ Rendition contains widgets for rendering Markdown and Mermaid text formats that 
         class="sc-gKXOVf ckXSHX sc-iBkjds bUOvBx"
       >
         <div
-          class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-ikjQzJ cjgMSN"
+          class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-WCkqM hiazeD"
         >
           <form
             class="rjsf"
@@ -3347,7 +3347,7 @@ Rendition contains widgets for rendering Markdown and Mermaid text formats that 
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-string rendition-form__field--root_Mermaid"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_Mermaid"
                       >
                         Mermaid
@@ -3400,7 +3400,7 @@ Rendition contains widgets for rendering Markdown and Mermaid text formats that 
                           role="tabpanel"
                         >
                           <textarea
-                            class="StyledTextArea-sc-17i3mwp-0 ffIuvj sc-hiMGwR jNGenP sc-ehmTmK eXkmsq"
+                            class="StyledTextArea-sc-17i3mwp-0 ffIuvj sc-olbas hajENe sc-hiMGwR dZpBIm"
                             label="Mermaid"
                             placeholder=""
                             rows="5"
@@ -3408,7 +3408,7 @@ Rendition contains widgets for rendering Markdown and Mermaid text formats that 
                         </div>
                       </div>
                       <a
-                        class="sc-eKBdFk eDgBSD sc-bUbCnL gNoHaL"
+                        class="sc-hlnMnd cpbYOv sc-eKBdFk hMOuti"
                         color="primary.main"
                         href="https://mermaidjs.github.io/"
                         rel="noopener"
@@ -3425,13 +3425,13 @@ Rendition contains widgets for rendering Markdown and Mermaid text formats that 
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-string rendition-form__field--root_Markdown"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_Markdown"
                       >
                         Markdown
                       </label>
                       <div
-                        class="sc-ckCjom cYmeNc"
+                        class="sc-geuGuN iFFFfs"
                         id="simplemde-editor-1-wrapper"
                       >
                         <textarea
@@ -3713,13 +3713,13 @@ Rendition contains widgets for rendering Markdown and Mermaid text formats that 
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-string rendition-form__field--root_Captcha"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_Captcha"
                       >
                         Captcha
                       </label>
                       <div
-                        class="sc-kIZKsT joNJPp"
+                        class="sc-ckCjom dRTbpO"
                       />
                     </div>
                   </div>
@@ -3754,7 +3754,7 @@ Rendition contains widgets for rendering Markdown and Mermaid text formats that 
 exports[`Storyshots Core/Form With Help Text 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY"
@@ -3763,7 +3763,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
         class="sc-gKXOVf ckXSHX sc-iBkjds bUOvBx"
       >
         <div
-          class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-ikjQzJ cjgMSN"
+          class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-WCkqM hiazeD"
         >
           <form
             class="rjsf"
@@ -3773,7 +3773,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
             >
               <section>
                 <legend
-                  class="sc-brCFrO jgvKuH"
+                  class="sc-dFdIVH kFYeai"
                   id="root__title"
                 >
                   Pokèmon
@@ -3788,7 +3788,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-string rendition-form__field--root_Name"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_Name"
                       >
                         Name
@@ -3799,7 +3799,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                         
                         <input
                           autocomplete="off"
-                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL fnlgoU sc-olbas cYXHg"
+                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi bMvozQ sc-eKszNL kpyrby"
                           id="root_Name"
                           label="Name"
                           list="dummy-datalist"
@@ -3812,11 +3812,11 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                         id="dummy-datalist"
                       />
                       <div
-                        class="sc-gKXOVf QRSBg sc-iBkjds QRvXl sc-hHLeRK dzJWYl sc-dFdIVH eBFQco rendition-form-help"
+                        class="sc-gKXOVf QRSBg sc-iBkjds QRvXl sc-hHLeRK dzJWYl sc-csvncw eCWApp rendition-form-help"
                         id="root_Name"
                       >
                         <div
-                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-chKnlQ jMOuPF"
+                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-kIZKsT geXume"
                         >
                           <div>
                             <p
@@ -3861,13 +3861,13 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-string rendition-form__field--root_Description"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_Description"
                       >
                         Description
                       </label>
                       <textarea
-                        class="StyledTextArea-sc-17i3mwp-0 ffIuvj sc-hiMGwR jNGenP sc-ehmTmK eXkmsq form-control"
+                        class="StyledTextArea-sc-17i3mwp-0 ffIuvj sc-olbas hajENe sc-hiMGwR dZpBIm form-control"
                         id="root_Description"
                         placeholder=""
                         rows="5"
@@ -3881,7 +3881,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-string rendition-form__field--root_Abilities"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_Abilities"
                       >
                         Abilities
@@ -3891,7 +3891,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL fnlgoU sc-olbas cYXHg"
+                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi bMvozQ sc-eKszNL kpyrby"
                           id="root_Abilities"
                           label="Abilities"
                           placeholder=""
@@ -3908,7 +3908,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-number rendition-form__field--root_Height"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_Height"
                       >
                         Height
@@ -3918,7 +3918,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL ckiHuf sc-olbas cYXHg"
+                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi jrWTtX sc-eKszNL kpyrby"
                           id="root_Height"
                           label="Height"
                           placeholder=""
@@ -3935,7 +3935,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-number rendition-form__field--root_Weight"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_Weight"
                       >
                         Weight
@@ -3945,7 +3945,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL fnlgoU sc-olbas cYXHg"
+                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi bMvozQ sc-eKszNL kpyrby"
                           id="root_Weight"
                           label="Weight"
                           placeholder=""
@@ -3962,7 +3962,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-string rendition-form__field--root_Category"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_Category"
                       >
                         Category
@@ -3972,7 +3972,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL fnlgoU sc-olbas cYXHg"
+                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi bMvozQ sc-eKszNL kpyrby"
                           id="root_Category"
                           label="Category"
                           placeholder=""
@@ -3989,7 +3989,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-number rendition-form__field--root_pokedex_number"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_pokedex_number"
                       >
                         National Pokèdex Number
@@ -3999,7 +3999,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL fnlgoU sc-olbas cYXHg"
+                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi bMvozQ sc-eKszNL kpyrby"
                           id="root_pokedex_number"
                           label="National Pokèdex Number"
                           placeholder=""
@@ -4016,17 +4016,17 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-string rendition-form__field--root_first_seen"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_first_seen"
                       >
                         First seen
                       </label>
                       <div
-                        class="sc-gKXOVf QRSBg sc-iBkjds QRvXl sc-hHLeRK dzJWYl sc-dFdIVH fxOFjV rendition-form-description"
+                        class="sc-gKXOVf QRSBg sc-iBkjds QRvXl sc-hHLeRK dzJWYl sc-csvncw bswcwg rendition-form-description"
                         id="root_first_seen__description"
                       >
                         <div
-                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-chKnlQ jMOuPF"
+                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-kIZKsT geXume"
                         >
                           <div>
                             <p
@@ -4042,7 +4042,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL fnlgoU sc-olbas cYXHg"
+                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi bMvozQ sc-eKszNL kpyrby"
                           id="root_first_seen"
                           label="First seen"
                           placeholder=""
@@ -4059,17 +4059,17 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-string rendition-form__field--root_poke_password"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_poke_password"
                       >
                         Poke Password
                       </label>
                       <div
-                        class="sc-gKXOVf QRSBg sc-iBkjds QRvXl sc-hHLeRK dzJWYl sc-dFdIVH fxOFjV rendition-form-description"
+                        class="sc-gKXOVf QRSBg sc-iBkjds QRvXl sc-hHLeRK dzJWYl sc-csvncw bswcwg rendition-form-description"
                         id="root_poke_password__description"
                       >
                         <div
-                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-chKnlQ jMOuPF"
+                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-kIZKsT geXume"
                         >
                           <div>
                             <p
@@ -4088,7 +4088,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                         >
                           
                           <input
-                            class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL fnlgoU sc-olbas cFVyzG"
+                            class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi bMvozQ sc-eKszNL jQmrOY"
                             id="root_poke_password"
                             label="Poke Password"
                             placeholder=""
@@ -4097,7 +4097,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                           />
                         </div>
                         <button
-                          class="StyledButton-sc-323bzc-0 jllRpX sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR jqisCT sc-duzrYq iHsgIe"
+                          class="StyledButton-sc-323bzc-0 jllRpX sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR jqisCT sc-fIavCj imGGOS"
                           type="button"
                         >
                           <svg
@@ -4126,13 +4126,13 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-string rendition-form__field--root_environment"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_environment"
                       >
                         environment
                       </label>
                       <div
-                        class="sc-iNWwEs iFVTvX sc-jfmDQi byZsiK"
+                        class="sc-lbxAil pYSLc sc-iNWwEs bpgSQG"
                       >
                         <button
                           aria-label="Open Drop"
@@ -4151,7 +4151,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                               >
                                 <input
                                   autocomplete="off"
-                                  class="StyledTextInput-sc-1x30a0s-0 ewHtlx Select__SelectTextInput-sc-17idtfo-0 bQAqdj sc-lbxAil gEeDUw"
+                                  class="StyledTextInput-sc-1x30a0s-0 ewHtlx Select__SelectTextInput-sc-17idtfo-0 bQAqdj sc-gSAPjG lmHZUC"
                                   id="root_environment__input"
                                   readonly=""
                                   tabindex="-1"
@@ -4190,17 +4190,17 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
                     >
                       <div>
                         <legend
-                          class="sc-brCFrO jgvKuH"
+                          class="sc-dFdIVH kFYeai"
                           id="root_tags__title"
                         >
                           Tags
                         </legend>
                         <div
-                          class="sc-gKXOVf QRSBg sc-iBkjds QRvXl sc-hHLeRK dzJWYl sc-dFdIVH fxOFjV rendition-form-description"
+                          class="sc-gKXOVf QRSBg sc-iBkjds QRvXl sc-hHLeRK dzJWYl sc-csvncw bswcwg rendition-form-description"
                           id="root_tags__description"
                         >
                           <div
-                            class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-chKnlQ jMOuPF"
+                            class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-kIZKsT geXume"
                           >
                             <div>
                               <p
@@ -4273,7 +4273,7 @@ exports[`Storyshots Core/Form With Help Text 1`] = `
 exports[`Storyshots Core/Form With Pattern Properties 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY"
@@ -4282,7 +4282,7 @@ exports[`Storyshots Core/Form With Pattern Properties 1`] = `
         class="sc-gKXOVf ckXSHX sc-iBkjds bUOvBx"
       >
         <div
-          class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-ikjQzJ cjgMSN"
+          class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-WCkqM hiazeD"
         >
           <form
             class="rjsf"
@@ -4302,7 +4302,7 @@ exports[`Storyshots Core/Form With Pattern Properties 1`] = `
                     >
                       <section>
                         <legend
-                          class="sc-brCFrO jgvKuH"
+                          class="sc-dFdIVH kFYeai"
                           id="root_dynamicObject__title"
                         >
                           Rules
@@ -4332,7 +4332,7 @@ exports[`Storyshots Core/Form With Pattern Properties 1`] = `
                                     >
                                       <input
                                         autocomplete="off"
-                                        class="StyledTextInput-sc-1x30a0s-0 wCJnS sc-eKszNL cmzDnv sc-olbas jFRZyP rendition-form-pattern-properties__key-field"
+                                        class="StyledTextInput-sc-1x30a0s-0 wCJnS sc-jfmDQi gsojrT sc-eKszNL hCjBDB rendition-form-pattern-properties__key-field"
                                         disabled=""
                                         pattern="^[0-9]+$"
                                         placeholder="Key"
@@ -4346,7 +4346,7 @@ exports[`Storyshots Core/Form With Pattern Properties 1`] = `
                                     >
                                       <input
                                         autocomplete="off"
-                                        class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL fnlgoU sc-olbas jFRZyP rendition-form-pattern-properties__value-field"
+                                        class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi bMvozQ sc-eKszNL hCjBDB rendition-form-pattern-properties__value-field"
                                         id="foo"
                                         placeholder="Rule"
                                         value=""
@@ -4394,7 +4394,7 @@ exports[`Storyshots Core/Form With Pattern Properties 1`] = `
 exports[`Storyshots Core/Form With Titles 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY"
@@ -4403,7 +4403,7 @@ exports[`Storyshots Core/Form With Titles 1`] = `
         class="sc-gKXOVf ckXSHX sc-iBkjds bUOvBx"
       >
         <div
-          class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-ikjQzJ cjgMSN"
+          class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-WCkqM hiazeD"
         >
           <form
             class="rjsf"
@@ -4413,7 +4413,7 @@ exports[`Storyshots Core/Form With Titles 1`] = `
             >
               <section>
                 <legend
-                  class="sc-brCFrO jgvKuH"
+                  class="sc-dFdIVH kFYeai"
                   id="root__title"
                 >
                   Networking
@@ -4429,7 +4429,7 @@ exports[`Storyshots Core/Form With Titles 1`] = `
                     >
                       <section>
                         <legend
-                          class="sc-brCFrO jgvKuH"
+                          class="sc-dFdIVH kFYeai"
                           id="root_vpn__title"
                         >
                           Virtual Private Network
@@ -4444,7 +4444,7 @@ exports[`Storyshots Core/Form With Titles 1`] = `
                               class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-string rendition-form__field--root_vpn_endpoint"
                             >
                               <label
-                                class="sc-evrZIY hA-dyyI control-label"
+                                class="sc-gITdmR gpOetS control-label"
                                 for="root_vpn_endpoint"
                               >
                                 Endpoint
@@ -4454,7 +4454,7 @@ exports[`Storyshots Core/Form With Titles 1`] = `
                               >
                                 
                                 <input
-                                  class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL fnlgoU sc-olbas cYXHg"
+                                  class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi bMvozQ sc-eKszNL kpyrby"
                                   id="root_vpn_endpoint"
                                   label="Endpoint"
                                   placeholder=""
@@ -4471,7 +4471,7 @@ exports[`Storyshots Core/Form With Titles 1`] = `
                               class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-string rendition-form__field--root_vpn_certificate"
                             >
                               <label
-                                class="sc-evrZIY hA-dyyI control-label"
+                                class="sc-gITdmR gpOetS control-label"
                                 for="root_vpn_certificate"
                               >
                                 Certificate
@@ -4481,7 +4481,7 @@ exports[`Storyshots Core/Form With Titles 1`] = `
                               >
                                 
                                 <input
-                                  class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL fnlgoU sc-olbas cYXHg"
+                                  class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi bMvozQ sc-eKszNL kpyrby"
                                   id="root_vpn_certificate"
                                   label="Certificate"
                                   placeholder=""
@@ -4503,7 +4503,7 @@ exports[`Storyshots Core/Form With Titles 1`] = `
                     >
                       <section>
                         <legend
-                          class="sc-brCFrO jgvKuH"
+                          class="sc-dFdIVH kFYeai"
                           id="root_wifiNetwork__title"
                         >
                           WiFi Network
@@ -4528,7 +4528,7 @@ exports[`Storyshots Core/Form With Titles 1`] = `
                                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-string rendition-form__field--root_wifiNetwork_wifi_ssid"
                                     >
                                       <label
-                                        class="sc-evrZIY hA-dyyI control-label"
+                                        class="sc-gITdmR gpOetS control-label"
                                         for="root_wifiNetwork_wifi_ssid"
                                       >
                                         Network SSID
@@ -4538,7 +4538,7 @@ exports[`Storyshots Core/Form With Titles 1`] = `
                                       >
                                         
                                         <input
-                                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL fnlgoU sc-olbas cYXHg"
+                                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi bMvozQ sc-eKszNL kpyrby"
                                           id="root_wifiNetwork_wifi_ssid"
                                           label="Network SSID"
                                           placeholder=""
@@ -4569,7 +4569,7 @@ exports[`Storyshots Core/Form With Titles 1`] = `
                                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-string rendition-form__field--root_wifiNetwork_wifiSecurity_psk"
                                     >
                                       <label
-                                        class="sc-evrZIY hA-dyyI control-label"
+                                        class="sc-gITdmR gpOetS control-label"
                                         for="root_wifiNetwork_wifiSecurity_psk"
                                       >
                                         Network Passphrase
@@ -4579,7 +4579,7 @@ exports[`Storyshots Core/Form With Titles 1`] = `
                                       >
                                         
                                         <input
-                                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL fnlgoU sc-olbas cYXHg"
+                                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi bMvozQ sc-eKszNL kpyrby"
                                           id="root_wifiNetwork_wifiSecurity_psk"
                                           label="Network Passphrase"
                                           placeholder=""
@@ -4634,7 +4634,7 @@ exports[`Storyshots Core/Form With Titles 1`] = `
 exports[`Storyshots Core/Form With Ui Schema 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY"
@@ -4643,7 +4643,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
         class="sc-gKXOVf ckXSHX sc-iBkjds bUOvBx"
       >
         <div
-          class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-ikjQzJ cjgMSN"
+          class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-WCkqM hiazeD"
         >
           <form
             class="rjsf"
@@ -4653,7 +4653,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
             >
               <section>
                 <legend
-                  class="sc-brCFrO jgvKuH"
+                  class="sc-dFdIVH kFYeai"
                   id="root__title"
                 >
                   Pokèmon
@@ -4668,7 +4668,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-string rendition-form__field--root_Name"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_Name"
                       >
                         Name
@@ -4679,7 +4679,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                         
                         <input
                           autocomplete="off"
-                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL fnlgoU sc-olbas cYXHg"
+                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi bMvozQ sc-eKszNL kpyrby"
                           id="root_Name"
                           label="Name"
                           list="dummy-datalist"
@@ -4721,13 +4721,13 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-string rendition-form__field--root_Description"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_Description"
                       >
                         Description
                       </label>
                       <textarea
-                        class="StyledTextArea-sc-17i3mwp-0 ffIuvj sc-hiMGwR jNGenP sc-ehmTmK eXkmsq form-control"
+                        class="StyledTextArea-sc-17i3mwp-0 ffIuvj sc-olbas hajENe sc-hiMGwR dZpBIm form-control"
                         id="root_Description"
                         placeholder=""
                         rows="5"
@@ -4741,7 +4741,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-string rendition-form__field--root_Abilities"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_Abilities"
                       >
                         Abilities
@@ -4751,7 +4751,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL fnlgoU sc-olbas cYXHg"
+                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi bMvozQ sc-eKszNL kpyrby"
                           id="root_Abilities"
                           label="Abilities"
                           placeholder=""
@@ -4768,7 +4768,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-number rendition-form__field--root_Height"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_Height"
                       >
                         Height
@@ -4778,7 +4778,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL ckiHuf sc-olbas cYXHg"
+                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi jrWTtX sc-eKszNL kpyrby"
                           id="root_Height"
                           label="Height"
                           placeholder=""
@@ -4795,7 +4795,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-number rendition-form__field--root_Weight"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_Weight"
                       >
                         Weight
@@ -4805,7 +4805,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL fnlgoU sc-olbas cYXHg"
+                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi bMvozQ sc-eKszNL kpyrby"
                           id="root_Weight"
                           label="Weight"
                           placeholder=""
@@ -4822,7 +4822,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-string rendition-form__field--root_Category"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_Category"
                       >
                         Category
@@ -4832,7 +4832,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL fnlgoU sc-olbas cYXHg"
+                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi bMvozQ sc-eKszNL kpyrby"
                           id="root_Category"
                           label="Category"
                           placeholder=""
@@ -4849,7 +4849,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-number rendition-form__field--root_pokedex_number"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_pokedex_number"
                       >
                         National Pokèdex Number
@@ -4859,7 +4859,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL fnlgoU sc-olbas cYXHg"
+                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi bMvozQ sc-eKszNL kpyrby"
                           id="root_pokedex_number"
                           label="National Pokèdex Number"
                           placeholder=""
@@ -4876,17 +4876,17 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-string rendition-form__field--root_first_seen"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_first_seen"
                       >
                         First seen
                       </label>
                       <div
-                        class="sc-gKXOVf QRSBg sc-iBkjds QRvXl sc-hHLeRK dzJWYl sc-dFdIVH fxOFjV rendition-form-description"
+                        class="sc-gKXOVf QRSBg sc-iBkjds QRvXl sc-hHLeRK dzJWYl sc-csvncw bswcwg rendition-form-description"
                         id="root_first_seen__description"
                       >
                         <div
-                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-chKnlQ jMOuPF"
+                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-kIZKsT geXume"
                         >
                           <div>
                             <p
@@ -4902,7 +4902,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL fnlgoU sc-olbas cYXHg"
+                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi bMvozQ sc-eKszNL kpyrby"
                           id="root_first_seen"
                           label="First seen"
                           placeholder=""
@@ -4919,17 +4919,17 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-string rendition-form__field--root_poke_password"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_poke_password"
                       >
                         Poke Password
                       </label>
                       <div
-                        class="sc-gKXOVf QRSBg sc-iBkjds QRvXl sc-hHLeRK dzJWYl sc-dFdIVH fxOFjV rendition-form-description"
+                        class="sc-gKXOVf QRSBg sc-iBkjds QRvXl sc-hHLeRK dzJWYl sc-csvncw bswcwg rendition-form-description"
                         id="root_poke_password__description"
                       >
                         <div
-                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-chKnlQ jMOuPF"
+                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-kIZKsT geXume"
                         >
                           <div>
                             <p
@@ -4948,7 +4948,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                         >
                           
                           <input
-                            class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL fnlgoU sc-olbas cFVyzG"
+                            class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi bMvozQ sc-eKszNL jQmrOY"
                             id="root_poke_password"
                             label="Poke Password"
                             placeholder=""
@@ -4957,7 +4957,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                           />
                         </div>
                         <button
-                          class="StyledButton-sc-323bzc-0 jllRpX sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR jqisCT sc-duzrYq iHsgIe"
+                          class="StyledButton-sc-323bzc-0 jllRpX sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR jqisCT sc-fIavCj imGGOS"
                           type="button"
                         >
                           <svg
@@ -4986,13 +4986,13 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-string rendition-form__field--root_environment"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_environment"
                       >
                         environment
                       </label>
                       <div
-                        class="sc-iNWwEs iFVTvX sc-jfmDQi byZsiK"
+                        class="sc-lbxAil pYSLc sc-iNWwEs bpgSQG"
                       >
                         <button
                           aria-label="Open Drop"
@@ -5011,7 +5011,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                               >
                                 <input
                                   autocomplete="off"
-                                  class="StyledTextInput-sc-1x30a0s-0 ewHtlx Select__SelectTextInput-sc-17idtfo-0 bQAqdj sc-lbxAil gEeDUw"
+                                  class="StyledTextInput-sc-1x30a0s-0 ewHtlx Select__SelectTextInput-sc-17idtfo-0 bQAqdj sc-gSAPjG lmHZUC"
                                   id="root_environment__input"
                                   readonly=""
                                   tabindex="-1"
@@ -5050,17 +5050,17 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
                     >
                       <div>
                         <legend
-                          class="sc-brCFrO jgvKuH"
+                          class="sc-dFdIVH kFYeai"
                           id="root_tags__title"
                         >
                           Tags
                         </legend>
                         <div
-                          class="sc-gKXOVf QRSBg sc-iBkjds QRvXl sc-hHLeRK dzJWYl sc-dFdIVH fxOFjV rendition-form-description"
+                          class="sc-gKXOVf QRSBg sc-iBkjds QRvXl sc-hHLeRK dzJWYl sc-csvncw bswcwg rendition-form-description"
                           id="root_tags__description"
                         >
                           <div
-                            class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-chKnlQ jMOuPF"
+                            class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-kIZKsT geXume"
                           >
                             <div>
                               <p
@@ -5133,7 +5133,7 @@ exports[`Storyshots Core/Form With Ui Schema 1`] = `
 exports[`Storyshots Core/Form With Warning 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY"
@@ -5142,7 +5142,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
         class="sc-gKXOVf ckXSHX sc-iBkjds bUOvBx"
       >
         <div
-          class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-ikjQzJ cjgMSN"
+          class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-WCkqM hiazeD"
         >
           <form
             class="rjsf"
@@ -5152,7 +5152,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
             >
               <section>
                 <legend
-                  class="sc-brCFrO jgvKuH"
+                  class="sc-dFdIVH kFYeai"
                   id="root__title"
                 >
                   Pokèmon
@@ -5167,7 +5167,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-string rendition-form__field--root_Name"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_Name"
                       >
                         Name
@@ -5198,10 +5198,10 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                           class="sc-ivTmOn dNJphr sc-llJcti hkztAs"
                         >
                           <div
-                            class="sc-gKXOVf QRSBg sc-iBkjds QRvXl sc-hHLeRK dzJWYl sc-dFdIVH wJFOl"
+                            class="sc-gKXOVf QRSBg sc-iBkjds QRvXl sc-hHLeRK dzJWYl sc-csvncw WGNnc"
                           >
                             <div
-                              class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-chKnlQ jMOuPF"
+                              class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-kIZKsT geXume"
                             >
                               <div>
                                 <p
@@ -5224,7 +5224,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                         
                         <input
                           autocomplete="off"
-                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL fnlgoU sc-olbas cYXHg"
+                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi bMvozQ sc-eKszNL kpyrby"
                           id="root_Name"
                           label="Name"
                           list="dummy-datalist"
@@ -5266,13 +5266,13 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-string rendition-form__field--root_Description"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_Description"
                       >
                         Description
                       </label>
                       <textarea
-                        class="StyledTextArea-sc-17i3mwp-0 ffIuvj sc-hiMGwR jNGenP sc-ehmTmK eXkmsq form-control"
+                        class="StyledTextArea-sc-17i3mwp-0 ffIuvj sc-olbas hajENe sc-hiMGwR dZpBIm form-control"
                         id="root_Description"
                         placeholder=""
                         rows="5"
@@ -5286,7 +5286,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-string rendition-form__field--root_Abilities"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_Abilities"
                       >
                         Abilities
@@ -5296,7 +5296,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL fnlgoU sc-olbas cYXHg"
+                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi bMvozQ sc-eKszNL kpyrby"
                           id="root_Abilities"
                           label="Abilities"
                           placeholder=""
@@ -5313,7 +5313,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-number rendition-form__field--root_Height"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_Height"
                       >
                         Height
@@ -5323,7 +5323,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL ckiHuf sc-olbas cYXHg"
+                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi jrWTtX sc-eKszNL kpyrby"
                           id="root_Height"
                           label="Height"
                           placeholder=""
@@ -5340,7 +5340,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-number rendition-form__field--root_Weight"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_Weight"
                       >
                         Weight
@@ -5350,7 +5350,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL fnlgoU sc-olbas cYXHg"
+                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi bMvozQ sc-eKszNL kpyrby"
                           id="root_Weight"
                           label="Weight"
                           placeholder=""
@@ -5367,7 +5367,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-string rendition-form__field--root_Category"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_Category"
                       >
                         Category
@@ -5377,7 +5377,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL fnlgoU sc-olbas cYXHg"
+                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi bMvozQ sc-eKszNL kpyrby"
                           id="root_Category"
                           label="Category"
                           placeholder=""
@@ -5394,7 +5394,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-number rendition-form__field--root_pokedex_number"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_pokedex_number"
                       >
                         National Pokèdex Number
@@ -5404,7 +5404,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL fnlgoU sc-olbas cYXHg"
+                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi bMvozQ sc-eKszNL kpyrby"
                           id="root_pokedex_number"
                           label="National Pokèdex Number"
                           placeholder=""
@@ -5421,17 +5421,17 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-string rendition-form__field--root_first_seen"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_first_seen"
                       >
                         First seen
                       </label>
                       <div
-                        class="sc-gKXOVf QRSBg sc-iBkjds QRvXl sc-hHLeRK dzJWYl sc-dFdIVH fxOFjV rendition-form-description"
+                        class="sc-gKXOVf QRSBg sc-iBkjds QRvXl sc-hHLeRK dzJWYl sc-csvncw bswcwg rendition-form-description"
                         id="root_first_seen__description"
                       >
                         <div
-                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-chKnlQ jMOuPF"
+                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-kIZKsT geXume"
                         >
                           <div>
                             <p
@@ -5447,7 +5447,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                       >
                         
                         <input
-                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL fnlgoU sc-olbas cYXHg"
+                          class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi bMvozQ sc-eKszNL kpyrby"
                           id="root_first_seen"
                           label="First seen"
                           placeholder=""
@@ -5464,17 +5464,17 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-string rendition-form__field--root_poke_password"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_poke_password"
                       >
                         Poke Password
                       </label>
                       <div
-                        class="sc-gKXOVf QRSBg sc-iBkjds QRvXl sc-hHLeRK dzJWYl sc-dFdIVH fxOFjV rendition-form-description"
+                        class="sc-gKXOVf QRSBg sc-iBkjds QRvXl sc-hHLeRK dzJWYl sc-csvncw bswcwg rendition-form-description"
                         id="root_poke_password__description"
                       >
                         <div
-                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-chKnlQ jMOuPF"
+                          class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-kIZKsT geXume"
                         >
                           <div>
                             <p
@@ -5493,7 +5493,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                         >
                           
                           <input
-                            class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL fnlgoU sc-olbas cFVyzG"
+                            class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi bMvozQ sc-eKszNL jQmrOY"
                             id="root_poke_password"
                             label="Poke Password"
                             placeholder=""
@@ -5502,7 +5502,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                           />
                         </div>
                         <button
-                          class="StyledButton-sc-323bzc-0 jllRpX sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR jqisCT sc-duzrYq iHsgIe"
+                          class="StyledButton-sc-323bzc-0 jllRpX sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR jqisCT sc-fIavCj imGGOS"
                           type="button"
                         >
                           <svg
@@ -5531,13 +5531,13 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                       class="sc-gKXOVf QRSBg sc-iBkjds hNqnWQ form-group field field-string rendition-form__field--root_environment"
                     >
                       <label
-                        class="sc-evrZIY hA-dyyI control-label"
+                        class="sc-gITdmR gpOetS control-label"
                         for="root_environment"
                       >
                         environment
                       </label>
                       <div
-                        class="sc-iNWwEs iFVTvX sc-jfmDQi byZsiK"
+                        class="sc-lbxAil pYSLc sc-iNWwEs bpgSQG"
                       >
                         <button
                           aria-label="Open Drop"
@@ -5556,7 +5556,7 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                               >
                                 <input
                                   autocomplete="off"
-                                  class="StyledTextInput-sc-1x30a0s-0 ewHtlx Select__SelectTextInput-sc-17idtfo-0 bQAqdj sc-lbxAil gEeDUw"
+                                  class="StyledTextInput-sc-1x30a0s-0 ewHtlx Select__SelectTextInput-sc-17idtfo-0 bQAqdj sc-gSAPjG lmHZUC"
                                   id="root_environment__input"
                                   readonly=""
                                   tabindex="-1"
@@ -5595,17 +5595,17 @@ exports[`Storyshots Core/Form With Warning 1`] = `
                     >
                       <div>
                         <legend
-                          class="sc-brCFrO jgvKuH"
+                          class="sc-dFdIVH kFYeai"
                           id="root_tags__title"
                         >
                           Tags
                         </legend>
                         <div
-                          class="sc-gKXOVf QRSBg sc-iBkjds QRvXl sc-hHLeRK dzJWYl sc-dFdIVH fxOFjV rendition-form-description"
+                          class="sc-gKXOVf QRSBg sc-iBkjds QRvXl sc-hHLeRK dzJWYl sc-csvncw bswcwg rendition-form-description"
                           id="root_tags__description"
                         >
                           <div
-                            class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-chKnlQ jMOuPF"
+                            class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-kIZKsT geXume"
                           >
                             <div>
                               <p

--- a/src/components/Form/__snapshots__/spec.tsx.snap
+++ b/src/components/Form/__snapshots__/spec.tsx.snap
@@ -1,5 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Form component description keyword should support markdown 1`] = `"<div id=\\"root_foo__description\\" class=\\"sc-gKXOVf QRSBg sc-iBkjds QRvXl sc-hHLeRK dzJWYl sc-dFdIVH fxOFjV rendition-form-description\\"><div class=\\"sc-ivTmOn dNJphr sc-cxabCf hcBkUF\\">Lorem ipsum *dolor* sit amet</div></div>"`;
+exports[`Form component description keyword should support markdown 1`] = `"<div id=\\"root_foo__description\\" class=\\"sc-gKXOVf QRSBg sc-iBkjds QRvXl sc-hHLeRK dzJWYl sc-csvncw bswcwg rendition-form-description\\"><div class=\\"sc-ivTmOn dNJphr sc-cxabCf hcBkUF\\">Lorem ipsum *dolor* sit amet</div></div>"`;
 
-exports[`Form component ui:help keyword should support markdown 1`] = `"<div id=\\"root_foo\\" class=\\"sc-gKXOVf QRSBg sc-iBkjds QRvXl sc-hHLeRK dzJWYl sc-dFdIVH eBFQco rendition-form-help\\"><div class=\\"sc-ivTmOn dNJphr sc-cxabCf hcBkUF\\">Lorem ipsum *dolor* sit amet</div></div>"`;
+exports[`Form component ui:help keyword should support markdown 1`] = `"<div id=\\"root_foo\\" class=\\"sc-gKXOVf QRSBg sc-iBkjds QRvXl sc-hHLeRK dzJWYl sc-csvncw eCWApp rendition-form-help\\"><div class=\\"sc-ivTmOn dNJphr sc-cxabCf hcBkUF\\">Lorem ipsum *dolor* sit amet</div></div>"`;

--- a/src/components/Heading/__snapshots__/Heading.stories.storyshot
+++ b/src/components/Heading/__snapshots__/Heading.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/Heading Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <h3
       class="sc-ciZhAO btUqKl sc-jdAMXn iwAvbM"
@@ -17,7 +17,7 @@ exports[`Storyshots Core/Heading Default 1`] = `
 exports[`Storyshots Core/Heading H 1 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <h1
       class="sc-ciZhAO btUqKl sc-bZnhIo lpvFVg"
@@ -31,7 +31,7 @@ exports[`Storyshots Core/Heading H 1 1`] = `
 exports[`Storyshots Core/Heading H 2 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <h2
       class="sc-ciZhAO btUqKl sc-iTONeN kZBtbJ"
@@ -45,7 +45,7 @@ exports[`Storyshots Core/Heading H 2 1`] = `
 exports[`Storyshots Core/Heading H 3 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <h3
       class="sc-ciZhAO btUqKl sc-iAvgwm iVTgLU"
@@ -59,7 +59,7 @@ exports[`Storyshots Core/Heading H 3 1`] = `
 exports[`Storyshots Core/Heading H 4 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <h4
       class="sc-ciZhAO iJFBxw sc-efBctP kDkMSi"
@@ -73,7 +73,7 @@ exports[`Storyshots Core/Heading H 4 1`] = `
 exports[`Storyshots Core/Heading H 5 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <h5
       class="sc-ciZhAO iJFBxw sc-cTQhss dOQXsM"

--- a/src/components/HighlightedName/__snapshots__/HighlightedName.stories.storyshot
+++ b/src/components/HighlightedName/__snapshots__/HighlightedName.stories.storyshot
@@ -3,10 +3,10 @@
 exports[`Storyshots Core/HighlightedName Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <span
-      class="sc-ivTmOn dNJphr sc-llJcti DBbdK sc-ZyCDH gpKjfs sc-jOhDuK bdSPxH"
+      class="sc-ivTmOn dNJphr sc-llJcti DBbdK sc-jIAOiI kBDhbd sc-ZyCDH deuHmg"
     >
       Frontend Service
     </span>
@@ -17,10 +17,10 @@ exports[`Storyshots Core/HighlightedName Default 1`] = `
 exports[`Storyshots Core/HighlightedName With Custom Colors 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <span
-      class="sc-ivTmOn dNJphr sc-llJcti cYBrip sc-ZyCDH gpKjfs sc-jOhDuK dWCTrg"
+      class="sc-ivTmOn dNJphr sc-llJcti cYBrip sc-jIAOiI kBDhbd sc-ZyCDH iUGlsz"
     >
       Frontend Service
     </span>

--- a/src/components/Img/__snapshots__/Img.stories.storyshot
+++ b/src/components/Img/__snapshots__/Img.stories.storyshot
@@ -3,10 +3,10 @@
 exports[`Storyshots Core/Img Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <img
-      class="sc-hlnMnd fzMXUQ"
+      class="sc-jOhDuK fgeoWi"
       src=""
     />
   </div>
@@ -16,10 +16,10 @@ exports[`Storyshots Core/Img Default 1`] = `
 exports[`Storyshots Core/Img With Fallback 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <img
-      class="sc-hlnMnd fzMXUQ"
+      class="sc-jOhDuK fgeoWi"
       src="imgthatfails"
     />
   </div>

--- a/src/components/Input/__snapshots__/Input.stories.storyshot
+++ b/src/components/Input/__snapshots__/Input.stories.storyshot
@@ -3,14 +3,14 @@
 exports[`Storyshots Core/Input Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 kZzThM"
     >
       <input
         autocomplete="off"
-        class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL fnlgoU sc-olbas jFRZyP"
+        class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi bMvozQ sc-eKszNL hCjBDB"
         value=""
       />
     </div>
@@ -21,14 +21,14 @@ exports[`Storyshots Core/Input Default 1`] = `
 exports[`Storyshots Core/Input Emphasized 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 kZzThM"
     >
       <input
         autocomplete="off"
-        class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL ckiHuf sc-olbas jFRZyP"
+        class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi jrWTtX sc-eKszNL hCjBDB"
         value=""
       />
     </div>
@@ -39,14 +39,14 @@ exports[`Storyshots Core/Input Emphasized 1`] = `
 exports[`Storyshots Core/Input Monospace 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 kZzThM"
     >
       <input
         autocomplete="off"
-        class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL bUedlJ sc-olbas jFRZyP"
+        class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi fzTSoF sc-eKszNL hCjBDB"
         value=""
       />
     </div>
@@ -57,14 +57,14 @@ exports[`Storyshots Core/Input Monospace 1`] = `
 exports[`Storyshots Core/Input With Placeholder 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 kZzThM"
     >
       <input
         autocomplete="off"
-        class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL fnlgoU sc-olbas jFRZyP"
+        class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi bMvozQ sc-eKszNL hCjBDB"
         placeholder="This is a placeholder"
         value=""
       />

--- a/src/components/Link/__snapshots__/Link.stories.storyshot
+++ b/src/components/Link/__snapshots__/Link.stories.storyshot
@@ -3,10 +3,10 @@
 exports[`Storyshots Core/Link Blank Target 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <a
-      class="sc-eKBdFk eDgBSD sc-bUbCnL aUvHI"
+      class="sc-hlnMnd cpbYOv sc-eKBdFk cTggPd"
       color="primary.main"
       href="https://balena.io"
       rel="noopener"
@@ -21,10 +21,10 @@ exports[`Storyshots Core/Link Blank Target 1`] = `
 exports[`Storyshots Core/Link Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <a
-      class="sc-eKBdFk eDgBSD sc-bUbCnL aUvHI"
+      class="sc-hlnMnd cpbYOv sc-eKBdFk cTggPd"
       color="primary.main"
       href="#"
     >
@@ -37,10 +37,10 @@ exports[`Storyshots Core/Link Default 1`] = `
 exports[`Storyshots Core/Link Disabled 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <a
-      class="sc-eKBdFk hlANuf sc-bUbCnL aUvHI"
+      class="sc-hlnMnd kwlaPz sc-eKBdFk cTggPd"
       color="primary.main"
       disabled=""
     />

--- a/src/components/List/__snapshots__/List.stories.storyshot
+++ b/src/components/List/__snapshots__/List.stories.storyshot
@@ -3,10 +3,10 @@
 exports[`Storyshots Core/List Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <ul
-      class="sc-kIKDeO sc-dsQDmV zlfFv dwBQur sc-cZwWEu QrmZN"
+      class="sc-bUbCnL sc-hNKHps yqZnU flAqRc sc-dsQDmV jUuGTp"
     >
       <li>
         <div
@@ -14,7 +14,7 @@ exports[`Storyshots Core/List Default 1`] = `
         >
           You can put 
           <a
-            class="sc-eKBdFk eDgBSD sc-bUbCnL aUvHI"
+            class="sc-hlnMnd cpbYOv sc-eKBdFk cTggPd"
             color="primary.main"
             href="#"
           >
@@ -52,10 +52,10 @@ exports[`Storyshots Core/List Default 1`] = `
 exports[`Storyshots Core/List Ordered 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <ol
-      class="sc-kIKDeO sc-hNKHps zlfFv eCLmQY sc-cZwWEu QrmZN"
+      class="sc-bUbCnL sc-kIKDeO yqZnU IIosZ sc-dsQDmV jUuGTp"
     >
       <li>
         <div
@@ -63,7 +63,7 @@ exports[`Storyshots Core/List Ordered 1`] = `
         >
           You can put 
           <a
-            class="sc-eKBdFk eDgBSD sc-bUbCnL aUvHI"
+            class="sc-hlnMnd cpbYOv sc-eKBdFk cTggPd"
             color="primary.main"
             href="#"
           >

--- a/src/components/Map/__snapshots__/Map.stories.storyshot
+++ b/src/components/Map/__snapshots__/Map.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/Map Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       style="height: 600px;"

--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Meta } from '@storybook/react';
 import { createTemplate, createStory } from '../../stories/utils';
-import { Box, Button, Heading } from '../../';
+import { Box, Button, Heading, Txt } from '../../';
 import { Modal, ModalProps } from '.';
 
 import PokeDex from '../../stories/assets/pokedex';
@@ -86,8 +86,14 @@ export const NoCancel = createStory<ModalProps>(Template, {
 });
 
 export const WithTitleDetails = createStory<ModalProps>(Template, {
-	title: 'Modal title',
-	titleDetails: 'Optional details',
+	title: (
+		<>
+			Modal title
+			<Txt mt={3} fontSize="initial">
+				Optional details
+			</Txt>
+		</>
+	),
 	children: (
 		<>
 			<p>Lorem ipsum dolor sit amet</p>
@@ -96,8 +102,14 @@ export const WithTitleDetails = createStory<ModalProps>(Template, {
 });
 
 export const WithCustomWidth = createStory<ModalProps>(Template, {
-	title: 'Modal title',
-	titleDetails: 'Optional details',
+	title: (
+		<>
+			Modal title
+			<Txt mt={3} fontSize="initial">
+				Optional details
+			</Txt>
+		</>
+	),
 	width: ['auto', 500, 1000],
 	children: (
 		<>
@@ -107,7 +119,7 @@ export const WithCustomWidth = createStory<ModalProps>(Template, {
 });
 
 export const WithMultielementTitle = createStory<ModalProps>(Template, {
-	titleElement: (
+	title: (
 		<React.Fragment>
 			<Heading.h3>Heading</Heading.h3>
 			<Button mt={3} primary>

--- a/src/components/Modal/__snapshots__/Modal.stories.storyshot
+++ b/src/components/Modal/__snapshots__/Modal.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/Modal Custom Action 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="sc-gKXOVf QRSBg sc-iBkjds ipRjux"
@@ -22,7 +22,7 @@ exports[`Storyshots Core/Modal Custom Action 1`] = `
 exports[`Storyshots Core/Modal Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="sc-gKXOVf QRSBg sc-iBkjds ipRjux"
@@ -41,7 +41,7 @@ exports[`Storyshots Core/Modal Default 1`] = `
 exports[`Storyshots Core/Modal Nested 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="sc-gKXOVf QRSBg sc-iBkjds ipRjux"
@@ -60,7 +60,7 @@ exports[`Storyshots Core/Modal Nested 1`] = `
 exports[`Storyshots Core/Modal No Cancel 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="sc-gKXOVf QRSBg sc-iBkjds ipRjux"
@@ -79,7 +79,7 @@ exports[`Storyshots Core/Modal No Cancel 1`] = `
 exports[`Storyshots Core/Modal With Custom Width 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="sc-gKXOVf QRSBg sc-iBkjds ipRjux"
@@ -98,7 +98,7 @@ exports[`Storyshots Core/Modal With Custom Width 1`] = `
 exports[`Storyshots Core/Modal With Customized Buttons 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="sc-gKXOVf QRSBg sc-iBkjds ipRjux"
@@ -117,7 +117,7 @@ exports[`Storyshots Core/Modal With Customized Buttons 1`] = `
 exports[`Storyshots Core/Modal With Multielement Title 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="sc-gKXOVf QRSBg sc-iBkjds ipRjux"
@@ -136,7 +136,7 @@ exports[`Storyshots Core/Modal With Multielement Title 1`] = `
 exports[`Storyshots Core/Modal With Overflowing Content 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="sc-gKXOVf QRSBg sc-iBkjds ipRjux"
@@ -155,7 +155,7 @@ exports[`Storyshots Core/Modal With Overflowing Content 1`] = `
 exports[`Storyshots Core/Modal With Title Details 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="sc-gKXOVf QRSBg sc-iBkjds ipRjux"
@@ -174,7 +174,7 @@ exports[`Storyshots Core/Modal With Title Details 1`] = `
 exports[`Storyshots Core/Modal With Tooltip 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="sc-gKXOVf QRSBg sc-iBkjds ipRjux"

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -8,7 +8,6 @@ import { Box } from '../Box';
 import { Button, ButtonProps } from '../Button';
 import { Flex } from '../Flex';
 import { Heading } from '../Heading';
-import { Txt } from '../Txt';
 
 const bodyNoOverflowClass = `rendition-modal-open`;
 
@@ -23,10 +22,6 @@ const DEFAULT_MODAL_WIDTH = 700;
 
 const ModalSizer = styled(Box)`
 	overflow-y: auto;
-`;
-
-const HeadingDescription = styled(Txt)`
-	font-weight: normal;
 `;
 
 const ModalButton = (props: ButtonProps) => {
@@ -149,20 +144,7 @@ class BaseModal extends React.Component<ThemedModalProps, any> {
 					className={props.className}
 				>
 					<Box p={[px(theme.space[3]), '40px 50px 30px']}>
-						{props.titleElement ? (
-							<Heading.h3 mb={4}>{props.titleElement}</Heading.h3>
-						) : (
-							!!props.title && (
-								<Heading.h3 mb={4}>
-									{props.title}
-									{!!props.titleDetails && (
-										<HeadingDescription color="text.light" fontSize={2}>
-											{props.titleDetails}
-										</HeadingDescription>
-									)}
-								</Heading.h3>
-							)
-						)}
+						{!!props.title && <Heading.h3 mb={4}>{props.title}</Heading.h3>}
 						{props.children}
 						<Flex mt={5} alignItems="center" justifyContent="flex-end">
 							{props.cancel && (
@@ -185,16 +167,13 @@ class BaseModal extends React.Component<ThemedModalProps, any> {
 	}
 }
 
-export interface ModalProps extends React.HTMLAttributes<HTMLElement> {
-	/** A title to display at the top of the Modal, only displayed if the `titleElement` property is not used */
-	title?: string;
+export interface ModalProps
+	extends Omit<React.HTMLAttributes<HTMLElement>, 'title'> {
 	width?: ResponsiveStyle;
 	/** Start the modal from the center (default) or top */
 	position?: 'center' | 'top';
 	/** A string or JSX element to display at the top of the modal */
-	titleElement?: string | JSX.Element;
-	/** A string or JSX element to display underneath the modal's `title`, only displayed if the `titleElement` property is not used and a `title` property is provided */
-	titleDetails?: string | JSX.Element;
+	title?: string | JSX.Element;
 	/** A string or JSX element to display in the primary modal button, defaults to 'OK' */
 	action?: string | JSX.Element;
 	/** A function that is called if the modal is dismissed */

--- a/src/components/Navbar/__snapshots__/Navbar.stories.storyshot
+++ b/src/components/Navbar/__snapshots__/Navbar.stories.storyshot
@@ -3,13 +3,13 @@
 exports[`Storyshots Core/Navbar Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="sc-gKXOVf QRSBg sc-iBkjds dNoAeF"
     >
       <div
-        class="sc-gKXOVf QRSBg sc-iBkjds bkEkLP sc-tQuYZ iejtYQ sc-dSuTWQ gvFvHw"
+        class="sc-gKXOVf QRSBg sc-iBkjds bkEkLP sc-bTMaZy iSKKFC sc-tQuYZ AZKVT"
       >
         <div
           class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK lQaPL"
@@ -18,22 +18,22 @@ exports[`Storyshots Core/Navbar Default 1`] = `
             class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY"
           >
             <div
-              class="sc-gKXOVf QRSBg sc-iBkjds fcYCAY sc-hZFzCs Bwoav"
+              class="sc-gKXOVf QRSBg sc-iBkjds fcYCAY sc-dSuTWQ jXwPLN"
             >
               <a
-                class="sc-eKBdFk gZLGMu sc-bUbCnL kxhRCL"
+                class="sc-hlnMnd fJVQsC sc-eKBdFk dZASRy"
                 color="white"
                 href="/"
               >
                 <img
-                  class="sc-hlnMnd fzMXUQ"
+                  class="sc-jOhDuK fgeoWi"
                   src=""
                   style="height: 20px;"
                 />
               </a>
             </div>
             <div
-              class="sc-gKXOVf QRSBg sc-iBkjds dyRNlF sc-cHPgQl dxEOOw"
+              class="sc-gKXOVf QRSBg sc-iBkjds dyRNlF sc-hZFzCs bRStsr"
             >
               <svg
                 aria-hidden="true"
@@ -53,7 +53,7 @@ exports[`Storyshots Core/Navbar Default 1`] = `
             </div>
           </div>
           <div
-            class="sc-gKXOVf QRSBg sc-iBkjds guQguK sc-hHLeRK sc-KfMfS iKIurY dZEySG"
+            class="sc-gKXOVf QRSBg sc-iBkjds guQguK sc-hHLeRK sc-cHPgQl iKIurY bnImva"
           >
             <div
               class="sc-gKXOVf QRSBg sc-iBkjds fdUOap sc-hHLeRK lQaPL"
@@ -62,7 +62,7 @@ exports[`Storyshots Core/Navbar Default 1`] = `
                 class="sc-gKXOVf QRSBg sc-iBkjds bYeWip"
               >
                 <a
-                  class="sc-eKBdFk gZLGMu sc-bUbCnL kxhRCL"
+                  class="sc-hlnMnd fJVQsC sc-eKBdFk dZASRy"
                   color="white"
                   href="/docs/"
                 >
@@ -73,7 +73,7 @@ exports[`Storyshots Core/Navbar Default 1`] = `
                 class="sc-gKXOVf QRSBg sc-iBkjds bYeWip"
               >
                 <a
-                  class="sc-eKBdFk gZLGMu sc-bUbCnL kxhRCL"
+                  class="sc-hlnMnd fJVQsC sc-eKBdFk dZASRy"
                   color="white"
                   href="/changelog/"
                 >
@@ -84,7 +84,7 @@ exports[`Storyshots Core/Navbar Default 1`] = `
                 class="sc-gKXOVf QRSBg sc-iBkjds bYeWip"
               >
                 <a
-                  class="sc-eKBdFk gZLGMu sc-bUbCnL kxhRCL"
+                  class="sc-hlnMnd fJVQsC sc-eKBdFk dZASRy"
                   color="white"
                   href="/gitter/"
                 >

--- a/src/components/Notifications/__snapshots__/Notifications.stories.storyshot
+++ b/src/components/Notifications/__snapshots__/Notifications.stories.storyshot
@@ -3,13 +3,13 @@
 exports[`Storyshots Core/Notifications Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="sc-gKXOVf QRSBg sc-iBkjds iqcFkW sc-hHLeRK dzJWYl"
     >
       <div
-        class="react-notification-root sc-bTMaZy ixteba"
+        class="react-notification-root sc-jKDlA-D jxCdPO"
       >
         <div
           class="notification-container-top-left"
@@ -25,7 +25,7 @@ exports[`Storyshots Core/Notifications Default 1`] = `
               class="notification-item n-child"
             >
               <div
-                class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-dmRaPn iKIurY gdKzWA sc-gicCDI cmHWGP sc-jKDlA-D brDSia"
+                class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-dmRaPn iKIurY gdKzWA sc-gicCDI cmHWGP sc-iWajrY gcSfIh"
               >
                 
                 <div
@@ -71,7 +71,7 @@ exports[`Storyshots Core/Notifications Default 1`] = `
               class="notification-item n-child"
             >
               <div
-                class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-dmRaPn iKIurY gdKzWA sc-gicCDI cmHWGP sc-jKDlA-D brDSia"
+                class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-dmRaPn iKIurY gdKzWA sc-gicCDI cmHWGP sc-iWajrY gcSfIh"
               >
                 
                 <div
@@ -164,10 +164,10 @@ exports[`Storyshots Core/Notifications Default 1`] = `
 exports[`Storyshots Core/Notifications Positioning 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
-      class="react-notification-root sc-bTMaZy ixteba"
+      class="react-notification-root sc-jKDlA-D jxCdPO"
     >
       <div
         class="notification-container-top-left"
@@ -180,7 +180,7 @@ exports[`Storyshots Core/Notifications Positioning 1`] = `
             class="notification-item n-child"
           >
             <div
-              class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-dmRaPn iKIurY gdKzWA sc-gicCDI cmHWGP sc-jKDlA-D brDSia"
+              class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-dmRaPn iKIurY gdKzWA sc-gicCDI cmHWGP sc-iWajrY gcSfIh"
             >
               
               <div
@@ -230,7 +230,7 @@ exports[`Storyshots Core/Notifications Positioning 1`] = `
             class="notification-item n-child"
           >
             <div
-              class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-dmRaPn iKIurY gdKzWA sc-gicCDI cmHWGP sc-jKDlA-D brDSia"
+              class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-dmRaPn iKIurY gdKzWA sc-gicCDI cmHWGP sc-iWajrY gcSfIh"
             >
               
               <div
@@ -280,7 +280,7 @@ exports[`Storyshots Core/Notifications Positioning 1`] = `
             class="notification-item n-child"
           >
             <div
-              class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-dmRaPn iKIurY gdKzWA sc-gicCDI cmHWGP sc-jKDlA-D brDSia"
+              class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-dmRaPn iKIurY gdKzWA sc-gicCDI cmHWGP sc-iWajrY gcSfIh"
             >
               
               <div
@@ -330,7 +330,7 @@ exports[`Storyshots Core/Notifications Positioning 1`] = `
             class="notification-item n-child"
           >
             <div
-              class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-dmRaPn iKIurY gdKzWA sc-gicCDI cmHWGP sc-jKDlA-D brDSia"
+              class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-dmRaPn iKIurY gdKzWA sc-gicCDI cmHWGP sc-iWajrY gcSfIh"
             >
               
               <div
@@ -380,7 +380,7 @@ exports[`Storyshots Core/Notifications Positioning 1`] = `
             class="notification-item n-child"
           >
             <div
-              class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-dmRaPn iKIurY gdKzWA sc-gicCDI cmHWGP sc-jKDlA-D brDSia"
+              class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-dmRaPn iKIurY gdKzWA sc-gicCDI cmHWGP sc-iWajrY gcSfIh"
             >
               
               <div
@@ -433,7 +433,7 @@ exports[`Storyshots Core/Notifications Positioning 1`] = `
               class="notification-item n-child"
             >
               <div
-                class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-dmRaPn iKIurY gdKzWA sc-gicCDI cmHWGP sc-jKDlA-D brDSia"
+                class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-dmRaPn iKIurY gdKzWA sc-gicCDI cmHWGP sc-iWajrY gcSfIh"
               >
                 
                 <div
@@ -484,7 +484,7 @@ exports[`Storyshots Core/Notifications Positioning 1`] = `
             class="notification-item n-child"
           >
             <div
-              class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-dmRaPn iKIurY gdKzWA sc-gicCDI cmHWGP sc-jKDlA-D brDSia"
+              class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-dmRaPn iKIurY gdKzWA sc-gicCDI cmHWGP sc-iWajrY gcSfIh"
             >
               
               <div
@@ -585,13 +585,13 @@ exports[`Storyshots Core/Notifications Positioning 1`] = `
 exports[`Storyshots Core/Notifications Types 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="sc-gKXOVf QRSBg sc-iBkjds iqcFkW sc-hHLeRK dzJWYl"
     >
       <div
-        class="react-notification-root sc-bTMaZy ixteba"
+        class="react-notification-root sc-jKDlA-D jxCdPO"
       >
         <div
           class="notification-container-top-left"
@@ -607,7 +607,7 @@ exports[`Storyshots Core/Notifications Types 1`] = `
               class="notification-item n-child"
             >
               <div
-                class="sc-gKXOVf QRSBg sc-iBkjds dnRYSM sc-hHLeRK sc-dmRaPn iKIurY FGhRa sc-gicCDI cmHWGP sc-jKDlA-D brDSia"
+                class="sc-gKXOVf QRSBg sc-iBkjds dnRYSM sc-hHLeRK sc-dmRaPn iKIurY FGhRa sc-gicCDI cmHWGP sc-iWajrY gcSfIh"
               >
                 <div
                   class="sc-ivTmOn dNJphr sc-cxabCf eemXLs"
@@ -675,7 +675,7 @@ exports[`Storyshots Core/Notifications Types 1`] = `
               class="notification-item n-child"
             >
               <div
-                class="sc-gKXOVf QRSBg sc-iBkjds gdzJDO sc-hHLeRK sc-dmRaPn iKIurY kIPQvp sc-gicCDI cmHWGP sc-jKDlA-D brDSia"
+                class="sc-gKXOVf QRSBg sc-iBkjds gdzJDO sc-hHLeRK sc-dmRaPn iKIurY kIPQvp sc-gicCDI cmHWGP sc-iWajrY gcSfIh"
               >
                 <div
                   class="sc-ivTmOn dNJphr sc-cxabCf bLiaOm"
@@ -743,7 +743,7 @@ exports[`Storyshots Core/Notifications Types 1`] = `
               class="notification-item n-child"
             >
               <div
-                class="sc-gKXOVf QRSBg sc-iBkjds gwVQPy sc-hHLeRK sc-dmRaPn iKIurY blUbwm sc-gicCDI cmHWGP sc-jKDlA-D brDSia"
+                class="sc-gKXOVf QRSBg sc-iBkjds gwVQPy sc-hHLeRK sc-dmRaPn iKIurY blUbwm sc-gicCDI cmHWGP sc-iWajrY gcSfIh"
               >
                 <div
                   class="sc-ivTmOn dNJphr sc-cxabCf CTiCS"
@@ -811,7 +811,7 @@ exports[`Storyshots Core/Notifications Types 1`] = `
               class="notification-item n-child"
             >
               <div
-                class="sc-gKXOVf QRSBg sc-iBkjds gDBmYX sc-hHLeRK sc-dmRaPn iKIurY jrmdGN sc-gicCDI cmHWGP sc-jKDlA-D brDSia"
+                class="sc-gKXOVf QRSBg sc-iBkjds gDBmYX sc-hHLeRK sc-dmRaPn iKIurY jrmdGN sc-gicCDI cmHWGP sc-iWajrY gcSfIh"
               >
                 <div
                   class="sc-gKXOVf ckXSHX sc-iBkjds iAZiqN"

--- a/src/components/Pager/__snapshots__/Pager.stories.storyshot
+++ b/src/components/Pager/__snapshots__/Pager.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/Pager Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK hoTTom"
@@ -80,7 +80,7 @@ exports[`Storyshots Core/Pager Default 1`] = `
 exports[`Storyshots Core/Pager Fuzzy 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK hoTTom"

--- a/src/components/Popover/__snapshots__/Popover.stories.storyshot
+++ b/src/components/Popover/__snapshots__/Popover.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/Popover Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="sc-gKXOVf QRSBg sc-iBkjds heXUfd"

--- a/src/components/ProgressBar/__snapshots__/ProgressBar.stories.storyshot
+++ b/src/components/ProgressBar/__snapshots__/ProgressBar.stories.storyshot
@@ -3,24 +3,24 @@
 exports[`Storyshots Core/ProgressBar Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
-      class="sc-fctJkW hVFQfg sc-HzFiz fzqlHq"
+      class="sc-fvNpTx hqRdaF sc-fctJkW gfcSxi"
       color="#fff"
     >
       <div
-        class="sc-jQHtVU cDMxHp"
+        class="sc-jTYCaT eFodso"
       >
         10
         %
       </div>
       <div
-        class="sc-jTYCaT dcZJub"
+        class="sc-cZwWEu hAnkiz"
         style="width: 10%;"
       >
         <div
-          class="sc-fvNpTx flrTXX"
+          class="sc-jQHtVU ezQmmd"
           style="width: 1000%;"
         >
           10
@@ -35,25 +35,25 @@ exports[`Storyshots Core/ProgressBar Default 1`] = `
 exports[`Storyshots Core/ProgressBar Different Color 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
-      class="sc-fctJkW hVFQfg sc-HzFiz fzqlHq"
+      class="sc-fvNpTx hqRdaF sc-fctJkW gfcSxi"
       color="#fff"
       type="danger"
     >
       <div
-        class="sc-jQHtVU cDMxHp"
+        class="sc-jTYCaT eFodso"
       >
         10
         %
       </div>
       <div
-        class="sc-jTYCaT cxASLt"
+        class="sc-cZwWEu zdrht"
         style="width: 10%;"
       >
         <div
-          class="sc-fvNpTx flrTXX"
+          class="sc-jQHtVU ezQmmd"
           style="width: 1000%;"
         >
           10
@@ -68,24 +68,24 @@ exports[`Storyshots Core/ProgressBar Different Color 1`] = `
 exports[`Storyshots Core/ProgressBar Emphasized 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
-      class="sc-fctJkW byhvdN sc-HzFiz fzqlHq"
+      class="sc-fvNpTx kYeMME sc-fctJkW gfcSxi"
       color="#fff"
     >
       <div
-        class="sc-jQHtVU cDMxHp"
+        class="sc-jTYCaT eFodso"
       >
         10
         %
       </div>
       <div
-        class="sc-jTYCaT dcZJub"
+        class="sc-cZwWEu hAnkiz"
         style="width: 10%;"
       >
         <div
-          class="sc-fvNpTx flrTXX"
+          class="sc-jQHtVU ezQmmd"
           style="width: 1000%;"
         >
           10

--- a/src/components/RadioButton/__snapshots__/RadioButton.stories.storyshot
+++ b/src/components/RadioButton/__snapshots__/RadioButton.stories.storyshot
@@ -3,10 +3,10 @@
 exports[`Storyshots Core/RadioButton Checked 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
-      class="sc-gzzPqb jBCpcO sc-gkJlnC dBMtEL"
+      class="sc-fHsOPI kPZdwN sc-gzzPqb eRNoIM"
     >
       <label
         class="StyledRadioButton__StyledRadioButtonContainer-sc-g1f6ld-0 inzTRD"
@@ -50,10 +50,10 @@ exports[`Storyshots Core/RadioButton Checked 1`] = `
 exports[`Storyshots Core/RadioButton Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
-      class="sc-gzzPqb dakkoy sc-gkJlnC dBMtEL"
+      class="sc-fHsOPI icBwUh sc-gzzPqb eRNoIM"
     >
       <label
         class="StyledRadioButton__StyledRadioButtonContainer-sc-g1f6ld-0 inzTRD"
@@ -84,10 +84,10 @@ exports[`Storyshots Core/RadioButton Default 1`] = `
 exports[`Storyshots Core/RadioButton Disabled 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
-      class="sc-gzzPqb dakkoy sc-gkJlnC dBMtEL"
+      class="sc-fHsOPI icBwUh sc-gzzPqb eRNoIM"
     >
       <label
         class="StyledRadioButton__StyledRadioButtonContainer-sc-g1f6ld-0 ixkEGa"

--- a/src/components/RadioButtonGroup/__snapshots__/RadioButtonGroup.stories.storyshot
+++ b/src/components/RadioButtonGroup/__snapshots__/RadioButtonGroup.stories.storyshot
@@ -3,10 +3,10 @@
 exports[`Storyshots Core/RadioButtonGroup Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hANpeK sc-fmrZth dUEvSK sc-eXBvqI liZNNF"
+      class="StyledBox-sc-13pk1d4-0 hANpeK sc-gkJlnC bewrqS sc-fmrZth ckKVNz"
       role="radiogroup"
     >
       <label
@@ -83,10 +83,10 @@ exports[`Storyshots Core/RadioButtonGroup Default 1`] = `
 exports[`Storyshots Core/RadioButtonGroup With Expanded Options 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hANpeK sc-fmrZth fOtvKK sc-eXBvqI liZNNF"
+      class="StyledBox-sc-13pk1d4-0 hANpeK sc-gkJlnC hWHwUK sc-fmrZth ckKVNz"
       role="radiogroup"
     >
       <label

--- a/src/components/Rating/__snapshots__/Rating.stories.storyshot
+++ b/src/components/Rating/__snapshots__/Rating.stories.storyshot
@@ -3,10 +3,10 @@
 exports[`Storyshots Core/Rating Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
-      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY sc-ESujJ JahXL"
+      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY sc-fWIMVQ iTEChS"
     >
       <svg
         aria-hidden="true"

--- a/src/components/Search/__snapshots__/Search.stories.storyshot
+++ b/src/components/Search/__snapshots__/Search.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/Search Dark 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-kgUAyh iKIurY kCkpfb sc-hTtwUo eWqTFt"
@@ -56,7 +56,7 @@ exports[`Storyshots Core/Search Dark 1`] = `
 exports[`Storyshots Core/Search Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-kgUAyh iKIurY kCkpfb sc-hTtwUo eWqTFt"
@@ -108,7 +108,7 @@ exports[`Storyshots Core/Search Default 1`] = `
 exports[`Storyshots Core/Search Disabled 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-kgUAyh iKIurY kCkpfb sc-hTtwUo eWqTFt"
@@ -161,7 +161,7 @@ exports[`Storyshots Core/Search Disabled 1`] = `
 exports[`Storyshots Core/Search With Placeholder 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-kgUAyh iKIurY kCkpfb sc-hTtwUo eWqTFt"

--- a/src/components/Select/__snapshots__/Select.stories.storyshot
+++ b/src/components/Select/__snapshots__/Select.stories.storyshot
@@ -3,10 +3,10 @@
 exports[`Storyshots Core/Select Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
-      class="sc-iNWwEs iFVTvX sc-jfmDQi cIsMNl"
+      class="sc-lbxAil pYSLc sc-iNWwEs kTxGWB"
     >
       <button
         aria-label="Open Drop"
@@ -24,7 +24,7 @@ exports[`Storyshots Core/Select Default 1`] = `
             >
               <input
                 autocomplete="off"
-                class="StyledTextInput-sc-1x30a0s-0 ewHtlx Select__SelectTextInput-sc-17idtfo-0 bQAqdj sc-lbxAil gvSMeT"
+                class="StyledTextInput-sc-1x30a0s-0 ewHtlx Select__SelectTextInput-sc-17idtfo-0 bQAqdj sc-gSAPjG hCdWnJ"
                 readonly=""
                 tabindex="-1"
                 type="text"
@@ -59,10 +59,10 @@ exports[`Storyshots Core/Select Default 1`] = `
 exports[`Storyshots Core/Select Emphasized 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
-      class="sc-iNWwEs iFVTvX sc-jfmDQi cIsMNl"
+      class="sc-lbxAil pYSLc sc-iNWwEs kTxGWB"
     >
       <button
         aria-label="Open Drop"
@@ -80,7 +80,7 @@ exports[`Storyshots Core/Select Emphasized 1`] = `
             >
               <input
                 autocomplete="off"
-                class="StyledTextInput-sc-1x30a0s-0 ewHtlx Select__SelectTextInput-sc-17idtfo-0 bQAqdj sc-lbxAil gEeDUw"
+                class="StyledTextInput-sc-1x30a0s-0 ewHtlx Select__SelectTextInput-sc-17idtfo-0 bQAqdj sc-gSAPjG lmHZUC"
                 readonly=""
                 tabindex="-1"
                 type="text"
@@ -115,10 +115,10 @@ exports[`Storyshots Core/Select Emphasized 1`] = `
 exports[`Storyshots Core/Select Invalid 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
-      class="sc-iNWwEs dLgant sc-jfmDQi cIsMNl"
+      class="sc-lbxAil cbZNye sc-iNWwEs kTxGWB"
     >
       <button
         aria-label="Open Drop"
@@ -136,7 +136,7 @@ exports[`Storyshots Core/Select Invalid 1`] = `
             >
               <input
                 autocomplete="off"
-                class="StyledTextInput-sc-1x30a0s-0 ewHtlx Select__SelectTextInput-sc-17idtfo-0 bQAqdj sc-lbxAil gvSMeT"
+                class="StyledTextInput-sc-1x30a0s-0 ewHtlx Select__SelectTextInput-sc-17idtfo-0 bQAqdj sc-gSAPjG hCdWnJ"
                 readonly=""
                 tabindex="-1"
                 type="text"
@@ -171,10 +171,10 @@ exports[`Storyshots Core/Select Invalid 1`] = `
 exports[`Storyshots Core/Select Object Options 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
-      class="sc-iNWwEs iFVTvX sc-jfmDQi cIsMNl"
+      class="sc-lbxAil pYSLc sc-iNWwEs kTxGWB"
     >
       <button
         aria-label="Open Drop"
@@ -192,7 +192,7 @@ exports[`Storyshots Core/Select Object Options 1`] = `
             >
               <input
                 autocomplete="off"
-                class="StyledTextInput-sc-1x30a0s-0 ewHtlx Select__SelectTextInput-sc-17idtfo-0 bQAqdj sc-lbxAil gvSMeT"
+                class="StyledTextInput-sc-1x30a0s-0 ewHtlx Select__SelectTextInput-sc-17idtfo-0 bQAqdj sc-gSAPjG hCdWnJ"
                 readonly=""
                 tabindex="-1"
                 type="text"
@@ -227,10 +227,10 @@ exports[`Storyshots Core/Select Object Options 1`] = `
 exports[`Storyshots Core/Select With Custom Option 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
-      class="sc-iNWwEs iFVTvX sc-jfmDQi cIsMNl"
+      class="sc-lbxAil pYSLc sc-iNWwEs kTxGWB"
     >
       <button
         aria-label="Open Drop"
@@ -248,7 +248,7 @@ exports[`Storyshots Core/Select With Custom Option 1`] = `
             >
               <input
                 autocomplete="off"
-                class="StyledTextInput-sc-1x30a0s-0 ewHtlx Select__SelectTextInput-sc-17idtfo-0 bQAqdj sc-lbxAil gvSMeT"
+                class="StyledTextInput-sc-1x30a0s-0 ewHtlx Select__SelectTextInput-sc-17idtfo-0 bQAqdj sc-gSAPjG hCdWnJ"
                 readonly=""
                 tabindex="-1"
                 type="text"
@@ -283,10 +283,10 @@ exports[`Storyshots Core/Select With Custom Option 1`] = `
 exports[`Storyshots Core/Select With Placeholder 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
-      class="sc-iNWwEs iFVTvX sc-jfmDQi cIsMNl"
+      class="sc-lbxAil pYSLc sc-iNWwEs kTxGWB"
     >
       <button
         aria-label="Open Drop"
@@ -304,7 +304,7 @@ exports[`Storyshots Core/Select With Placeholder 1`] = `
             >
               <input
                 autocomplete="off"
-                class="StyledTextInput-sc-1x30a0s-0 ewHtlx Select__SelectTextInput-sc-17idtfo-0 bQAqdj sc-lbxAil gvSMeT"
+                class="StyledTextInput-sc-1x30a0s-0 ewHtlx Select__SelectTextInput-sc-17idtfo-0 bQAqdj sc-gSAPjG hCdWnJ"
                 placeholder="Select one..."
                 readonly=""
                 tabindex="-1"

--- a/src/components/Sidebar/__snapshots__/Sidebar.stories.storyshot
+++ b/src/components/Sidebar/__snapshots__/Sidebar.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/Sidebar Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="sc-gKXOVf QRSBg sc-iBkjds ideygz sc-hHLeRK iKIurY"
@@ -28,7 +28,7 @@ exports[`Storyshots Core/Sidebar Default 1`] = `
                   class="sc-gKXOVf QRSBg sc-iBkjds gNjzDq sc-hHLeRK liHVdE"
                 >
                   <div
-                    class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-jWEIYm iKIurY iWCKqs"
+                    class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-ESujJ iKIurY iPkcIm"
                   />
                   <div
                     class="sc-gKXOVf QRSBg sc-iBkjds dqCdat sc-hHLeRK iKIurY"
@@ -64,7 +64,7 @@ exports[`Storyshots Core/Sidebar Default 1`] = `
                   class="sc-gKXOVf QRSBg sc-iBkjds gNjzDq sc-hHLeRK liHVdE"
                 >
                   <div
-                    class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-jWEIYm iKIurY bFtnjU"
+                    class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-ESujJ iKIurY IUhdi"
                   />
                   <div
                     class="sc-gKXOVf QRSBg sc-iBkjds dqCdat sc-hHLeRK iKIurY"
@@ -92,7 +92,7 @@ exports[`Storyshots Core/Sidebar Default 1`] = `
             href="/menuitem1"
           >
             <div
-              class="sc-gKXOVf QRSBg sc-iBkjds lbcSYZ sc-hHLeRK sc-fmRtwQ dlYhNW ixFnmQ"
+              class="sc-gKXOVf QRSBg sc-iBkjds lbcSYZ sc-hHLeRK sc-eEOqmf dlYhNW boSbZi"
             >
               <span
                 class="sc-ivTmOn fSbxau sc-llJcti gHzjsC"
@@ -106,7 +106,7 @@ exports[`Storyshots Core/Sidebar Default 1`] = `
             href="/menuitem2"
           >
             <div
-              class="sc-gKXOVf QRSBg sc-iBkjds lbcSYZ sc-hHLeRK sc-fmRtwQ dlYhNW ixFnmQ"
+              class="sc-gKXOVf QRSBg sc-iBkjds lbcSYZ sc-hHLeRK sc-eEOqmf dlYhNW boSbZi"
             >
               <span
                 class="sc-ivTmOn fSbxau sc-llJcti gHzjsC"
@@ -120,7 +120,7 @@ exports[`Storyshots Core/Sidebar Default 1`] = `
             href="/menuitem3"
           >
             <div
-              class="sc-gKXOVf QRSBg sc-iBkjds lbcSYZ sc-hHLeRK sc-fmRtwQ dlYhNW ixFnmQ"
+              class="sc-gKXOVf QRSBg sc-iBkjds lbcSYZ sc-hHLeRK sc-eEOqmf dlYhNW boSbZi"
             >
               <span
                 class="sc-ivTmOn fSbxau sc-llJcti gHzjsC"
@@ -146,7 +146,7 @@ exports[`Storyshots Core/Sidebar Default 1`] = `
 exports[`Storyshots Core/Sidebar With Additional Components 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="sc-gKXOVf QRSBg sc-iBkjds ideygz sc-hHLeRK iKIurY"
@@ -171,7 +171,7 @@ exports[`Storyshots Core/Sidebar With Additional Components 1`] = `
                   class="sc-gKXOVf QRSBg sc-iBkjds gNjzDq sc-hHLeRK liHVdE"
                 >
                   <div
-                    class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-jWEIYm iKIurY iWCKqs"
+                    class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-ESujJ iKIurY iPkcIm"
                   />
                   <div
                     class="sc-gKXOVf QRSBg sc-iBkjds dqCdat sc-hHLeRK iKIurY"
@@ -207,7 +207,7 @@ exports[`Storyshots Core/Sidebar With Additional Components 1`] = `
                   class="sc-gKXOVf QRSBg sc-iBkjds gNjzDq sc-hHLeRK liHVdE"
                 >
                   <div
-                    class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-jWEIYm iKIurY bFtnjU"
+                    class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-ESujJ iKIurY IUhdi"
                   />
                   <div
                     class="sc-gKXOVf QRSBg sc-iBkjds dqCdat sc-hHLeRK iKIurY"
@@ -235,7 +235,7 @@ exports[`Storyshots Core/Sidebar With Additional Components 1`] = `
             href="/menuitem1"
           >
             <div
-              class="sc-gKXOVf QRSBg sc-iBkjds lbcSYZ sc-hHLeRK sc-fmRtwQ dlYhNW ixFnmQ"
+              class="sc-gKXOVf QRSBg sc-iBkjds lbcSYZ sc-hHLeRK sc-eEOqmf dlYhNW boSbZi"
             >
               <span
                 class="sc-ivTmOn fSbxau sc-llJcti gHzjsC"
@@ -249,7 +249,7 @@ exports[`Storyshots Core/Sidebar With Additional Components 1`] = `
             href="/menuitem2"
           >
             <div
-              class="sc-gKXOVf QRSBg sc-iBkjds lbcSYZ sc-hHLeRK sc-fmRtwQ dlYhNW ixFnmQ"
+              class="sc-gKXOVf QRSBg sc-iBkjds lbcSYZ sc-hHLeRK sc-eEOqmf dlYhNW boSbZi"
             >
               <span
                 class="sc-ivTmOn fSbxau sc-llJcti gHzjsC"
@@ -263,7 +263,7 @@ exports[`Storyshots Core/Sidebar With Additional Components 1`] = `
             href="/menuitem3"
           >
             <div
-              class="sc-gKXOVf QRSBg sc-iBkjds lbcSYZ sc-hHLeRK sc-fmRtwQ dlYhNW ixFnmQ"
+              class="sc-gKXOVf QRSBg sc-iBkjds lbcSYZ sc-hHLeRK sc-eEOqmf dlYhNW boSbZi"
             >
               <span
                 class="sc-ivTmOn fSbxau sc-llJcti gHzjsC"

--- a/src/components/Spinner/__snapshots__/Spinner.stories.storyshot
+++ b/src/components/Spinner/__snapshots__/Spinner.stories.storyshot
@@ -3,13 +3,13 @@
 exports[`Storyshots Core/Spinner Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
-      class="sc-gKXOVf QRSBg sc-iBkjds iyqvCV sc-hHLeRK kvKuwg sc-caXVBt efHDjS"
+      class="sc-gKXOVf QRSBg sc-iBkjds iyqvCV sc-hHLeRK kvKuwg sc-hsOonA fPwlCE"
     >
       <div
-        class="sc-lkwKjF kpvPDv"
+        class="sc-fmRtwQ eGcdpz"
       />
     </div>
   </div>
@@ -19,13 +19,13 @@ exports[`Storyshots Core/Spinner Default 1`] = `
 exports[`Storyshots Core/Spinner Emphasized 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
-      class="sc-gKXOVf QRSBg sc-iBkjds iyqvCV sc-hHLeRK fDtTuc sc-caXVBt efHDjS"
+      class="sc-gKXOVf QRSBg sc-iBkjds iyqvCV sc-hHLeRK fDtTuc sc-hsOonA fPwlCE"
     >
       <div
-        class="sc-lkwKjF gPZNod"
+        class="sc-fmRtwQ jAbYuN"
       />
     </div>
   </div>
@@ -35,19 +35,19 @@ exports[`Storyshots Core/Spinner Emphasized 1`] = `
 exports[`Storyshots Core/Spinner With Children 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
-      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-jmNpzm iKIurY iITdfN sc-caXVBt efHDjS"
+      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-lkwKjF iKIurY khcTuI sc-hsOonA fPwlCE"
     >
       <div
-        class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-dUWWNf efXsRo dZYlTq"
+        class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-jmNpzm efXsRo heDVKZ"
       >
         <div
           class="sc-gKXOVf QRSBg sc-iBkjds iyqvCV sc-hHLeRK kvKuwg"
         >
           <div
-            class="sc-lkwKjF kpvPDv"
+            class="sc-fmRtwQ eGcdpz"
           />
           <div
             class="sc-ivTmOn dNJphr sc-cxabCf hPeMSo"
@@ -57,7 +57,7 @@ exports[`Storyshots Core/Spinner With Children 1`] = `
         </div>
       </div>
       <div
-        class="sc-hsOonA kVcSYM"
+        class="sc-dUWWNf jLMSpx"
       >
         <div
           class="sc-gKXOVf QRSBg sc-iBkjds bjjfxN"
@@ -74,13 +74,13 @@ exports[`Storyshots Core/Spinner With Children 1`] = `
 exports[`Storyshots Core/Spinner With Component Label 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
-      class="sc-gKXOVf QRSBg sc-iBkjds iyqvCV sc-hHLeRK kvKuwg sc-caXVBt efHDjS"
+      class="sc-gKXOVf QRSBg sc-iBkjds iyqvCV sc-hHLeRK kvKuwg sc-hsOonA fPwlCE"
     >
       <div
-        class="sc-lkwKjF kpvPDv"
+        class="sc-fmRtwQ eGcdpz"
       />
       <div
         class="sc-ivTmOn dNJphr sc-cxabCf hPeMSo"
@@ -106,13 +106,13 @@ exports[`Storyshots Core/Spinner With Component Label 1`] = `
 exports[`Storyshots Core/Spinner With Label 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
-      class="sc-gKXOVf QRSBg sc-iBkjds iyqvCV sc-hHLeRK kvKuwg sc-caXVBt efHDjS"
+      class="sc-gKXOVf QRSBg sc-iBkjds iyqvCV sc-hHLeRK kvKuwg sc-hsOonA fPwlCE"
     >
       <div
-        class="sc-lkwKjF kpvPDv"
+        class="sc-fmRtwQ eGcdpz"
       />
       <div
         class="sc-ivTmOn dNJphr sc-cxabCf hPeMSo"

--- a/src/components/StatsBar/__snapshots__/StatsBar.stories.storyshot
+++ b/src/components/StatsBar/__snapshots__/StatsBar.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/StatsBar Cpu Temp 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="sc-gKXOVf ckXSHX sc-iBkjds gXkNkX sc-hHLeRK eTSHtc"
@@ -66,19 +66,19 @@ exports[`Storyshots Core/StatsBar Cpu Temp 1`] = `
           class="sc-gKXOVf ckXSHX sc-iBkjds hYdgwD"
         >
           <div
-            class="sc-fctJkW hVFQfg sc-HzFiz fzqlHq"
+            class="sc-fvNpTx hqRdaF sc-fctJkW gfcSxi"
             color="#fff"
             type="success"
           >
             <div
-              class="sc-jQHtVU cDMxHp"
+              class="sc-jTYCaT eFodso"
             />
             <div
-              class="sc-jTYCaT mCDFM"
+              class="sc-cZwWEu jSxaSQ"
               style="width: 34%;"
             >
               <div
-                class="sc-fvNpTx flrTXX"
+                class="sc-jQHtVU ezQmmd"
                 style="width: 294.11764705882354%;"
               />
             </div>
@@ -93,7 +93,7 @@ exports[`Storyshots Core/StatsBar Cpu Temp 1`] = `
 exports[`Storyshots Core/StatsBar Cpu Usage 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="sc-gKXOVf ckXSHX sc-iBkjds gXkNkX sc-hHLeRK eTSHtc"
@@ -156,19 +156,19 @@ exports[`Storyshots Core/StatsBar Cpu Usage 1`] = `
           class="sc-gKXOVf ckXSHX sc-iBkjds dLaGQT"
         >
           <div
-            class="sc-fctJkW hVFQfg sc-HzFiz fzqlHq"
+            class="sc-fvNpTx hqRdaF sc-fctJkW gfcSxi"
             color="#fff"
             type="success"
           >
             <div
-              class="sc-jQHtVU cDMxHp"
+              class="sc-jTYCaT eFodso"
             />
             <div
-              class="sc-jTYCaT mCDFM"
+              class="sc-cZwWEu jSxaSQ"
               style="width: 100%;"
             >
               <div
-                class="sc-fvNpTx flrTXX"
+                class="sc-jQHtVU ezQmmd"
                 style="width: 100%;"
               />
             </div>
@@ -178,19 +178,19 @@ exports[`Storyshots Core/StatsBar Cpu Usage 1`] = `
           class="sc-gKXOVf ckXSHX sc-iBkjds dLaGQT"
         >
           <div
-            class="sc-fctJkW hVFQfg sc-HzFiz fzqlHq"
+            class="sc-fvNpTx hqRdaF sc-fctJkW gfcSxi"
             color="#fff"
             type="success"
           >
             <div
-              class="sc-jQHtVU cDMxHp"
+              class="sc-jTYCaT eFodso"
             />
             <div
-              class="sc-jTYCaT mCDFM"
+              class="sc-cZwWEu jSxaSQ"
               style="width: 100%;"
             >
               <div
-                class="sc-fvNpTx flrTXX"
+                class="sc-jQHtVU ezQmmd"
                 style="width: 100%;"
               />
             </div>
@@ -200,19 +200,19 @@ exports[`Storyshots Core/StatsBar Cpu Usage 1`] = `
           class="sc-gKXOVf ckXSHX sc-iBkjds dLaGQT"
         >
           <div
-            class="sc-fctJkW hVFQfg sc-HzFiz fzqlHq"
+            class="sc-fvNpTx hqRdaF sc-fctJkW gfcSxi"
             color="#fff"
             type="success"
           >
             <div
-              class="sc-jQHtVU cDMxHp"
+              class="sc-jTYCaT eFodso"
             />
             <div
-              class="sc-jTYCaT mCDFM"
+              class="sc-cZwWEu jSxaSQ"
               style="width: 0%;"
             >
               <div
-                class="sc-fvNpTx flrTXX"
+                class="sc-jQHtVU ezQmmd"
                 style="width: 0%;"
               />
             </div>
@@ -222,19 +222,19 @@ exports[`Storyshots Core/StatsBar Cpu Usage 1`] = `
           class="sc-gKXOVf ckXSHX sc-iBkjds dLaGQT"
         >
           <div
-            class="sc-fctJkW hVFQfg sc-HzFiz fzqlHq"
+            class="sc-fvNpTx hqRdaF sc-fctJkW gfcSxi"
             color="#fff"
             type="success"
           >
             <div
-              class="sc-jQHtVU cDMxHp"
+              class="sc-jTYCaT eFodso"
             />
             <div
-              class="sc-jTYCaT mCDFM"
+              class="sc-cZwWEu jSxaSQ"
               style="width: 0%;"
             >
               <div
-                class="sc-fvNpTx flrTXX"
+                class="sc-jQHtVU ezQmmd"
                 style="width: 0%;"
               />
             </div>
@@ -244,19 +244,19 @@ exports[`Storyshots Core/StatsBar Cpu Usage 1`] = `
           class="sc-gKXOVf ckXSHX sc-iBkjds hYdgwD"
         >
           <div
-            class="sc-fctJkW hVFQfg sc-HzFiz fzqlHq"
+            class="sc-fvNpTx hqRdaF sc-fctJkW gfcSxi"
             color="#fff"
             type="success"
           >
             <div
-              class="sc-jQHtVU cDMxHp"
+              class="sc-jTYCaT eFodso"
             />
             <div
-              class="sc-jTYCaT mCDFM"
+              class="sc-cZwWEu jSxaSQ"
               style="width: 0%;"
             >
               <div
-                class="sc-fvNpTx flrTXX"
+                class="sc-jQHtVU ezQmmd"
                 style="width: 0%;"
               />
             </div>
@@ -271,7 +271,7 @@ exports[`Storyshots Core/StatsBar Cpu Usage 1`] = `
 exports[`Storyshots Core/StatsBar Memory 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="sc-gKXOVf ckXSHX sc-iBkjds gXkNkX sc-hHLeRK eTSHtc"
@@ -344,19 +344,19 @@ exports[`Storyshots Core/StatsBar Memory 1`] = `
           class="sc-gKXOVf ckXSHX sc-iBkjds hYdgwD"
         >
           <div
-            class="sc-fctJkW hVFQfg sc-HzFiz fzqlHq"
+            class="sc-fvNpTx hqRdaF sc-fctJkW gfcSxi"
             color="#fff"
             type="success"
           >
             <div
-              class="sc-jQHtVU cDMxHp"
+              class="sc-jTYCaT eFodso"
             />
             <div
-              class="sc-jTYCaT mCDFM"
+              class="sc-cZwWEu jSxaSQ"
               style="width: 45.300000000000004%;"
             >
               <div
-                class="sc-fvNpTx flrTXX"
+                class="sc-jQHtVU ezQmmd"
                 style="width: 220.75055187637966%;"
               />
             </div>
@@ -371,7 +371,7 @@ exports[`Storyshots Core/StatsBar Memory 1`] = `
 exports[`Storyshots Core/StatsBar Storage 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="sc-gKXOVf ckXSHX sc-iBkjds gXkNkX sc-hHLeRK eTSHtc"
@@ -444,19 +444,19 @@ exports[`Storyshots Core/StatsBar Storage 1`] = `
           class="sc-gKXOVf ckXSHX sc-iBkjds hYdgwD"
         >
           <div
-            class="sc-fctJkW hVFQfg sc-HzFiz fzqlHq"
+            class="sc-fvNpTx hqRdaF sc-fctJkW gfcSxi"
             color="#fff"
             type="warning"
           >
             <div
-              class="sc-jQHtVU cDMxHp"
+              class="sc-jTYCaT eFodso"
             />
             <div
-              class="sc-jTYCaT inPfE"
+              class="sc-cZwWEu hjrMRo"
               style="width: 62.3%;"
             >
               <div
-                class="sc-fvNpTx flrTXX"
+                class="sc-jQHtVU ezQmmd"
                 style="width: 160.51364365971108%;"
               />
             </div>

--- a/src/components/Steps/__snapshots__/Steps.stories.storyshot
+++ b/src/components/Steps/__snapshots__/Steps.stories.storyshot
@@ -3,10 +3,10 @@
 exports[`Storyshots Core/Steps Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
-      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-dmRaPn bxEzyD coYthk sc-fHsOPI nVgYz"
+      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-dmRaPn bxEzyD coYthk sc-fWjsSh eRQEaz"
     >
       <div
         class="sc-gKXOVf QRSBg sc-iBkjds kHbOVG sc-hHLeRK cGKEdj"
@@ -18,7 +18,7 @@ exports[`Storyshots Core/Steps Default 1`] = `
             class="sc-gKXOVf QRSBg sc-iBkjds eYvdLm sc-hHLeRK kvKuwg"
           >
             <div
-              class="sc-gKXOVf QRSBg sc-iBkjds eiTTiE sc-hHLeRK sc-hjriPb iKIurY gsFnjE"
+              class="sc-gKXOVf QRSBg sc-iBkjds eiTTiE sc-hHLeRK sc-caXVBt iKIurY dytJIB"
             >
               <svg
                 aria-hidden="true"
@@ -76,7 +76,7 @@ exports[`Storyshots Core/Steps Default 1`] = `
             class="sc-gKXOVf QRSBg sc-iBkjds eYvdLm sc-hHLeRK kvKuwg"
           >
             <div
-              class="sc-gKXOVf QRSBg sc-iBkjds eiTTiE sc-hHLeRK sc-hjriPb iKIurY gsFnjE"
+              class="sc-gKXOVf QRSBg sc-iBkjds eiTTiE sc-hHLeRK sc-caXVBt iKIurY dytJIB"
             >
               <svg
                 aria-hidden="true"
@@ -134,7 +134,7 @@ exports[`Storyshots Core/Steps Default 1`] = `
             class="sc-gKXOVf QRSBg sc-iBkjds eYvdLm sc-hHLeRK kvKuwg"
           >
             <div
-              class="sc-gKXOVf QRSBg sc-iBkjds eiTTiE sc-hHLeRK sc-hjriPb iKIurY gsFnjE"
+              class="sc-gKXOVf QRSBg sc-iBkjds eiTTiE sc-hHLeRK sc-caXVBt iKIurY dytJIB"
             >
               <svg
                 aria-hidden="true"
@@ -168,10 +168,10 @@ exports[`Storyshots Core/Steps Default 1`] = `
 exports[`Storyshots Core/Steps Ordered 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
-      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-dmRaPn bxEzyD coYthk sc-fHsOPI nVgYz"
+      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-dmRaPn bxEzyD coYthk sc-fWjsSh eRQEaz"
     >
       <div
         class="sc-gKXOVf QRSBg sc-iBkjds kHbOVG sc-hHLeRK cGKEdj"
@@ -183,7 +183,7 @@ exports[`Storyshots Core/Steps Ordered 1`] = `
             class="sc-gKXOVf QRSBg sc-iBkjds eYvdLm sc-hHLeRK kvKuwg"
           >
             <div
-              class="sc-gKXOVf QRSBg sc-iBkjds eiTTiE sc-hHLeRK sc-hjriPb iKIurY gsFnjE"
+              class="sc-gKXOVf QRSBg sc-iBkjds eiTTiE sc-hHLeRK sc-caXVBt iKIurY dytJIB"
             >
               <svg
                 aria-hidden="true"
@@ -241,7 +241,7 @@ exports[`Storyshots Core/Steps Ordered 1`] = `
             class="sc-gKXOVf QRSBg sc-iBkjds eYvdLm sc-hHLeRK kvKuwg"
           >
             <div
-              class="sc-gKXOVf QRSBg sc-iBkjds esEVfz sc-hHLeRK sc-hjriPb iKIurY gsFnjE fa-layers"
+              class="sc-gKXOVf QRSBg sc-iBkjds esEVfz sc-hHLeRK sc-caXVBt iKIurY dytJIB fa-layers"
             >
               <svg
                 aria-hidden="true"
@@ -259,7 +259,7 @@ exports[`Storyshots Core/Steps Ordered 1`] = `
                 />
               </svg>
               <div
-                class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-gUAEMC ctSCoc fa-layers-text fa-inverse"
+                class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-hjriPb kFqVVT fa-layers-text fa-inverse"
               >
                 2
               </div>
@@ -304,13 +304,13 @@ exports[`Storyshots Core/Steps Ordered 1`] = `
             class="sc-gKXOVf QRSBg sc-iBkjds eYvdLm sc-hHLeRK kvKuwg"
           >
             <div
-              class="sc-gKXOVf QRSBg sc-iBkjds hdgZGZ sc-hHLeRK sc-hjriPb iKIurY gsFnjE fa-layers"
+              class="sc-gKXOVf QRSBg sc-iBkjds hdgZGZ sc-hHLeRK sc-caXVBt iKIurY dytJIB fa-layers"
             >
               <div
-                class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-fWjsSh itvbil"
+                class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-gUAEMC eOZriG"
               />
               <div
-                class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-gUAEMC ctSCoc fa-layers-text"
+                class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-hjriPb kFqVVT fa-layers-text"
               >
                 3
               </div>
@@ -331,10 +331,10 @@ exports[`Storyshots Core/Steps Ordered 1`] = `
 exports[`Storyshots Core/Steps With Custom Title 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
-      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-dmRaPn bxEzyD coYthk sc-fHsOPI nVgYz"
+      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-dmRaPn bxEzyD coYthk sc-fWjsSh eRQEaz"
     >
       <div
         class="sc-gKXOVf QRSBg sc-iBkjds GPkRS sc-hHLeRK efXsRo"
@@ -374,7 +374,7 @@ exports[`Storyshots Core/Steps With Custom Title 1`] = `
             class="sc-gKXOVf QRSBg sc-iBkjds eYvdLm sc-hHLeRK kvKuwg"
           >
             <div
-              class="sc-gKXOVf QRSBg sc-iBkjds eiTTiE sc-hHLeRK sc-hjriPb iKIurY gsFnjE"
+              class="sc-gKXOVf QRSBg sc-iBkjds eiTTiE sc-hHLeRK sc-caXVBt iKIurY dytJIB"
             >
               <svg
                 aria-hidden="true"
@@ -432,7 +432,7 @@ exports[`Storyshots Core/Steps With Custom Title 1`] = `
             class="sc-gKXOVf QRSBg sc-iBkjds eYvdLm sc-hHLeRK kvKuwg"
           >
             <div
-              class="sc-gKXOVf QRSBg sc-iBkjds eiTTiE sc-hHLeRK sc-hjriPb iKIurY gsFnjE"
+              class="sc-gKXOVf QRSBg sc-iBkjds eiTTiE sc-hHLeRK sc-caXVBt iKIurY dytJIB"
             >
               <svg
                 aria-hidden="true"
@@ -490,7 +490,7 @@ exports[`Storyshots Core/Steps With Custom Title 1`] = `
             class="sc-gKXOVf QRSBg sc-iBkjds eYvdLm sc-hHLeRK kvKuwg"
           >
             <div
-              class="sc-gKXOVf QRSBg sc-iBkjds eiTTiE sc-hHLeRK sc-hjriPb iKIurY gsFnjE"
+              class="sc-gKXOVf QRSBg sc-iBkjds eiTTiE sc-hHLeRK sc-caXVBt iKIurY dytJIB"
             >
               <svg
                 aria-hidden="true"
@@ -524,10 +524,10 @@ exports[`Storyshots Core/Steps With Custom Title 1`] = `
 exports[`Storyshots Core/Steps Without Borders 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
-      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-dmRaPn bxEzyD gXAAKr sc-fHsOPI nVgYz"
+      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-dmRaPn bxEzyD gXAAKr sc-fWjsSh eRQEaz"
     >
       <div
         class="sc-gKXOVf QRSBg sc-iBkjds kHbOVG sc-hHLeRK cGKEdj"
@@ -539,7 +539,7 @@ exports[`Storyshots Core/Steps Without Borders 1`] = `
             class="sc-gKXOVf QRSBg sc-iBkjds eYvdLm sc-hHLeRK kvKuwg"
           >
             <div
-              class="sc-gKXOVf QRSBg sc-iBkjds eiTTiE sc-hHLeRK sc-hjriPb iKIurY gsFnjE"
+              class="sc-gKXOVf QRSBg sc-iBkjds eiTTiE sc-hHLeRK sc-caXVBt iKIurY dytJIB"
             >
               <svg
                 aria-hidden="true"
@@ -558,7 +558,7 @@ exports[`Storyshots Core/Steps Without Borders 1`] = `
               </svg>
             </div>
             <a
-              class="sc-eKBdFk eDgBSD sc-bUbCnL aUvHI"
+              class="sc-hlnMnd cpbYOv sc-eKBdFk cTggPd"
               color="primary.main"
             >
               Doesn't have
@@ -598,7 +598,7 @@ exports[`Storyshots Core/Steps Without Borders 1`] = `
             class="sc-gKXOVf QRSBg sc-iBkjds eYvdLm sc-hHLeRK kvKuwg"
           >
             <div
-              class="sc-gKXOVf QRSBg sc-iBkjds hdgZGZ sc-hHLeRK sc-hjriPb iKIurY gsFnjE"
+              class="sc-gKXOVf QRSBg sc-iBkjds hdgZGZ sc-hHLeRK sc-caXVBt iKIurY dytJIB"
             >
               <svg
                 aria-hidden="true"
@@ -617,7 +617,7 @@ exports[`Storyshots Core/Steps Without Borders 1`] = `
               </svg>
             </div>
             <a
-              class="sc-eKBdFk eDgBSD sc-bUbCnL aUvHI"
+              class="sc-hlnMnd cpbYOv sc-eKBdFk cTggPd"
               color="primary.main"
             >
               Title or dismiss button
@@ -657,7 +657,7 @@ exports[`Storyshots Core/Steps Without Borders 1`] = `
             class="sc-gKXOVf QRSBg sc-iBkjds eYvdLm sc-hHLeRK kvKuwg"
           >
             <a
-              class="sc-eKBdFk eDgBSD sc-bUbCnL aUvHI"
+              class="sc-hlnMnd cpbYOv sc-eKBdFk cTggPd"
               color="primary.main"
             >
               That's it (no icon)

--- a/src/components/SurroundingOverlay/__snapshots__/SurroundingOverlay.stories.storyshot
+++ b/src/components/SurroundingOverlay/__snapshots__/SurroundingOverlay.stories.storyshot
@@ -3,14 +3,14 @@
 exports[`Storyshots Core/SurroundingOverlay Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 kZzThM"
     >
       <input
         autocomplete="off"
-        class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL fnlgoU sc-olbas dakThl"
+        class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi bMvozQ sc-eKszNL kdCIVL"
         type="text"
         value=""
       />
@@ -20,7 +20,7 @@ exports[`Storyshots Core/SurroundingOverlay Default 1`] = `
     >
       <input
         autocomplete="off"
-        class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL fnlgoU sc-olbas dakThl"
+        class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi bMvozQ sc-eKszNL kdCIVL"
         type="text"
         value=""
       />
@@ -30,7 +30,7 @@ exports[`Storyshots Core/SurroundingOverlay Default 1`] = `
     >
       <input
         autocomplete="off"
-        class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL fnlgoU sc-olbas jFRZyP"
+        class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi bMvozQ sc-eKszNL hCjBDB"
         type="datetime-local"
         value=""
       />
@@ -42,14 +42,14 @@ exports[`Storyshots Core/SurroundingOverlay Default 1`] = `
 exports[`Storyshots Core/SurroundingOverlay With Different Color 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 kZzThM"
     >
       <input
         autocomplete="off"
-        class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL fnlgoU sc-olbas dakThl"
+        class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi bMvozQ sc-eKszNL kdCIVL"
         type="text"
         value=""
       />
@@ -59,7 +59,7 @@ exports[`Storyshots Core/SurroundingOverlay With Different Color 1`] = `
     >
       <input
         autocomplete="off"
-        class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL fnlgoU sc-olbas dakThl"
+        class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi bMvozQ sc-eKszNL kdCIVL"
         type="text"
         value=""
       />
@@ -69,7 +69,7 @@ exports[`Storyshots Core/SurroundingOverlay With Different Color 1`] = `
     >
       <input
         autocomplete="off"
-        class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-eKszNL fnlgoU sc-olbas jFRZyP"
+        class="StyledTextInput-sc-1x30a0s-0 jDoemc sc-jfmDQi bMvozQ sc-eKszNL hCjBDB"
         type="datetime-local"
         value=""
       />

--- a/src/components/Table/__snapshots__/Table.stories.storyshot
+++ b/src/components/Table/__snapshots__/Table.stories.storyshot
@@ -3,19 +3,19 @@
 exports[`Storyshots Core/Table Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
-      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-kngDgl iKIurY kdKlCZ"
+      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-afnQL iKIurY eFWjlE"
     >
       <div
         class="sc-gKXOVf ckXSHX sc-iBkjds gNjzDq sc-hHLeRK eTSHtc"
       >
         <div
-          class="sc-iqGgem lbaJJA"
+          class="sc-iFwKgL cqyvps"
         >
           <div
-            class="sc-eVQfli lbmlHZ sc-dkSuNL bzbeQN"
+            class="sc-iqGgem lyCqM sc-cwpsFg cwqlwQ"
           >
             <div
               data-display="table-head"
@@ -506,19 +506,19 @@ exports[`Storyshots Core/Table Default 1`] = `
 exports[`Storyshots Core/Table Sorted 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
-      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-kngDgl iKIurY kdKlCZ"
+      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-afnQL iKIurY eFWjlE"
     >
       <div
         class="sc-gKXOVf ckXSHX sc-iBkjds gNjzDq sc-hHLeRK eTSHtc"
       >
         <div
-          class="sc-iqGgem lbaJJA"
+          class="sc-iFwKgL cqyvps"
         >
           <div
-            class="sc-eVQfli lbmlHZ sc-dkSuNL bzbeQN"
+            class="sc-iqGgem lyCqM sc-cwpsFg cwqlwQ"
           >
             <div
               data-display="table-head"
@@ -1009,19 +1009,19 @@ exports[`Storyshots Core/Table Sorted 1`] = `
 exports[`Storyshots Core/Table With Anchor Rows 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
-      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-kngDgl iKIurY kdKlCZ"
+      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-afnQL iKIurY eFWjlE"
     >
       <div
         class="sc-gKXOVf ckXSHX sc-iBkjds gNjzDq sc-hHLeRK eTSHtc"
       >
         <div
-          class="sc-iqGgem lbaJJA"
+          class="sc-iFwKgL cqyvps"
         >
           <div
-            class="sc-eVQfli cdbYRb sc-dkSuNL bzbeQN"
+            class="sc-iqGgem ilPLQu sc-cwpsFg cwqlwQ"
           >
             <div
               data-display="table-head"
@@ -1600,19 +1600,19 @@ exports[`Storyshots Core/Table With Anchor Rows 1`] = `
 exports[`Storyshots Core/Table With Checkboxes 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
-      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-kngDgl iKIurY kdKlCZ"
+      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-afnQL iKIurY eFWjlE"
     >
       <div
         class="sc-gKXOVf ckXSHX sc-iBkjds gNjzDq sc-hHLeRK eTSHtc"
       >
         <div
-          class="sc-iqGgem lbaJJA"
+          class="sc-iFwKgL cqyvps"
         >
           <div
-            class="sc-eVQfli ievGIH sc-dkSuNL lomGJk"
+            class="sc-iqGgem kdhdEq sc-cwpsFg fWCnRp"
           >
             <div
               data-display="table-head"
@@ -1621,7 +1621,7 @@ exports[`Storyshots Core/Table With Checkboxes 1`] = `
                 data-display="table-row"
               >
                 <div
-                  class="sc-iFwKgL bfGZOr"
+                  class="sc-eXBvqI jHeTGy"
                   data-display="table-cell"
                 >
                   <div
@@ -1778,7 +1778,7 @@ exports[`Storyshots Core/Table With Checkboxes 1`] = `
                 data-highlight="true"
               >
                 <div
-                  class="sc-iFwKgL bfGZOr"
+                  class="sc-eXBvqI jHeTGy"
                   data-display="table-cell"
                 >
                   <div
@@ -1845,7 +1845,7 @@ exports[`Storyshots Core/Table With Checkboxes 1`] = `
                 data-highlight="true"
               >
                 <div
-                  class="sc-iFwKgL bfGZOr"
+                  class="sc-eXBvqI jHeTGy"
                   data-display="table-cell"
                 >
                   <div
@@ -1912,7 +1912,7 @@ exports[`Storyshots Core/Table With Checkboxes 1`] = `
                 data-highlight="true"
               >
                 <div
-                  class="sc-iFwKgL bfGZOr"
+                  class="sc-eXBvqI jHeTGy"
                   data-display="table-cell"
                 >
                   <div
@@ -1979,7 +1979,7 @@ exports[`Storyshots Core/Table With Checkboxes 1`] = `
                 data-highlight="false"
               >
                 <div
-                  class="sc-iFwKgL bfGZOr"
+                  class="sc-eXBvqI jHeTGy"
                   data-display="table-cell"
                 >
                   <div
@@ -2034,7 +2034,7 @@ exports[`Storyshots Core/Table With Checkboxes 1`] = `
                 data-highlight="false"
               >
                 <div
-                  class="sc-iFwKgL bfGZOr"
+                  class="sc-eXBvqI jHeTGy"
                   data-display="table-cell"
                 >
                   <div
@@ -2097,7 +2097,7 @@ exports[`Storyshots Core/Table With Checkboxes 1`] = `
                 data-highlight="false"
               >
                 <div
-                  class="sc-iFwKgL bfGZOr"
+                  class="sc-eXBvqI jHeTGy"
                   data-display="table-cell"
                 >
                   <div
@@ -2160,7 +2160,7 @@ exports[`Storyshots Core/Table With Checkboxes 1`] = `
                 data-highlight="false"
               >
                 <div
-                  class="sc-iFwKgL bfGZOr"
+                  class="sc-eXBvqI jHeTGy"
                   data-display="table-cell"
                 >
                   <div
@@ -2223,7 +2223,7 @@ exports[`Storyshots Core/Table With Checkboxes 1`] = `
                 data-highlight="false"
               >
                 <div
-                  class="sc-iFwKgL bfGZOr"
+                  class="sc-eXBvqI jHeTGy"
                   data-display="table-cell"
                 >
                   <div
@@ -2278,7 +2278,7 @@ exports[`Storyshots Core/Table With Checkboxes 1`] = `
                 data-highlight="false"
               >
                 <div
-                  class="sc-iFwKgL bfGZOr"
+                  class="sc-eXBvqI jHeTGy"
                   data-display="table-cell"
                 >
                   <div
@@ -2333,7 +2333,7 @@ exports[`Storyshots Core/Table With Checkboxes 1`] = `
                 data-highlight="false"
               >
                 <div
-                  class="sc-iFwKgL bfGZOr"
+                  class="sc-eXBvqI jHeTGy"
                   data-display="table-cell"
                 >
                   <div
@@ -2388,7 +2388,7 @@ exports[`Storyshots Core/Table With Checkboxes 1`] = `
                 data-highlight="false"
               >
                 <div
-                  class="sc-iFwKgL bfGZOr"
+                  class="sc-eXBvqI jHeTGy"
                   data-display="table-cell"
                 >
                   <div
@@ -2449,19 +2449,19 @@ exports[`Storyshots Core/Table With Checkboxes 1`] = `
 exports[`Storyshots Core/Table With Conditional Row Classes 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
-      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-kngDgl iKIurY kdKlCZ"
+      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-afnQL iKIurY eFWjlE"
     >
       <div
         class="sc-gKXOVf ckXSHX sc-iBkjds gNjzDq sc-hHLeRK eTSHtc"
       >
         <div
-          class="sc-iqGgem lbaJJA"
+          class="sc-iFwKgL cqyvps"
         >
           <div
-            class="sc-eVQfli lbmlHZ sc-dkSuNL bzbeQN"
+            class="sc-iqGgem lyCqM sc-cwpsFg cwqlwQ"
           >
             <div
               data-display="table-head"
@@ -2952,19 +2952,19 @@ exports[`Storyshots Core/Table With Conditional Row Classes 1`] = `
 exports[`Storyshots Core/Table With Custom Columns 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
-      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-kngDgl iKIurY kdKlCZ"
+      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-afnQL iKIurY eFWjlE"
     >
       <div
         class="sc-gKXOVf ckXSHX sc-iBkjds gNjzDq sc-hHLeRK eTSHtc"
       >
         <div
-          class="sc-iqGgem lbaJJA"
+          class="sc-iFwKgL cqyvps"
         >
           <div
-            class="sc-eVQfli lbmlHZ sc-dkSuNL htuKgJ"
+            class="sc-iqGgem lyCqM sc-cwpsFg bNFRXc"
           >
             <div
               data-display="table-head"
@@ -3448,13 +3448,13 @@ exports[`Storyshots Core/Table With Custom Columns 1`] = `
         </div>
       </div>
       <div
-        class="sc-cwpsFg iJEoTV"
+        class="sc-kngDgl JIDoa"
       >
         <div
-          class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-fXynhf ifKwFV sc-jIAOiI bpUFTZ"
+          class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-GVOUr bFSVuL sc-TRNrF kulTqM"
         >
           <button
-            class="StyledButton-sc-323bzc-0 iFDLDn sc-breuTD sc-bjUoiL Krizp dANmhT sc-dIouRR kAoSkv sc-TRNrF eEcMpL"
+            class="StyledButton-sc-323bzc-0 iFDLDn sc-breuTD sc-bjUoiL Krizp dANmhT sc-dIouRR kAoSkv sc-dwLEzm yrxfS"
             type="button"
           >
             <div
@@ -3465,7 +3465,7 @@ exports[`Storyshots Core/Table With Custom Columns 1`] = `
               >
                 <svg
                   aria-hidden="true"
-                  class="svg-inline--fa fa-gear sc-kTvvXX cGjQKm"
+                  class="svg-inline--fa fa-gear sc-eVQfli iSUjrE"
                   data-icon="gear"
                   data-prefix="fas"
                   focusable="false"
@@ -3506,10 +3506,10 @@ exports[`Storyshots Core/Table With Custom Columns 1`] = `
 exports[`Storyshots Core/Table With Fuzzy Pager 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
-      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-kngDgl iKIurY kdKlCZ"
+      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-afnQL iKIurY eFWjlE"
     >
       <div
         class="sc-gKXOVf ckXSHX sc-iBkjds gNjzDq sc-hHLeRK eTSHtc"
@@ -3584,10 +3584,10 @@ exports[`Storyshots Core/Table With Fuzzy Pager 1`] = `
           </div>
         </div>
         <div
-          class="sc-iqGgem lbaJJA"
+          class="sc-iFwKgL cqyvps"
         >
           <div
-            class="sc-eVQfli lbmlHZ sc-dkSuNL bzbeQN"
+            class="sc-iqGgem lyCqM sc-cwpsFg cwqlwQ"
           >
             <div
               data-display="table-head"
@@ -3883,19 +3883,19 @@ exports[`Storyshots Core/Table With Fuzzy Pager 1`] = `
 exports[`Storyshots Core/Table With Highlighted Rows 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
-      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-kngDgl iKIurY kdKlCZ"
+      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-afnQL iKIurY eFWjlE"
     >
       <div
         class="sc-gKXOVf ckXSHX sc-iBkjds gNjzDq sc-hHLeRK eTSHtc"
       >
         <div
-          class="sc-iqGgem lbaJJA"
+          class="sc-iFwKgL cqyvps"
         >
           <div
-            class="sc-eVQfli lbmlHZ sc-dkSuNL bzbeQN"
+            class="sc-iqGgem lyCqM sc-cwpsFg cwqlwQ"
           >
             <div
               data-display="table-head"
@@ -4386,10 +4386,10 @@ exports[`Storyshots Core/Table With Highlighted Rows 1`] = `
 exports[`Storyshots Core/Table With Pager 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
-      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-kngDgl iKIurY kdKlCZ"
+      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-afnQL iKIurY eFWjlE"
     >
       <div
         class="sc-gKXOVf ckXSHX sc-iBkjds gNjzDq sc-hHLeRK eTSHtc"
@@ -4464,10 +4464,10 @@ exports[`Storyshots Core/Table With Pager 1`] = `
           </div>
         </div>
         <div
-          class="sc-iqGgem lbaJJA"
+          class="sc-iFwKgL cqyvps"
         >
           <div
-            class="sc-eVQfli lbmlHZ sc-dkSuNL bzbeQN"
+            class="sc-iqGgem lyCqM sc-cwpsFg cwqlwQ"
           >
             <div
               data-display="table-head"
@@ -4763,19 +4763,19 @@ exports[`Storyshots Core/Table With Pager 1`] = `
 exports[`Storyshots Core/Table With Prefix 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
-      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-kngDgl iKIurY kdKlCZ"
+      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-afnQL iKIurY eFWjlE"
     >
       <div
         class="sc-gKXOVf ckXSHX sc-iBkjds gNjzDq sc-hHLeRK eTSHtc"
       >
         <div
-          class="sc-iqGgem lbaJJA"
+          class="sc-iFwKgL cqyvps"
         >
           <div
-            class="sc-eVQfli lbmlHZ sc-dkSuNL bzbeQN"
+            class="sc-iqGgem lyCqM sc-cwpsFg cwqlwQ"
           >
             <div
               data-display="table-head"
@@ -5288,19 +5288,19 @@ exports[`Storyshots Core/Table With Prefix 1`] = `
 exports[`Storyshots Core/Table With Row Click 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
-      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-kngDgl iKIurY kdKlCZ"
+      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-afnQL iKIurY eFWjlE"
     >
       <div
         class="sc-gKXOVf ckXSHX sc-iBkjds gNjzDq sc-hHLeRK eTSHtc"
       >
         <div
-          class="sc-iqGgem lbaJJA"
+          class="sc-iFwKgL cqyvps"
         >
           <div
-            class="sc-eVQfli cdbYRb sc-dkSuNL bzbeQN"
+            class="sc-iqGgem ilPLQu sc-cwpsFg cwqlwQ"
           >
             <div
               data-display="table-head"

--- a/src/components/Tabs/__snapshots__/Tabs.stories.storyshot
+++ b/src/components/Tabs/__snapshots__/Tabs.stories.storyshot
@@ -3,10 +3,10 @@
 exports[`Storyshots Core/Tabs Compact 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hANpeK StyledTabs-sc-a4fwxl-2 eCNyif sc-gHLcSH bWgFzj sc-djUGQo kSyKMW"
+      class="StyledBox-sc-13pk1d4-0 hANpeK StyledTabs-sc-a4fwxl-2 eCNyif sc-KfMfS iviGgR sc-gHLcSH ihYMZv"
       role="tablist"
     >
       <div
@@ -134,10 +134,10 @@ exports[`Storyshots Core/Tabs Compact 1`] = `
 exports[`Storyshots Core/Tabs Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hANpeK StyledTabs-sc-a4fwxl-2 eCNyif sc-gHLcSH gDXdlK sc-djUGQo kSyKMW"
+      class="StyledBox-sc-13pk1d4-0 hANpeK StyledTabs-sc-a4fwxl-2 eCNyif sc-KfMfS hNILow sc-gHLcSH ihYMZv"
       role="tablist"
     >
       <div
@@ -214,10 +214,10 @@ exports[`Storyshots Core/Tabs Default 1`] = `
 exports[`Storyshots Core/Tabs With Long Titles 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hANpeK StyledTabs-sc-a4fwxl-2 eCNyif sc-gHLcSH gDXdlK sc-djUGQo kSyKMW"
+      class="StyledBox-sc-13pk1d4-0 hANpeK StyledTabs-sc-a4fwxl-2 eCNyif sc-KfMfS hNILow sc-gHLcSH ihYMZv"
       role="tablist"
     >
       <div

--- a/src/components/Tag/__snapshots__/Tag.stories.storyshot
+++ b/src/components/Tag/__snapshots__/Tag.stories.storyshot
@@ -3,17 +3,17 @@
 exports[`Storyshots Core/Tag Clickable 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
-      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY sc-eFWqGp gPSCbK"
+      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY sc-bWXABl jdyMoq"
     >
       <button
         class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR kAoSkv"
         type="button"
       >
         <div
-          class="sc-gKXOVf QRSBg sc-iBkjds eecmTK sc-hHLeRK sc-grREDI iKIurY coRGQK"
+          class="sc-gKXOVf QRSBg sc-iBkjds eecmTK sc-hHLeRK sc-HzFiz iKIurY fECpVO"
         >
           <div
             class="sc-ivTmOn qStAn sc-cxabCf ecsbJB"
@@ -35,13 +35,13 @@ exports[`Storyshots Core/Tag Clickable 1`] = `
 exports[`Storyshots Core/Tag Closable 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
-      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY sc-eFWqGp gPSCbK"
+      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY sc-bWXABl jdyMoq"
     >
       <div
-        class="sc-gKXOVf QRSBg sc-iBkjds eecmTK sc-hHLeRK sc-grREDI iKIurY coRGQK"
+        class="sc-gKXOVf QRSBg sc-iBkjds eecmTK sc-hHLeRK sc-HzFiz iKIurY fECpVO"
       >
         <div
           class="sc-ivTmOn qStAn sc-cxabCf ecsbJB"
@@ -55,7 +55,7 @@ exports[`Storyshots Core/Tag Closable 1`] = `
         </div>
       </div>
       <button
-        class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR bXRmqK sc-bWXABl cmijpj"
+        class="StyledButton-sc-323bzc-0 eXTxNK sc-breuTD sc-bjUoiL Krizp gOoGXe sc-dIouRR bXRmqK sc-grREDI bSUine"
         type="button"
       >
         <svg
@@ -82,13 +82,13 @@ exports[`Storyshots Core/Tag Closable 1`] = `
 exports[`Storyshots Core/Tag Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
-      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY sc-eFWqGp gPSCbK"
+      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY sc-bWXABl jdyMoq"
     >
       <div
-        class="sc-gKXOVf QRSBg sc-iBkjds eecmTK sc-hHLeRK sc-grREDI iKIurY coRGQK"
+        class="sc-gKXOVf QRSBg sc-iBkjds eecmTK sc-hHLeRK sc-HzFiz iKIurY fECpVO"
       >
         <div
           class="sc-ivTmOn qStAn sc-cxabCf ecsbJB"
@@ -109,13 +109,13 @@ exports[`Storyshots Core/Tag Default 1`] = `
 exports[`Storyshots Core/Tag Empty 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
-      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY sc-eFWqGp gPSCbK"
+      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY sc-bWXABl jdyMoq"
     >
       <div
-        class="sc-gKXOVf QRSBg sc-iBkjds eecmTK sc-hHLeRK sc-grREDI iKIurY coRGQK"
+        class="sc-gKXOVf QRSBg sc-iBkjds eecmTK sc-hHLeRK sc-HzFiz iKIurY fECpVO"
       >
         <div
           class="sc-ivTmOn WZUmp sc-cxabCf ecsbJB"
@@ -131,13 +131,13 @@ exports[`Storyshots Core/Tag Empty 1`] = `
 exports[`Storyshots Core/Tag Multiple Values 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
-      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY sc-eFWqGp gPSCbK"
+      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY sc-bWXABl jdyMoq"
     >
       <div
-        class="sc-gKXOVf QRSBg sc-iBkjds eecmTK sc-hHLeRK sc-grREDI iKIurY coRGQK"
+        class="sc-gKXOVf QRSBg sc-iBkjds eecmTK sc-hHLeRK sc-HzFiz iKIurY fECpVO"
       >
         <div
           class="sc-ivTmOn qStAn sc-cxabCf ecsbJB"
@@ -173,13 +173,13 @@ exports[`Storyshots Core/Tag Multiple Values 1`] = `
 exports[`Storyshots Core/Tag Only Name 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
-      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY sc-eFWqGp gPSCbK"
+      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY sc-bWXABl jdyMoq"
     >
       <div
-        class="sc-gKXOVf QRSBg sc-iBkjds eecmTK sc-hHLeRK sc-grREDI iKIurY coRGQK"
+        class="sc-gKXOVf QRSBg sc-iBkjds eecmTK sc-hHLeRK sc-HzFiz iKIurY fECpVO"
       >
         <div
           class="sc-ivTmOn fSbxau sc-cxabCf ecsbJB"
@@ -195,13 +195,13 @@ exports[`Storyshots Core/Tag Only Name 1`] = `
 exports[`Storyshots Core/Tag Only Value 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
-      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY sc-eFWqGp gPSCbK"
+      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY sc-bWXABl jdyMoq"
     >
       <div
-        class="sc-gKXOVf QRSBg sc-iBkjds eecmTK sc-hHLeRK sc-grREDI iKIurY coRGQK"
+        class="sc-gKXOVf QRSBg sc-iBkjds eecmTK sc-hHLeRK sc-HzFiz iKIurY fECpVO"
       >
         <div
           class="sc-ivTmOn fSbxau sc-cxabCf ecsbJB"
@@ -217,13 +217,13 @@ exports[`Storyshots Core/Tag Only Value 1`] = `
 exports[`Storyshots Core/Tag Overflow 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
-      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY sc-eFWqGp gPSCbK"
+      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK iKIurY sc-bWXABl jdyMoq"
     >
       <div
-        class="sc-gKXOVf QRSBg sc-iBkjds eecmTK sc-hHLeRK sc-grREDI iKIurY coRGQK"
+        class="sc-gKXOVf QRSBg sc-iBkjds eecmTK sc-hHLeRK sc-HzFiz iKIurY fECpVO"
       >
         <div
           class="sc-ivTmOn qStAn sc-cxabCf ecsbJB"

--- a/src/components/TagManagementModal/__snapshots__/TagManagementModal.stories.storyshot
+++ b/src/components/TagManagementModal/__snapshots__/TagManagementModal.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/TagManagementModal Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <button
       class="StyledButton-sc-323bzc-0 gvCdQt sc-breuTD sc-ksZaOG Krizp jFzPEx sc-dIouRR kAoSkv"

--- a/src/components/TagManagementModal/index.tsx
+++ b/src/components/TagManagementModal/index.tsx
@@ -411,7 +411,7 @@ export const TagManagementModal = <T extends TaggedResource>({
 	return (
 		<Modal
 			width={1000}
-			titleElement={
+			title={
 				<div>
 					<Heading.h3 mt={0} mb={10}>
 						{items.length > 1 && <span>{t('labels.shared')} </span>}

--- a/src/components/Terminal/__snapshots__/Terminal.stories.storyshot
+++ b/src/components/Terminal/__snapshots__/Terminal.stories.storyshot
@@ -3,16 +3,16 @@
 exports[`Storyshots Core/Terminal Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       style="height: 500px;"
     >
       <div
-        class="sc-gKXOVf ckXSHX sc-iBkjds eRknfj sc-hHLeRK sc-fxvKuh iKIurY jsBVvj"
+        class="sc-gKXOVf ckXSHX sc-iBkjds eRknfj sc-hHLeRK sc-gJwTLC iKIurY bpbARM"
       >
         <div
-          class="sc-gKXOVf ckXSHX sc-iBkjds ipRjux sc-hHLeRK sc-iWajrY eTSHtc cPschW"
+          class="sc-gKXOVf ckXSHX sc-iBkjds ipRjux sc-hHLeRK sc-fxvKuh eTSHtc fGztam"
         />
       </div>
     </div>
@@ -23,16 +23,16 @@ exports[`Storyshots Core/Terminal Default 1`] = `
 exports[`Storyshots Core/Terminal Noninteractive Terminal 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       style="height: 500px;"
     >
       <div
-        class="sc-gKXOVf ckXSHX sc-iBkjds eRknfj sc-hHLeRK sc-fxvKuh iKIurY jsBVvj"
+        class="sc-gKXOVf ckXSHX sc-iBkjds eRknfj sc-hHLeRK sc-gJwTLC iKIurY bpbARM"
       >
         <div
-          class="sc-gKXOVf ckXSHX sc-iBkjds ipRjux sc-hHLeRK sc-iWajrY eTSHtc cPschW"
+          class="sc-gKXOVf ckXSHX sc-iBkjds ipRjux sc-hHLeRK sc-fxvKuh eTSHtc fGztam"
         />
       </div>
     </div>

--- a/src/components/Textarea/__snapshots__/Textarea.stories.storyshot
+++ b/src/components/Textarea/__snapshots__/Textarea.stories.storyshot
@@ -3,10 +3,10 @@
 exports[`Storyshots Core/Textarea Auto Rows 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <textarea
-      class="StyledTextArea-sc-17i3mwp-0 ffIuvj sc-hiMGwR jNGenP sc-ehmTmK eXkmsq"
+      class="StyledTextArea-sc-17i3mwp-0 ffIuvj sc-olbas hajENe sc-hiMGwR dZpBIm"
     />
   </div>
 </div>
@@ -15,10 +15,10 @@ exports[`Storyshots Core/Textarea Auto Rows 1`] = `
 exports[`Storyshots Core/Textarea Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <textarea
-      class="StyledTextArea-sc-17i3mwp-0 ffIuvj sc-hiMGwR jNGenP sc-ehmTmK eXkmsq"
+      class="StyledTextArea-sc-17i3mwp-0 ffIuvj sc-olbas hajENe sc-hiMGwR dZpBIm"
     />
   </div>
 </div>
@@ -27,10 +27,10 @@ exports[`Storyshots Core/Textarea Default 1`] = `
 exports[`Storyshots Core/Textarea Disabled 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <textarea
-      class="StyledTextArea-sc-17i3mwp-0 ePDaUN sc-hiMGwR bVMfkQ sc-ehmTmK eXkmsq"
+      class="StyledTextArea-sc-17i3mwp-0 ePDaUN sc-olbas jyLhGp sc-hiMGwR dZpBIm"
       disabled=""
     />
   </div>
@@ -40,10 +40,10 @@ exports[`Storyshots Core/Textarea Disabled 1`] = `
 exports[`Storyshots Core/Textarea Min Max Rows 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <textarea
-      class="StyledTextArea-sc-17i3mwp-0 ffIuvj sc-hiMGwR jNGenP sc-ehmTmK eXkmsq"
+      class="StyledTextArea-sc-17i3mwp-0 ffIuvj sc-olbas hajENe sc-hiMGwR dZpBIm"
       rows="4"
     />
   </div>
@@ -53,10 +53,10 @@ exports[`Storyshots Core/Textarea Min Max Rows 1`] = `
 exports[`Storyshots Core/Textarea Monospace 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <textarea
-      class="StyledTextArea-sc-17i3mwp-0 ffIuvj sc-hiMGwR cQCONy sc-ehmTmK eXkmsq"
+      class="StyledTextArea-sc-17i3mwp-0 ffIuvj sc-olbas weSOz sc-hiMGwR dZpBIm"
       placeholder="Type something..."
     />
   </div>
@@ -66,10 +66,10 @@ exports[`Storyshots Core/Textarea Monospace 1`] = `
 exports[`Storyshots Core/Textarea Read Only 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <textarea
-      class="StyledTextArea-sc-17i3mwp-0 ffIuvj sc-hiMGwR jNGenP sc-ehmTmK eXkmsq"
+      class="StyledTextArea-sc-17i3mwp-0 ffIuvj sc-olbas hajENe sc-hiMGwR dZpBIm"
       readonly=""
     />
   </div>
@@ -79,10 +79,10 @@ exports[`Storyshots Core/Textarea Read Only 1`] = `
 exports[`Storyshots Core/Textarea With Placeholder 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <textarea
-      class="StyledTextArea-sc-17i3mwp-0 ffIuvj sc-hiMGwR jNGenP sc-ehmTmK eXkmsq"
+      class="StyledTextArea-sc-17i3mwp-0 ffIuvj sc-olbas hajENe sc-hiMGwR dZpBIm"
       placeholder="Type something..."
     />
   </div>

--- a/src/components/Txt/__snapshots__/Txt.stories.storyshot
+++ b/src/components/Txt/__snapshots__/Txt.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core/Txt Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF"
@@ -17,7 +17,7 @@ exports[`Storyshots Core/Txt Default 1`] = `
 exports[`Storyshots Core/Txt In Color 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="sc-ivTmOn dNJphr sc-cxabCf lesVkD"
@@ -31,7 +31,7 @@ exports[`Storyshots Core/Txt In Color 1`] = `
 exports[`Storyshots Core/Txt Span Component 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <span
       class="sc-ivTmOn qStAn sc-llJcti hQwFFc"
@@ -45,7 +45,7 @@ exports[`Storyshots Core/Txt Span Component 1`] = `
 exports[`Storyshots Core/Txt Styled 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="sc-ivTmOn jMeriV sc-cxabCf hcBkUF"

--- a/src/extra/AutoUI/__snapshots__/AutoUI.stories.storyshot
+++ b/src/extra/AutoUI/__snapshots__/AutoUI.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Extra/AutoUI Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <h5
       class="sc-ciZhAO iJFBxw sc-cTQhss dOQXsM"
@@ -20,10 +20,10 @@ exports[`Storyshots Extra/AutoUI Default 1`] = `
       class="sc-gKXOVf ckXSHX sc-iBkjds ipRjux sc-hHLeRK eTSHtc"
     >
       <div
-        class="sc-gKXOVf ckXSHX sc-iBkjds ipRjux sc-hHLeRK sc-jmNpzm iKIurY iITdfN sc-caXVBt efHDjS"
+        class="sc-gKXOVf ckXSHX sc-iBkjds ipRjux sc-hHLeRK sc-lkwKjF iKIurY khcTuI sc-hsOonA fPwlCE"
       >
         <div
-          class="sc-hsOonA fInNYD"
+          class="sc-dUWWNf iOmmoa"
         >
           <div
             class="sc-gKXOVf QRSBg sc-iBkjds eRknfj sc-hHLeRK eTSHtc"
@@ -32,20 +32,20 @@ exports[`Storyshots Extra/AutoUI Default 1`] = `
               class="sc-gKXOVf QRSBg sc-iBkjds diGonb"
             >
               <div
-                class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-fSUSjI klWzuj bSMjiJ"
+                class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-cuqtlR klWzuj eXTlRI"
               >
                 <div
                   class="sc-gKXOVf klumOZ sc-iBkjds hNqnWQ"
                   order="-1,-1,-1,0"
                 >
                   <div
-                    class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-yeoIj gpSmxc"
+                    class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-kYWVYA ikOJWL"
                   >
                     <div
                       class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK eccixI"
                     >
                       <div
-                        class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-kYWVYA jBjBTq"
+                        class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hAsxaJ cmyIYE"
                       >
                         <div
                           class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-kgUAyh iKIurY kCkpfb sc-hTtwUo eWqTFt"
@@ -101,10 +101,10 @@ exports[`Storyshots Extra/AutoUI Default 1`] = `
                         </div>
                       </button>
                       <div
-                        class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-fXynhf ifKwFV sc-jIAOiI dwhOCm"
+                        class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-GVOUr bFSVuL sc-TRNrF kXUaZr"
                       >
                         <button
-                          class="StyledButton-sc-323bzc-0 eBMyPP sc-breuTD sc-hAZoDl Krizp eagAYV sc-dIouRR kAoSkv sc-TRNrF eEcMpL"
+                          class="StyledButton-sc-323bzc-0 eBMyPP sc-breuTD sc-hAZoDl Krizp eagAYV sc-dIouRR kAoSkv sc-dwLEzm yrxfS"
                           type="button"
                         >
                           <div
@@ -161,16 +161,16 @@ exports[`Storyshots Extra/AutoUI Default 1`] = `
               </div>
             </div>
             <div
-              class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-kngDgl iKIurY kdKlCZ"
+              class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-afnQL iKIurY eFWjlE"
             >
               <div
                 class="sc-gKXOVf ckXSHX sc-iBkjds gNjzDq sc-hHLeRK eTSHtc"
               >
                 <div
-                  class="sc-iqGgem lbaJJA"
+                  class="sc-iFwKgL cqyvps"
                 >
                   <div
-                    class="sc-eVQfli lbmlHZ sc-dkSuNL htuKgJ"
+                    class="sc-iqGgem lyCqM sc-cwpsFg bNFRXc"
                   >
                     <div
                       data-display="table-head"
@@ -608,13 +608,13 @@ exports[`Storyshots Extra/AutoUI Default 1`] = `
                 </div>
               </div>
               <div
-                class="sc-cwpsFg dJofXK"
+                class="sc-kngDgl QwFJh"
               >
                 <div
-                  class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-fXynhf ifKwFV sc-jIAOiI bpUFTZ"
+                  class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-GVOUr bFSVuL sc-TRNrF kulTqM"
                 >
                   <button
-                    class="StyledButton-sc-323bzc-0 iFDLDn sc-breuTD sc-bjUoiL Krizp dANmhT sc-dIouRR kAoSkv sc-TRNrF eEcMpL"
+                    class="StyledButton-sc-323bzc-0 iFDLDn sc-breuTD sc-bjUoiL Krizp dANmhT sc-dIouRR kAoSkv sc-dwLEzm yrxfS"
                     type="button"
                   >
                     <div
@@ -625,7 +625,7 @@ exports[`Storyshots Extra/AutoUI Default 1`] = `
                       >
                         <svg
                           aria-hidden="true"
-                          class="svg-inline--fa fa-gear sc-kTvvXX cGjQKm"
+                          class="svg-inline--fa fa-gear sc-eVQfli iSUjrE"
                           data-icon="gear"
                           data-prefix="fas"
                           focusable="false"

--- a/src/extra/Markdown/__snapshots__/Markdown.stories.storyshot
+++ b/src/extra/Markdown/__snapshots__/Markdown.stories.storyshot
@@ -3,19 +3,19 @@
 exports[`Storyshots Extra/Markdown Customized 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
-      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-kngDgl iKIurY kdKlCZ"
+      class="sc-gKXOVf QRSBg sc-iBkjds ipRjux sc-hHLeRK sc-afnQL iKIurY eFWjlE"
     >
       <div
         class="sc-gKXOVf ckXSHX sc-iBkjds gNjzDq sc-hHLeRK eTSHtc"
       >
         <div
-          class="sc-iqGgem lbaJJA"
+          class="sc-iFwKgL cqyvps"
         >
           <div
-            class="sc-eVQfli lbmlHZ sc-dkSuNL bzbeQN"
+            class="sc-iqGgem lyCqM sc-cwpsFg cwqlwQ"
           >
             <div
               data-display="table-head"
@@ -73,7 +73,7 @@ exports[`Storyshots Extra/Markdown Customized 1`] = `
                       class="sc-gKXOVf ckXSHX sc-iBkjds eYvdLm sc-hHLeRK dUykMD"
                     >
                       <div
-                        class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-chKnlQ jMOuPF"
+                        class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-kIZKsT geXume"
                       >
                         <div>
                           <h1
@@ -106,7 +106,7 @@ exports[`Storyshots Extra/Markdown Customized 1`] = `
                       class="sc-gKXOVf ckXSHX sc-iBkjds eYvdLm sc-hHLeRK dUykMD"
                     >
                       <div
-                        class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-chKnlQ jMOuPF"
+                        class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-kIZKsT geXume"
                       >
                         <div>
                           A title
@@ -156,7 +156,7 @@ exports[`Storyshots Extra/Markdown Customized 1`] = `
                       class="sc-gKXOVf ckXSHX sc-iBkjds eYvdLm sc-hHLeRK dUykMD"
                     >
                       <div
-                        class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-chKnlQ jMOuPF"
+                        class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-kIZKsT geXume"
                       >
                         <div>
                           <h1
@@ -189,7 +189,7 @@ exports[`Storyshots Extra/Markdown Customized 1`] = `
                       class="sc-gKXOVf ckXSHX sc-iBkjds eYvdLm sc-hHLeRK dUykMD"
                     >
                       <div
-                        class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-chKnlQ jMOuPF"
+                        class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-kIZKsT geXume"
                       >
                         <div>
                           A title
@@ -233,7 +233,7 @@ exports[`Storyshots Extra/Markdown Customized 1`] = `
                       class="sc-gKXOVf ckXSHX sc-iBkjds eYvdLm sc-hHLeRK dUykMD"
                     >
                       <div
-                        class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-chKnlQ jMOuPF"
+                        class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-kIZKsT geXume"
                       >
                         <div>
                           <h1
@@ -266,7 +266,7 @@ exports[`Storyshots Extra/Markdown Customized 1`] = `
                       class="sc-gKXOVf ckXSHX sc-iBkjds eYvdLm sc-hHLeRK dUykMD"
                     >
                       <div
-                        class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-chKnlQ jMOuPF"
+                        class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-kIZKsT geXume"
                       >
                         <div>
                           <h1
@@ -293,10 +293,10 @@ exports[`Storyshots Extra/Markdown Customized 1`] = `
 exports[`Storyshots Extra/Markdown Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
-      class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-chKnlQ jMOuPF"
+      class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-kIZKsT geXume"
     >
       <div>
         <h1
@@ -304,7 +304,7 @@ exports[`Storyshots Extra/Markdown Default 1`] = `
           id="user-content-markdown"
         >
           <a
-            class="sc-eKBdFk eDgBSD sc-bUbCnL aUvHI heading-anchor-link"
+            class="sc-hlnMnd cpbYOv sc-eKBdFk cTggPd heading-anchor-link"
             color="primary.main"
             href="#markdown"
           >
@@ -332,7 +332,7 @@ exports[`Storyshots Extra/Markdown Default 1`] = `
           id="user-content-headers"
         >
           <a
-            class="sc-eKBdFk eDgBSD sc-bUbCnL aUvHI heading-anchor-link"
+            class="sc-hlnMnd cpbYOv sc-eKBdFk cTggPd heading-anchor-link"
             color="primary.main"
             href="#headers"
           >
@@ -349,7 +349,7 @@ exports[`Storyshots Extra/Markdown Default 1`] = `
           id="user-content-this-is-an-h1-tag"
         >
           <a
-            class="sc-eKBdFk eDgBSD sc-bUbCnL aUvHI heading-anchor-link"
+            class="sc-hlnMnd cpbYOv sc-eKBdFk cTggPd heading-anchor-link"
             color="primary.main"
             href="#this-is-an-h1-tag"
           >
@@ -370,7 +370,7 @@ exports[`Storyshots Extra/Markdown Default 1`] = `
           id="user-content-this-is-an-h2-tag"
         >
           <a
-            class="sc-eKBdFk eDgBSD sc-bUbCnL aUvHI heading-anchor-link"
+            class="sc-hlnMnd cpbYOv sc-eKBdFk cTggPd heading-anchor-link"
             color="primary.main"
             href="#this-is-an-h2-tag"
           >
@@ -391,7 +391,7 @@ exports[`Storyshots Extra/Markdown Default 1`] = `
           id="user-content-this-is-an-h6-tag"
         >
           <a
-            class="sc-eKBdFk eDgBSD sc-bUbCnL aUvHI heading-anchor-link"
+            class="sc-hlnMnd cpbYOv sc-eKBdFk cTggPd heading-anchor-link"
             color="primary.main"
             href="#this-is-an-h6-tag"
           >
@@ -412,7 +412,7 @@ exports[`Storyshots Extra/Markdown Default 1`] = `
           id="user-content-emphasis"
         >
           <a
-            class="sc-eKBdFk eDgBSD sc-bUbCnL aUvHI heading-anchor-link"
+            class="sc-hlnMnd cpbYOv sc-eKBdFk cTggPd heading-anchor-link"
             color="primary.main"
             href="#emphasis"
           >
@@ -472,7 +472,7 @@ exports[`Storyshots Extra/Markdown Default 1`] = `
           id="user-content-lists"
         >
           <a
-            class="sc-eKBdFk eDgBSD sc-bUbCnL aUvHI heading-anchor-link"
+            class="sc-hlnMnd cpbYOv sc-eKBdFk cTggPd heading-anchor-link"
             color="primary.main"
             href="#lists"
           >
@@ -489,7 +489,7 @@ exports[`Storyshots Extra/Markdown Default 1`] = `
           id="user-content-unordered"
         >
           <a
-            class="sc-eKBdFk eDgBSD sc-bUbCnL aUvHI heading-anchor-link"
+            class="sc-hlnMnd cpbYOv sc-eKBdFk cTggPd heading-anchor-link"
             color="primary.main"
             href="#unordered"
           >
@@ -539,7 +539,7 @@ exports[`Storyshots Extra/Markdown Default 1`] = `
           id="user-content-ordered"
         >
           <a
-            class="sc-eKBdFk eDgBSD sc-bUbCnL aUvHI heading-anchor-link"
+            class="sc-hlnMnd cpbYOv sc-eKBdFk cTggPd heading-anchor-link"
             color="primary.main"
             href="#ordered"
           >
@@ -594,7 +594,7 @@ exports[`Storyshots Extra/Markdown Default 1`] = `
           id="user-content-images"
         >
           <a
-            class="sc-eKBdFk eDgBSD sc-bUbCnL aUvHI heading-anchor-link"
+            class="sc-hlnMnd cpbYOv sc-eKBdFk cTggPd heading-anchor-link"
             color="primary.main"
             href="#images"
           >
@@ -621,7 +621,7 @@ exports[`Storyshots Extra/Markdown Default 1`] = `
           id="user-content-links"
         >
           <a
-            class="sc-eKBdFk eDgBSD sc-bUbCnL aUvHI heading-anchor-link"
+            class="sc-hlnMnd cpbYOv sc-eKBdFk cTggPd heading-anchor-link"
             color="primary.main"
             href="#links"
           >
@@ -637,7 +637,7 @@ exports[`Storyshots Extra/Markdown Default 1`] = `
           class="sc-ivTmOn dNJphr sc-iIPllB eSdPCy"
         >
           <a
-            class="sc-eKBdFk eDgBSD sc-bUbCnL aUvHI"
+            class="sc-hlnMnd cpbYOv sc-eKBdFk cTggPd"
             color="primary.main"
             href="http://github.com"
           >
@@ -651,7 +651,7 @@ exports[`Storyshots Extra/Markdown Default 1`] = `
           class="sc-ivTmOn dNJphr sc-iIPllB eSdPCy"
         >
           <a
-            class="sc-eKBdFk eDgBSD sc-bUbCnL aUvHI"
+            class="sc-hlnMnd cpbYOv sc-eKBdFk cTggPd"
             color="primary.main"
             href="http://github.com"
           >
@@ -665,7 +665,7 @@ exports[`Storyshots Extra/Markdown Default 1`] = `
           id="user-content-blockquotes"
         >
           <a
-            class="sc-eKBdFk eDgBSD sc-bUbCnL aUvHI heading-anchor-link"
+            class="sc-hlnMnd cpbYOv sc-eKBdFk cTggPd heading-anchor-link"
             color="primary.main"
             href="#blockquotes"
           >
@@ -702,7 +702,7 @@ exports[`Storyshots Extra/Markdown Default 1`] = `
           id="user-content-inline-code"
         >
           <a
-            class="sc-eKBdFk eDgBSD sc-bUbCnL aUvHI heading-anchor-link"
+            class="sc-hlnMnd cpbYOv sc-eKBdFk cTggPd heading-anchor-link"
             color="primary.main"
             href="#inline-code"
           >
@@ -733,7 +733,7 @@ exports[`Storyshots Extra/Markdown Default 1`] = `
           id="user-content-code-blocks"
         >
           <a
-            class="sc-eKBdFk eDgBSD sc-bUbCnL aUvHI heading-anchor-link"
+            class="sc-hlnMnd cpbYOv sc-eKBdFk cTggPd heading-anchor-link"
             color="primary.main"
             href="#code-blocks"
           >
@@ -840,7 +840,7 @@ const foo = () =&gt; {
           id="user-content-task-lists"
         >
           <a
-            class="sc-eKBdFk eDgBSD sc-bUbCnL aUvHI heading-anchor-link"
+            class="sc-hlnMnd cpbYOv sc-eKBdFk cTggPd heading-anchor-link"
             color="primary.main"
             href="#task-lists"
           >
@@ -900,7 +900,7 @@ const foo = () =&gt; {
           id="user-content-tables"
         >
           <a
-            class="sc-eKBdFk eDgBSD sc-bUbCnL aUvHI heading-anchor-link"
+            class="sc-hlnMnd cpbYOv sc-eKBdFk cTggPd heading-anchor-link"
             color="primary.main"
             href="#tables"
           >
@@ -966,7 +966,7 @@ const foo = () =&gt; {
           id="user-content-strikethrough"
         >
           <a
-            class="sc-eKBdFk eDgBSD sc-bUbCnL aUvHI heading-anchor-link"
+            class="sc-hlnMnd cpbYOv sc-eKBdFk cTggPd heading-anchor-link"
             color="primary.main"
             href="#strikethrough"
           >
@@ -1003,7 +1003,7 @@ const foo = () =&gt; {
           id="user-content-inline-html"
         >
           <a
-            class="sc-eKBdFk eDgBSD sc-bUbCnL aUvHI heading-anchor-link"
+            class="sc-hlnMnd cpbYOv sc-eKBdFk cTggPd heading-anchor-link"
             color="primary.main"
             href="#inline-html"
           >
@@ -1045,7 +1045,7 @@ const foo = () =&gt; {
           
 
           <a
-            class="sc-eKBdFk eDgBSD sc-bUbCnL aUvHI"
+            class="sc-hlnMnd cpbYOv sc-eKBdFk cTggPd"
             color="primary.main"
             href="http://github.com/"
           >
@@ -1059,7 +1059,7 @@ const foo = () =&gt; {
           id="user-content-keyboard-keys"
         >
           <a
-            class="sc-eKBdFk eDgBSD sc-bUbCnL aUvHI heading-anchor-link"
+            class="sc-hlnMnd cpbYOv sc-eKBdFk cTggPd heading-anchor-link"
             color="primary.main"
             href="#keyboard-keys"
           >
@@ -1099,10 +1099,10 @@ const foo = () =&gt; {
 exports[`Storyshots Extra/Markdown With Decorators 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
-      class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-chKnlQ jMOuPF"
+      class="sc-ivTmOn dNJphr sc-cxabCf hcBkUF sc-kIZKsT geXume"
     >
       <div>
         <p
@@ -1118,7 +1118,7 @@ exports[`Storyshots Extra/Markdown With Decorators 1`] = `
              foo @bad@bad 
           </span>
           <a
-            class="sc-eKBdFk eDgBSD sc-bUbCnL aUvHI"
+            class="sc-hlnMnd cpbYOv sc-eKBdFk cTggPd"
             color="primary.main"
             href="https://github.com"
           >

--- a/src/extra/MarkdownEditor/__snapshots__/MarkdownEditor.stories.storyshot
+++ b/src/extra/MarkdownEditor/__snapshots__/MarkdownEditor.stories.storyshot
@@ -3,10 +3,10 @@
 exports[`Storyshots Extra/MarkdownEditor Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
-      class="sc-ckCjom cYmeNc"
+      class="sc-geuGuN iFFFfs"
       id="simplemde-editor-2-wrapper"
     >
       <textarea

--- a/src/extra/Mermaid/__snapshots__/Mermaid.stories.storyshot
+++ b/src/extra/Mermaid/__snapshots__/Mermaid.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Extra/Mermaid Default 1`] = `
 <div>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-fWIMVQ jMbSIt"
+    class="StyledGrommet-sc-19lkkz7-0 jbmlFX sc-bPyhqo dWxQcS"
   >
     <div
       class="sc-gKXOVf QRSBg sc-iBkjds ipRjux"

--- a/src/internal/SimpleConfirmationModal.tsx
+++ b/src/internal/SimpleConfirmationModal.tsx
@@ -17,7 +17,7 @@ export const SimpleConfirmationModal = (
 	const { t } = useTranslation();
 	return (
 		<Modal
-			titleElement={props.title || t('actions_messages.confirmation')}
+			title={props.title || t('actions_messages.confirmation')}
 			cancel={() => props.onClose(false)}
 			done={() => props.onClose(true)}
 			primaryButtonProps={props.primaryButtonProps}

--- a/src/unstable-temp/DownloadImageModal/DownloadImageModal.tsx
+++ b/src/unstable-temp/DownloadImageModal/DownloadImageModal.tsx
@@ -219,7 +219,7 @@ export const UnstableTempDownloadImageModal = ({
 	return (
 		<FooterlessModal
 			width={1400}
-			titleElement={
+			title={
 				// fixed height prevents jumping due to the logo size changing.
 				<Flex style={{ height: 32 }} alignItems="center">
 					<DeviceLogo small={false} src={logoSrc} title={defaultDisplayName} />


### PR DESCRIPTION
Drop Modal component's titleElement and titleDetails properties in favor of the `title` property and add `JSX.Element` as an acceptable type for `title`

Resolves: #452 
Change-type: major
Signed-off-by: Matthew Yarmolinsky <matthew-timothy@balena.io>

---

##### Contributor checklist

<!-- For completed items, change [ ] to [x].  -->

- [ ] I have regenerated jest snapshots for any affected components with `npm run generate-snapshots`

##### Reviewer Guidelines

- When submitting a review, please pick:
  - '_Approve_' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '_Request Changes_' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '_Comment_' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)

---
