### PR TITLE
Revert react-monaco-editor version to 0.45.0 to fix incompatibilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "prettier": "^2.4.1",
     "react": "^16.14.0",
     "react-dom": "^16.14.0",
-    "react-monaco-editor": "^0.50.1",
+    "react-monaco-editor": "^0.45.0",
     "rimraf": "^3.0.2",
     "sinon": "^4.5.0",
     "strip-css-comments": "^3.0.0",

--- a/renovate.json
+++ b/renovate.json
@@ -24,6 +24,17 @@
   ],
   "packageRules": [
     {
+      "groupName": "monaco",
+      "matchPackageNames": ["react-monaco-editor", "monaco-editor-webpack-plugin"],
+      "commitBody": "Change-type: patch",
+      "matchUpdateTypes": [
+        "major",
+        "minor",
+        "patch"
+      ],
+      "automerge": false
+    },
+    {
       "groupName": "storybook-non-major",
       "matchPackagePrefixes": ["@storybook"],
       "commitBody": "Change-type: patch",


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Andrea Rosci <andrear@balena.io>

<!-- You can remove tags that do not apply. -->

Connects-to: # <!-- waffle convention to track a PR's status through its connected, open issue -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->
Change-type: major|minor|patch <!-- The change type of this PR -->

---

##### Contributor checklist

<!-- For completed items, change [ ] to [x].  -->

- [ ] I have regenerated jest snapshots for any affected components with `npm run generate-snapshots`

##### Reviewer Guidelines

- When submitting a review, please pick:
  - '_Approve_' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '_Request Changes_' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '_Comment_' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)

---
