### PR TITLE
AutoUI: Fix empty string values being converted to null when passed into widgets

### DIFF
--- a/src/extra/AutoUI/CustomWidget.tsx
+++ b/src/extra/AutoUI/CustomWidget.tsx
@@ -50,7 +50,7 @@ export const CustomWidget = ({
 		<Widget
 			extraContext={extraContext}
 			extraFormats={extraFormats}
-			value={processedValue || null}
+			value={processedValue ?? null}
 			schema={schema}
 		/>
 	);


### PR DESCRIPTION
AutoUI: Fix empty string values being converted to null when passed into widgets

Change-type: patch
Signed-off-by: Matthew Yarmolinsky <matthew-timothy@balena.io>

---

##### Contributor checklist

<!-- For completed items, change [ ] to [x].  -->

- [ ] I have regenerated jest snapshots for any affected components with `npm run generate-snapshots`

##### Reviewer Guidelines

- When submitting a review, please pick:
  - '_Approve_' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '_Request Changes_' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '_Comment_' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)

---
