### PR TITLE
ChangelogButton: Open changelog modal automatically for major versions

### DIFF
--- a/src/components/Changelog/ChangelogButton.tsx
+++ b/src/components/Changelog/ChangelogButton.tsx
@@ -39,6 +39,33 @@ export const ChangelogButton = ({
 		[showChangelogModal],
 	);
 
+	React.useEffect(() => {
+		if (!lastViewedChangelogVersion) {
+			setToLocalStorage(
+				LAST_VIEWED_CHANGELOG_VERSION_STORAGE_KEY,
+				latestChangelogVersion,
+			);
+		}
+	}, []);
+	React.useEffect(() => {
+		if (showChangelogModal) {
+			setToLocalStorage(
+				LAST_VIEWED_CHANGELOG_VERSION_STORAGE_KEY,
+				latestChangelogVersion,
+			);
+		}
+	}, [showChangelogModal]);
+	React.useEffect(() => {
+		if (
+			lastViewedChangelogVersion &&
+			latestChangelogVersion &&
+			Number(lastViewedChangelogVersion.split('.')[0]) <
+				Number(latestChangelogVersion.split('.')[0])
+		) {
+			setShowChangelogModal(true);
+		}
+	}, [lastViewedChangelogVersion]);
+
 	return (
 		<Flex justifyContent="flex-end">
 			<Button
@@ -46,10 +73,6 @@ export const ChangelogButton = ({
 				onClick={(e) => {
 					onClick?.(e);
 					setShowChangelogModal(true);
-					setToLocalStorage(
-						LAST_VIEWED_CHANGELOG_VERSION_STORAGE_KEY,
-						latestChangelogVersion,
-					);
 				}}
 				style={{
 					background: 'rgba(0, 0, 0, 0.1)',


### PR DESCRIPTION
ChangelogButton: Open changelog modal automatically for major versions

Connects-to: https://github.com/balena-io/balena-ui/issues/5685
Changelog-entry: ChangelogButton: Open changelog modal automatically when there has been a major version change since last viewed
Change-type: patch

---

##### Contributor checklist

<!-- For completed items, change [ ] to [x].  -->

- [ ] I have regenerated jest snapshots for any affected components with `npm run generate-snapshots`

##### Reviewer Guidelines

- When submitting a review, please pick:
  - '_Approve_' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '_Request Changes_' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '_Comment_' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)

---
