### PR TITLE
Modal: Await the done callback to avoid double firing on Enter keypress

### DIFF
--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -34,6 +34,7 @@ const ModalButton = (props: ButtonProps) => {
 
 class BaseModal extends React.Component<ThemedModalProps, any> {
 	public static mountedCount = 0;
+	private ongoingSubmit = false;
 
 	public ownIndex = 0;
 
@@ -70,14 +71,23 @@ class BaseModal extends React.Component<ThemedModalProps, any> {
 			e.preventDefault();
 			e.stopPropagation();
 
-			if (this.props.primaryButtonProps?.disabled) {
+			if (this.props.primaryButtonProps?.disabled || this.ongoingSubmit) {
 				return;
 			}
 
 			// Enter key
 			if (e.which === 13) {
-				this.props.done();
+				this.done();
 			}
+		}
+	};
+
+	public done = async () => {
+		try {
+			this.ongoingSubmit = true;
+			await this.props.done();
+		} finally {
+			this.ongoingSubmit = false;
 		}
 	};
 
@@ -89,7 +99,7 @@ class BaseModal extends React.Component<ThemedModalProps, any> {
 			return;
 		}
 
-		(this.props.cancel || this.props.done)();
+		(this.props.cancel || this.done)();
 	};
 
 	public render() {
@@ -156,7 +166,7 @@ class BaseModal extends React.Component<ThemedModalProps, any> {
 							{props.secondaryButtonProps && (
 								<ModalButton {...secondaryButtonProps} />
 							)}
-							<ModalButton {...primaryButtonProps} onClick={props.done}>
+							<ModalButton {...primaryButtonProps} onClick={this.done}>
 								{props.action || 'OK'}
 							</ModalButton>
 						</Flex>


### PR DESCRIPTION
Change-type: patch
See: https://balena.zulipchat.com/#narrow/stream/346007-balena-io.2FbalenaCloud/topic/Prevent.20double.20PATCHing

<!-- You can remove tags that do not apply. -->

Connects-to: # <!-- waffle convention to track a PR's status through its connected, open issue -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->
Change-type: major|minor|patch <!-- The change type of this PR -->

---

##### Contributor checklist

<!-- For completed items, change [ ] to [x].  -->

- [ ] I have regenerated jest snapshots for any affected components with `npm run generate-snapshots`

##### Reviewer Guidelines

- When submitting a review, please pick:
  - '_Approve_' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '_Request Changes_' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '_Comment_' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)

---
