### PR TITLE
Fix AutoUI entity lens not working with new keys and surface tags in it

### DIFF
--- a/src/extra/AutoUI/Lenses/types/entity.tsx
+++ b/src/extra/AutoUI/Lenses/types/entity.tsx
@@ -10,6 +10,7 @@ import { Update } from '../../Actions/Update';
 import { ActionData } from '../../schemaOps';
 import { LensTemplate } from '..';
 import { EntityLensRendererProps } from '.';
+import { TagLabelList } from '../../../../components/TagManagementModal/TagLabelList';
 
 const Label = styled(Txt)`
 	color: #252629;
@@ -58,7 +59,7 @@ export const entity: LensTemplate = {
 								<Flex flexDirection="column">
 									<Heading.h2>
 										{properties.length > 0 &&
-											properties[0].render(data[properties[0].key], data)}
+											properties[0].render(data[properties[0].field], data)}
 									</Heading.h2>
 								</Flex>
 								<Flex flexDirection="column" alignItems="flex-end">
@@ -85,14 +86,27 @@ export const entity: LensTemplate = {
 										property.priority !== 'primary' && (
 											<Flex
 												flexDirection="column"
-												m={10}
+												my={10}
 												key={property.key}
 												flex={['100%', '0 0 30%']}
 											>
 												<Label>{property.title}</Label>
-												<Txt>{property.render(data[property.key], data)}</Txt>
+												<Txt>{property.render(data[property.field], data)}</Txt>
 											</Flex>
 										),
+								)}
+								{!!data[`${model.resource}_tag`]?.length && (
+									<Flex
+										flexDirection="column"
+										my={10}
+										key={'device_tag'}
+										flex={['100%', '0 0 30%']}
+									>
+										<Label>Tags</Label>
+										<Txt>
+											<TagLabelList tags={data[`${model.resource}_tag`]} />
+										</Txt>
+									</Flex>
 								)}
 							</Flex>
 							{actionData?.action?.renderer &&


### PR DESCRIPTION
Fix AutoUI entity lens not working with new keys and surface tags in it

Change-type: patch
Signed-off-by: Matthew Yarmolinsky <matthew-timothy@balena.io>

---

##### Contributor checklist

<!-- For completed items, change [ ] to [x].  -->

- [ ] I have regenerated jest snapshots for any affected components with `npm run generate-snapshots`

##### Reviewer Guidelines

- When submitting a review, please pick:
  - '_Approve_' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '_Request Changes_' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '_Comment_' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)

---
