### PR TITLE
Add theme primary color main to Badge shades

### DIFF
--- a/src/components/Badge/index.tsx
+++ b/src/components/Badge/index.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import styled from 'styled-components';
+import theme from '../../theme';
 import asRendition from '../../asRendition';
 import { RenditionSystemProps, Theme } from '../../common-types';
 import { getLegibleTextColor } from '../../utils';
@@ -30,6 +31,7 @@ const shades = [
 	'#CAFECD',
 	'#D7E46C',
 	'#F7D8BA',
+	theme.colors.primary.main,
 ];
 
 const StyledBadge = styled(Txt.span)`
@@ -59,8 +61,8 @@ const BaseBadge = ({
 			px="12px"
 			fontSize={1}
 			bg={shadeHex}
-			{...otherProps}
 			color={getLegibleTextColor(shadeHex)}
+			{...otherProps}
 		>
 			{children}
 		</StyledBadge>


### PR DESCRIPTION
Add theme primary color main to Badge shades

Change-type: minor
Signed-off-by: Matthew Yarmolinsky <matthew-timothy@balena.io>

---

##### Contributor checklist

<!-- For completed items, change [ ] to [x].  -->

- [ ] I have regenerated jest snapshots for any affected components with `npm run generate-snapshots`

##### Reviewer Guidelines

- When submitting a review, please pick:
  - '_Approve_' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '_Request Changes_' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '_Comment_' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)

---
