### PR TITLE
DownloadImageModal: Fix mixing instructions when a step is repeated

### DIFF
--- a/src/unstable-temp/DownloadImageModal/ApplicationInstructions.tsx
+++ b/src/unstable-temp/DownloadImageModal/ApplicationInstructions.tsx
@@ -161,8 +161,8 @@ const InstructionsItem = (props: InstructionsItemProps) => {
 
 			{hasChildren && (
 				<List>
-					{node.children.map((item: any) => {
-						return <InstructionsItem node={item} />;
+					{(node.children as any[]).map((item, i) => {
+						return <InstructionsItem key={i} node={item} />;
 					})}
 				</List>
 			)}
@@ -177,8 +177,8 @@ const InstructionsList = (props: InstructionsListProps) => {
 		// TODO: On 13px the line height is calculated as 19.5px, which breaks the alignment of the number inside the list item due to rounding.
 		// Remove custom font size once fixed in rendition https://github.com/balena-io-modules/rendition/issues/1025
 		<List ordered fontSize={14}>
-			{instructions.map((item) => {
-				return <InstructionsItem key={item} node={item} />;
+			{instructions.map((item, i) => {
+				return <InstructionsItem key={`${item}_${i}`} node={item} />;
 			})}
 		</List>
 	);


### PR DESCRIPTION
Change-type: patch
See: https://github.com/balena-io/balena-ui/issues/5818

<!-- You can remove tags that do not apply. -->

Connects-to: # <!-- waffle convention to track a PR's status through its connected, open issue -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->
Change-type: major|minor|patch <!-- The change type of this PR -->

---

##### Contributor checklist

<!-- For completed items, change [ ] to [x].  -->

- [ ] I have regenerated jest snapshots for any affected components with `npm run generate-snapshots`

##### Reviewer Guidelines

- When submitting a review, please pick:
  - '_Approve_' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '_Request Changes_' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '_Comment_' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)

---
