### PR TITLE
Make MenuItem badge small when Sidebar is collapsed

### DIFF
--- a/src/components/Sidebar/Menu.tsx
+++ b/src/components/Sidebar/Menu.tsx
@@ -14,12 +14,18 @@ export interface MenuItem {
 	icon?: React.ReactNode;
 }
 
-const StyledBadge = styled(Badge)`
+const StyledBadge = styled(Badge)<{ isCollapsed: boolean }>`
 	border-radius: 0 1em 1em 0;
 	position: absolute;
 	transform: scale(0.75);
 	left: -5%;
 	bottom: 5%;
+	${(props) =>
+		props.isCollapsed &&
+		`
+			left: -15%;
+			height: 1.675em;
+		`}
 `;
 
 const MenuItem = styled(Flex)<{ isCurrent: boolean }>`
@@ -79,7 +85,11 @@ export const Menu = ({
 							alignItems="center"
 							justifyContent={isCollapsed ? 'center' : 'unset'}
 						>
-							{!!item.badge && <StyledBadge {...item.badge} />}
+							{!!item.badge && (
+								<StyledBadge {...item.badge} isCollapsed={isCollapsed}>
+									{isCollapsed ? '' : item.badge.children}
+								</StyledBadge>
+							)}
 							{!!item.icon && (
 								<Txt.span
 									bold


### PR DESCRIPTION
Make MenuItem badge small when Sidebar is collapsed

Change-type: patch
Signed-off-by: Matthew Yarmolinsky <matthew-timothy@balena.io>

---

##### Contributor checklist

<!-- For completed items, change [ ] to [x].  -->

- [ ] I have regenerated jest snapshots for any affected components with `npm run generate-snapshots`

##### Reviewer Guidelines

- When submitting a review, please pick:
  - '_Approve_' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '_Request Changes_' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '_Comment_' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)

---
