### PR TITLE
DownloadImageModal: Add support for empty string OS variant

### DIFF
--- a/src/components/Renderer/__snapshots__/spec.tsx.snap
+++ b/src/components/Renderer/__snapshots__/spec.tsx.snap
@@ -855,9 +855,12 @@ exports[`Renderer component A button group widget 1`] = `
   box-shadow: none;
 }
 
-.c7:focus:not(:focus-visible) > circle,.c7:focus:not(:focus-visible) > ellipse,
-.c7:focus:not(:focus-visible) > line,.c7:focus:not(:focus-visible) > path,
-.c7:focus:not(:focus-visible) > polygon,.c7:focus:not(:focus-visible) > polyline,
+.c7:focus:not(:focus-visible) > circle,
+.c7:focus:not(:focus-visible) > ellipse,
+.c7:focus:not(:focus-visible) > line,
+.c7:focus:not(:focus-visible) > path,
+.c7:focus:not(:focus-visible) > polygon,
+.c7:focus:not(:focus-visible) > polyline,
 .c7:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
@@ -1080,9 +1083,12 @@ exports[`Renderer component A button widget 1`] = `
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,.c5:focus:not(:focus-visible) > polyline,
+.c5:focus:not(:focus-visible) > circle,
+.c5:focus:not(:focus-visible) > ellipse,
+.c5:focus:not(:focus-visible) > line,
+.c5:focus:not(:focus-visible) > path,
+.c5:focus:not(:focus-visible) > polygon,
+.c5:focus:not(:focus-visible) > polyline,
 .c5:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
@@ -1427,9 +1433,12 @@ exports[`Renderer component A drop-down button widget 1`] = `
   box-shadow: none;
 }
 
-.c6:focus:not(:focus-visible) > circle,.c6:focus:not(:focus-visible) > ellipse,
-.c6:focus:not(:focus-visible) > line,.c6:focus:not(:focus-visible) > path,
-.c6:focus:not(:focus-visible) > polygon,.c6:focus:not(:focus-visible) > polyline,
+.c6:focus:not(:focus-visible) > circle,
+.c6:focus:not(:focus-visible) > ellipse,
+.c6:focus:not(:focus-visible) > line,
+.c6:focus:not(:focus-visible) > path,
+.c6:focus:not(:focus-visible) > polygon,
+.c6:focus:not(:focus-visible) > polyline,
 .c6:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
@@ -1824,7 +1833,8 @@ exports[`Renderer component A markdown field 1`] = `
   color: #2A506F;
 }
 
-.c5 code[class*='language-'],.c5 pre[class*='language-'] {
+.c5 code[class*='language-'],
+.c5 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -1848,12 +1858,18 @@ exports[`Renderer component A markdown field 1`] = `
   hyphens: none;
 }
 
-.c5 pre[class*='language-']::-moz-selection,.c5 pre[class*='language-'] ::-moz-selection,.c5 code[class*='language-']::-moz-selection,.c5 code[class*='language-'] ::-moz-selection {
+.c5 pre[class*='language-']::-moz-selection,
+.c5 pre[class*='language-'] ::-moz-selection,
+.c5 code[class*='language-']::-moz-selection,
+.c5 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c5 pre[class*='language-']::selection,.c5 pre[class*='language-'] ::selection,.c5 code[class*='language-']::selection,.c5 code[class*='language-'] ::selection {
+.c5 pre[class*='language-']::selection,
+.c5 pre[class*='language-'] ::selection,
+.c5 code[class*='language-']::selection,
+.c5 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -1864,7 +1880,8 @@ exports[`Renderer component A markdown field 1`] = `
   overflow: auto;
 }
 
-.c5:not(pre) > code[class*='language-'],.c5 pre[class*='language-'] {
+.c5:not(pre) > code[class*='language-'],
+.c5 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -2115,7 +2132,8 @@ exports[`Renderer component A markdown field 1`] = `
 }
 
 @media print {
-  .c5 code[class*='language-'],.c5 pre[class*='language-'] {
+  .c5 code[class*='language-'],
+  .c5 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -3003,7 +3021,8 @@ exports[`Renderer component An array of different type items 1`] = `
   color: #2A506F;
 }
 
-.c8 code[class*='language-'],.c8 pre[class*='language-'] {
+.c8 code[class*='language-'],
+.c8 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -3027,12 +3046,18 @@ exports[`Renderer component An array of different type items 1`] = `
   hyphens: none;
 }
 
-.c8 pre[class*='language-']::-moz-selection,.c8 pre[class*='language-'] ::-moz-selection,.c8 code[class*='language-']::-moz-selection,.c8 code[class*='language-'] ::-moz-selection {
+.c8 pre[class*='language-']::-moz-selection,
+.c8 pre[class*='language-'] ::-moz-selection,
+.c8 code[class*='language-']::-moz-selection,
+.c8 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c8 pre[class*='language-']::selection,.c8 pre[class*='language-'] ::selection,.c8 code[class*='language-']::selection,.c8 code[class*='language-'] ::selection {
+.c8 pre[class*='language-']::selection,
+.c8 pre[class*='language-'] ::selection,
+.c8 code[class*='language-']::selection,
+.c8 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -3043,7 +3068,8 @@ exports[`Renderer component An array of different type items 1`] = `
   overflow: auto;
 }
 
-.c8:not(pre) > code[class*='language-'],.c8 pre[class*='language-'] {
+.c8:not(pre) > code[class*='language-'],
+.c8 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -3294,7 +3320,8 @@ exports[`Renderer component An array of different type items 1`] = `
 }
 
 @media print {
-  .c8 code[class*='language-'],.c8 pre[class*='language-'] {
+  .c8 code[class*='language-'],
+  .c8 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -3675,7 +3702,8 @@ exports[`Renderer component An evaluated value 1`] = `
   cursor: pointer;
 }
 
-.c8:hover input:not([disabled]) + div,.c8:hover input:not([disabled]) + span {
+.c8:hover input:not([disabled]) + div,
+.c8:hover input:not([disabled]) + span {
   border-color: #DDE1f0;
 }
 
@@ -4149,7 +4177,8 @@ exports[`Renderer component An object with various properties 1`] = `
   cursor: pointer;
 }
 
-.c9:hover input:not([disabled]) + div,.c9:hover input:not([disabled]) + span {
+.c9:hover input:not([disabled]) + div,
+.c9:hover input:not([disabled]) + span {
   border-color: #DDE1f0;
 }
 
@@ -4752,7 +4781,8 @@ exports[`Renderer component anyOf options 1`] = `
   color: #2A506F;
 }
 
-.c7 code[class*='language-'],.c7 pre[class*='language-'] {
+.c7 code[class*='language-'],
+.c7 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -4776,12 +4806,18 @@ exports[`Renderer component anyOf options 1`] = `
   hyphens: none;
 }
 
-.c7 pre[class*='language-']::-moz-selection,.c7 pre[class*='language-'] ::-moz-selection,.c7 code[class*='language-']::-moz-selection,.c7 code[class*='language-'] ::-moz-selection {
+.c7 pre[class*='language-']::-moz-selection,
+.c7 pre[class*='language-'] ::-moz-selection,
+.c7 code[class*='language-']::-moz-selection,
+.c7 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c7 pre[class*='language-']::selection,.c7 pre[class*='language-'] ::selection,.c7 code[class*='language-']::selection,.c7 code[class*='language-'] ::selection {
+.c7 pre[class*='language-']::selection,
+.c7 pre[class*='language-'] ::selection,
+.c7 code[class*='language-']::selection,
+.c7 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -4792,7 +4828,8 @@ exports[`Renderer component anyOf options 1`] = `
   overflow: auto;
 }
 
-.c7:not(pre) > code[class*='language-'],.c7 pre[class*='language-'] {
+.c7:not(pre) > code[class*='language-'],
+.c7 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -5043,7 +5080,8 @@ exports[`Renderer component anyOf options 1`] = `
 }
 
 @media print {
-  .c7 code[class*='language-'],.c7 pre[class*='language-'] {
+  .c7 code[class*='language-'],
+  .c7 pre[class*='language-'] {
     text-shadow: none;
   }
 }

--- a/src/extra/Markdown/__snapshots__/spec.tsx.snap
+++ b/src/extra/Markdown/__snapshots__/spec.tsx.snap
@@ -18,7 +18,8 @@ exports[`Markdown component Custom sanitizer options: allowedAttributes can be o
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -42,12 +43,18 @@ exports[`Markdown component Custom sanitizer options: allowedAttributes can be o
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -58,7 +65,8 @@ exports[`Markdown component Custom sanitizer options: allowedAttributes can be o
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -309,7 +317,8 @@ exports[`Markdown component Custom sanitizer options: allowedAttributes can be o
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -367,7 +376,8 @@ exports[`Markdown component Custom sanitizer options: allowedTags can be overrid
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -391,12 +401,18 @@ exports[`Markdown component Custom sanitizer options: allowedTags can be overrid
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -407,7 +423,8 @@ exports[`Markdown component Custom sanitizer options: allowedTags can be overrid
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -658,7 +675,8 @@ exports[`Markdown component Custom sanitizer options: allowedTags can be overrid
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -727,7 +745,8 @@ exports[`Markdown component should decorate the text matching the condition 1`] 
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -751,12 +770,18 @@ exports[`Markdown component should decorate the text matching the condition 1`] 
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -767,7 +792,8 @@ exports[`Markdown component should decorate the text matching the condition 1`] 
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -1018,7 +1044,8 @@ exports[`Markdown component should decorate the text matching the condition 1`] 
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -1095,7 +1122,8 @@ exports[`Markdown component should drop the content of style elements tag 1`] = 
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -1119,12 +1147,18 @@ exports[`Markdown component should drop the content of style elements tag 1`] = 
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -1135,7 +1169,8 @@ exports[`Markdown component should drop the content of style elements tag 1`] = 
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -1386,7 +1421,8 @@ exports[`Markdown component should drop the content of style elements tag 1`] = 
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -1424,7 +1460,8 @@ exports[`Markdown component should drop the content of textarea elements tag 1`]
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -1448,12 +1485,18 @@ exports[`Markdown component should drop the content of textarea elements tag 1`]
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -1464,7 +1507,8 @@ exports[`Markdown component should drop the content of textarea elements tag 1`]
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -1715,7 +1759,8 @@ exports[`Markdown component should drop the content of textarea elements tag 1`]
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -1783,7 +1828,8 @@ exports[`Markdown component should not highlight code when disabled 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -1807,12 +1853,18 @@ exports[`Markdown component should not highlight code when disabled 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -1823,7 +1875,8 @@ exports[`Markdown component should not highlight code when disabled 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -2074,7 +2127,8 @@ exports[`Markdown component should not highlight code when disabled 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -2176,7 +2230,8 @@ exports[`Markdown component should not render raw html when disabled 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -2200,12 +2255,18 @@ exports[`Markdown component should not render raw html when disabled 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -2216,7 +2277,8 @@ exports[`Markdown component should not render raw html when disabled 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -2467,7 +2529,8 @@ exports[`Markdown component should not render raw html when disabled 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -2573,7 +2636,8 @@ exports[`Markdown component should not sanitize html when disabled 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -2597,12 +2661,18 @@ exports[`Markdown component should not sanitize html when disabled 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -2613,7 +2683,8 @@ exports[`Markdown component should not sanitize html when disabled 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -2864,7 +2935,8 @@ exports[`Markdown component should not sanitize html when disabled 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -2904,7 +2976,8 @@ exports[`Markdown component should render html images 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -2928,12 +3001,18 @@ exports[`Markdown component should render html images 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -2944,7 +3023,8 @@ exports[`Markdown component should render html images 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -3195,7 +3275,8 @@ exports[`Markdown component should render html images 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -3252,7 +3333,8 @@ exports[`Markdown component should render html links 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -3276,12 +3358,18 @@ exports[`Markdown component should render html links 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -3292,7 +3380,8 @@ exports[`Markdown component should render html links 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -3543,7 +3632,8 @@ exports[`Markdown component should render html links 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -3608,7 +3698,8 @@ exports[`Markdown component should render link type strings as links 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -3632,12 +3723,18 @@ exports[`Markdown component should render link type strings as links 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -3648,7 +3745,8 @@ exports[`Markdown component should render link type strings as links 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -3899,7 +3997,8 @@ exports[`Markdown component should render link type strings as links 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -3947,7 +4046,8 @@ exports[`Markdown component should render markdown blockquotes 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -3971,12 +4071,18 @@ exports[`Markdown component should render markdown blockquotes 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -3987,7 +4093,8 @@ exports[`Markdown component should render markdown blockquotes 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -4238,7 +4345,8 @@ exports[`Markdown component should render markdown blockquotes 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -4286,7 +4394,8 @@ exports[`Markdown component should render markdown bold using ** 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -4310,12 +4419,18 @@ exports[`Markdown component should render markdown bold using ** 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -4326,7 +4441,8 @@ exports[`Markdown component should render markdown bold using ** 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -4577,7 +4693,8 @@ exports[`Markdown component should render markdown bold using ** 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -4621,7 +4738,8 @@ exports[`Markdown component should render markdown bold using __ 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -4645,12 +4763,18 @@ exports[`Markdown component should render markdown bold using __ 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -4661,7 +4785,8 @@ exports[`Markdown component should render markdown bold using __ 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -4912,7 +5037,8 @@ exports[`Markdown component should render markdown bold using __ 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -4956,7 +5082,8 @@ exports[`Markdown component should render markdown code blocks 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -4980,12 +5107,18 @@ exports[`Markdown component should render markdown code blocks 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -4996,7 +5129,8 @@ exports[`Markdown component should render markdown code blocks 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -5247,7 +5381,8 @@ exports[`Markdown component should render markdown code blocks 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -5292,7 +5427,8 @@ exports[`Markdown component should render markdown code blocks with language spe
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -5316,12 +5452,18 @@ exports[`Markdown component should render markdown code blocks with language spe
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -5332,7 +5474,8 @@ exports[`Markdown component should render markdown code blocks with language spe
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -5583,7 +5726,8 @@ exports[`Markdown component should render markdown code blocks with language spe
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -5716,7 +5860,8 @@ exports[`Markdown component should render markdown h1 headers 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -5740,12 +5885,18 @@ exports[`Markdown component should render markdown h1 headers 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -5756,7 +5907,8 @@ exports[`Markdown component should render markdown h1 headers 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -6007,7 +6159,8 @@ exports[`Markdown component should render markdown h1 headers 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -6085,7 +6238,8 @@ exports[`Markdown component should render markdown h2 headers 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -6109,12 +6263,18 @@ exports[`Markdown component should render markdown h2 headers 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -6125,7 +6285,8 @@ exports[`Markdown component should render markdown h2 headers 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -6376,7 +6537,8 @@ exports[`Markdown component should render markdown h2 headers 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -6454,7 +6616,8 @@ exports[`Markdown component should render markdown h3 headers 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -6478,12 +6641,18 @@ exports[`Markdown component should render markdown h3 headers 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -6494,7 +6663,8 @@ exports[`Markdown component should render markdown h3 headers 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -6745,7 +6915,8 @@ exports[`Markdown component should render markdown h3 headers 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -6824,7 +6995,8 @@ exports[`Markdown component should render markdown h4 headers 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -6848,12 +7020,18 @@ exports[`Markdown component should render markdown h4 headers 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -6864,7 +7042,8 @@ exports[`Markdown component should render markdown h4 headers 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -7115,7 +7294,8 @@ exports[`Markdown component should render markdown h4 headers 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -7194,7 +7374,8 @@ exports[`Markdown component should render markdown h4 headers 2`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -7218,12 +7399,18 @@ exports[`Markdown component should render markdown h4 headers 2`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -7234,7 +7421,8 @@ exports[`Markdown component should render markdown h4 headers 2`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -7485,7 +7673,8 @@ exports[`Markdown component should render markdown h4 headers 2`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -7564,7 +7753,8 @@ exports[`Markdown component should render markdown h5 headers 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -7588,12 +7778,18 @@ exports[`Markdown component should render markdown h5 headers 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -7604,7 +7800,8 @@ exports[`Markdown component should render markdown h5 headers 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -7855,7 +8052,8 @@ exports[`Markdown component should render markdown h5 headers 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -7934,7 +8132,8 @@ exports[`Markdown component should render markdown h5 headers 2`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -7958,12 +8157,18 @@ exports[`Markdown component should render markdown h5 headers 2`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -7974,7 +8179,8 @@ exports[`Markdown component should render markdown h5 headers 2`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -8225,7 +8431,8 @@ exports[`Markdown component should render markdown h5 headers 2`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -8277,7 +8484,8 @@ exports[`Markdown component should render markdown images 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -8301,12 +8509,18 @@ exports[`Markdown component should render markdown images 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -8317,7 +8531,8 @@ exports[`Markdown component should render markdown images 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -8568,7 +8783,8 @@ exports[`Markdown component should render markdown images 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -8613,7 +8829,8 @@ exports[`Markdown component should render markdown inline code 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -8637,12 +8854,18 @@ exports[`Markdown component should render markdown inline code 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -8653,7 +8876,8 @@ exports[`Markdown component should render markdown inline code 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -8904,7 +9128,8 @@ exports[`Markdown component should render markdown inline code 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -8948,7 +9173,8 @@ exports[`Markdown component should render markdown italics using * 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -8972,12 +9198,18 @@ exports[`Markdown component should render markdown italics using * 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -8988,7 +9220,8 @@ exports[`Markdown component should render markdown italics using * 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -9239,7 +9472,8 @@ exports[`Markdown component should render markdown italics using * 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -9283,7 +9517,8 @@ exports[`Markdown component should render markdown italics using _ 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -9307,12 +9542,18 @@ exports[`Markdown component should render markdown italics using _ 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -9323,7 +9564,8 @@ exports[`Markdown component should render markdown italics using _ 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -9574,7 +9816,8 @@ exports[`Markdown component should render markdown italics using _ 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -9635,7 +9878,8 @@ exports[`Markdown component should render markdown links 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -9659,12 +9903,18 @@ exports[`Markdown component should render markdown links 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -9675,7 +9925,8 @@ exports[`Markdown component should render markdown links 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -9926,7 +10177,8 @@ exports[`Markdown component should render markdown links 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -9974,7 +10226,8 @@ exports[`Markdown component should render markdown ordered lists 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -9998,12 +10251,18 @@ exports[`Markdown component should render markdown ordered lists 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -10014,7 +10273,8 @@ exports[`Markdown component should render markdown ordered lists 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -10265,7 +10525,8 @@ exports[`Markdown component should render markdown ordered lists 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -10326,7 +10587,8 @@ exports[`Markdown component should render markdown strikethroughs 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -10350,12 +10612,18 @@ exports[`Markdown component should render markdown strikethroughs 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -10366,7 +10634,8 @@ exports[`Markdown component should render markdown strikethroughs 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -10617,7 +10886,8 @@ exports[`Markdown component should render markdown strikethroughs 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -10661,7 +10931,8 @@ exports[`Markdown component should render markdown tables 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -10685,12 +10956,18 @@ exports[`Markdown component should render markdown tables 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -10701,7 +10978,8 @@ exports[`Markdown component should render markdown tables 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -10952,7 +11230,8 @@ exports[`Markdown component should render markdown tables 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -11037,7 +11316,8 @@ exports[`Markdown component should render markdown task lists 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -11061,12 +11341,18 @@ exports[`Markdown component should render markdown task lists 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -11077,7 +11363,8 @@ exports[`Markdown component should render markdown task lists 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -11328,7 +11615,8 @@ exports[`Markdown component should render markdown task lists 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -11406,7 +11694,8 @@ exports[`Markdown component should render markdown unordered lists 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -11430,12 +11719,18 @@ exports[`Markdown component should render markdown unordered lists 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -11446,7 +11741,8 @@ exports[`Markdown component should render markdown unordered lists 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -11697,7 +11993,8 @@ exports[`Markdown component should render markdown unordered lists 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -11765,7 +12062,8 @@ exports[`Markdown component xss: 1 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -11789,12 +12087,18 @@ exports[`Markdown component xss: 1 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -11805,7 +12109,8 @@ exports[`Markdown component xss: 1 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -12056,7 +12361,8 @@ exports[`Markdown component xss: 1 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -12092,7 +12398,8 @@ exports[`Markdown component xss: 2 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -12116,12 +12423,18 @@ exports[`Markdown component xss: 2 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -12132,7 +12445,8 @@ exports[`Markdown component xss: 2 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -12383,7 +12697,8 @@ exports[`Markdown component xss: 2 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -12425,7 +12740,8 @@ exports[`Markdown component xss: 3 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -12449,12 +12765,18 @@ exports[`Markdown component xss: 3 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -12465,7 +12787,8 @@ exports[`Markdown component xss: 3 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -12716,7 +13039,8 @@ exports[`Markdown component xss: 3 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -12756,7 +13080,8 @@ exports[`Markdown component xss: 4 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -12780,12 +13105,18 @@ exports[`Markdown component xss: 4 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -12796,7 +13127,8 @@ exports[`Markdown component xss: 4 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -13047,7 +13379,8 @@ exports[`Markdown component xss: 4 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -13087,7 +13420,8 @@ exports[`Markdown component xss: 5 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -13111,12 +13445,18 @@ exports[`Markdown component xss: 5 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -13127,7 +13467,8 @@ exports[`Markdown component xss: 5 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -13378,7 +13719,8 @@ exports[`Markdown component xss: 5 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -13420,7 +13762,8 @@ exports[`Markdown component xss: 6 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -13444,12 +13787,18 @@ exports[`Markdown component xss: 6 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -13460,7 +13809,8 @@ exports[`Markdown component xss: 6 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -13711,7 +14061,8 @@ exports[`Markdown component xss: 6 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -13753,7 +14104,8 @@ exports[`Markdown component xss: 7 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -13777,12 +14129,18 @@ exports[`Markdown component xss: 7 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -13793,7 +14151,8 @@ exports[`Markdown component xss: 7 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -14044,7 +14403,8 @@ exports[`Markdown component xss: 7 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -14086,7 +14446,8 @@ exports[`Markdown component xss: 8 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -14110,12 +14471,18 @@ exports[`Markdown component xss: 8 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -14126,7 +14493,8 @@ exports[`Markdown component xss: 8 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -14377,7 +14745,8 @@ exports[`Markdown component xss: 8 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -14420,7 +14789,8 @@ exports[`Markdown component xss: 9 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -14444,12 +14814,18 @@ exports[`Markdown component xss: 9 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -14460,7 +14836,8 @@ exports[`Markdown component xss: 9 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -14711,7 +15088,8 @@ exports[`Markdown component xss: 9 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -14751,7 +15129,8 @@ exports[`Markdown component xss: 10 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -14775,12 +15154,18 @@ exports[`Markdown component xss: 10 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -14791,7 +15176,8 @@ exports[`Markdown component xss: 10 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -15042,7 +15428,8 @@ exports[`Markdown component xss: 10 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -15084,7 +15471,8 @@ exports[`Markdown component xss: 11 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -15108,12 +15496,18 @@ exports[`Markdown component xss: 11 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -15124,7 +15518,8 @@ exports[`Markdown component xss: 11 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -15375,7 +15770,8 @@ exports[`Markdown component xss: 11 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -15417,7 +15813,8 @@ exports[`Markdown component xss: 12 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -15441,12 +15838,18 @@ exports[`Markdown component xss: 12 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -15457,7 +15860,8 @@ exports[`Markdown component xss: 12 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -15708,7 +16112,8 @@ exports[`Markdown component xss: 12 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -15750,7 +16155,8 @@ exports[`Markdown component xss: 13 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -15774,12 +16180,18 @@ exports[`Markdown component xss: 13 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -15790,7 +16202,8 @@ exports[`Markdown component xss: 13 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -16041,7 +16454,8 @@ exports[`Markdown component xss: 13 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -16083,7 +16497,8 @@ exports[`Markdown component xss: 14 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -16107,12 +16522,18 @@ exports[`Markdown component xss: 14 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -16123,7 +16544,8 @@ exports[`Markdown component xss: 14 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -16374,7 +16796,8 @@ exports[`Markdown component xss: 14 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -16416,7 +16839,8 @@ exports[`Markdown component xss: 15 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -16440,12 +16864,18 @@ exports[`Markdown component xss: 15 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -16456,7 +16886,8 @@ exports[`Markdown component xss: 15 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -16707,7 +17138,8 @@ exports[`Markdown component xss: 15 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -16750,7 +17182,8 @@ exports[`Markdown component xss: 16 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -16774,12 +17207,18 @@ exports[`Markdown component xss: 16 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -16790,7 +17229,8 @@ exports[`Markdown component xss: 16 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -17041,7 +17481,8 @@ exports[`Markdown component xss: 16 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -17083,7 +17524,8 @@ exports[`Markdown component xss: 17 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -17107,12 +17549,18 @@ exports[`Markdown component xss: 17 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -17123,7 +17571,8 @@ exports[`Markdown component xss: 17 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -17374,7 +17823,8 @@ exports[`Markdown component xss: 17 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -17416,7 +17866,8 @@ exports[`Markdown component xss: 18 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -17440,12 +17891,18 @@ exports[`Markdown component xss: 18 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -17456,7 +17913,8 @@ exports[`Markdown component xss: 18 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -17707,7 +18165,8 @@ exports[`Markdown component xss: 18 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -17749,7 +18208,8 @@ exports[`Markdown component xss: 19 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -17773,12 +18233,18 @@ exports[`Markdown component xss: 19 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -17789,7 +18255,8 @@ exports[`Markdown component xss: 19 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -18040,7 +18507,8 @@ exports[`Markdown component xss: 19 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -18082,7 +18550,8 @@ exports[`Markdown component xss: 20 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -18106,12 +18575,18 @@ exports[`Markdown component xss: 20 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -18122,7 +18597,8 @@ exports[`Markdown component xss: 20 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -18373,7 +18849,8 @@ exports[`Markdown component xss: 20 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -18415,7 +18892,8 @@ exports[`Markdown component xss: 21 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -18439,12 +18917,18 @@ exports[`Markdown component xss: 21 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -18455,7 +18939,8 @@ exports[`Markdown component xss: 21 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -18706,7 +19191,8 @@ exports[`Markdown component xss: 21 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -18748,7 +19234,8 @@ exports[`Markdown component xss: 22 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -18772,12 +19259,18 @@ exports[`Markdown component xss: 22 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -18788,7 +19281,8 @@ exports[`Markdown component xss: 22 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -19039,7 +19533,8 @@ exports[`Markdown component xss: 22 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -19081,7 +19576,8 @@ exports[`Markdown component xss: 23 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -19105,12 +19601,18 @@ exports[`Markdown component xss: 23 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -19121,7 +19623,8 @@ exports[`Markdown component xss: 23 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -19372,7 +19875,8 @@ exports[`Markdown component xss: 23 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -19414,7 +19918,8 @@ exports[`Markdown component xss: 24 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -19438,12 +19943,18 @@ exports[`Markdown component xss: 24 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -19454,7 +19965,8 @@ exports[`Markdown component xss: 24 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -19705,7 +20217,8 @@ exports[`Markdown component xss: 24 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -19746,7 +20259,8 @@ exports[`Markdown component xss: 25 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -19770,12 +20284,18 @@ exports[`Markdown component xss: 25 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -19786,7 +20306,8 @@ exports[`Markdown component xss: 25 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -20037,7 +20558,8 @@ exports[`Markdown component xss: 25 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -20079,7 +20601,8 @@ exports[`Markdown component xss: 26 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -20103,12 +20626,18 @@ exports[`Markdown component xss: 26 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -20119,7 +20648,8 @@ exports[`Markdown component xss: 26 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -20370,7 +20900,8 @@ exports[`Markdown component xss: 26 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -20412,7 +20943,8 @@ exports[`Markdown component xss: 27 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -20436,12 +20968,18 @@ exports[`Markdown component xss: 27 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -20452,7 +20990,8 @@ exports[`Markdown component xss: 27 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -20703,7 +21242,8 @@ exports[`Markdown component xss: 27 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -20745,7 +21285,8 @@ exports[`Markdown component xss: 28 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -20769,12 +21310,18 @@ exports[`Markdown component xss: 28 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -20785,7 +21332,8 @@ exports[`Markdown component xss: 28 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -21036,7 +21584,8 @@ exports[`Markdown component xss: 28 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -21078,7 +21627,8 @@ exports[`Markdown component xss: 29 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -21102,12 +21652,18 @@ exports[`Markdown component xss: 29 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -21118,7 +21674,8 @@ exports[`Markdown component xss: 29 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -21369,7 +21926,8 @@ exports[`Markdown component xss: 29 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -21411,7 +21969,8 @@ exports[`Markdown component xss: 30 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -21435,12 +21994,18 @@ exports[`Markdown component xss: 30 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -21451,7 +22016,8 @@ exports[`Markdown component xss: 30 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -21702,7 +22268,8 @@ exports[`Markdown component xss: 30 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -21744,7 +22311,8 @@ exports[`Markdown component xss: 31 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -21768,12 +22336,18 @@ exports[`Markdown component xss: 31 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -21784,7 +22358,8 @@ exports[`Markdown component xss: 31 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -22035,7 +22610,8 @@ exports[`Markdown component xss: 31 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -22077,7 +22653,8 @@ exports[`Markdown component xss: 32 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -22101,12 +22678,18 @@ exports[`Markdown component xss: 32 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -22117,7 +22700,8 @@ exports[`Markdown component xss: 32 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -22368,7 +22952,8 @@ exports[`Markdown component xss: 32 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -22410,7 +22995,8 @@ exports[`Markdown component xss: 33 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -22434,12 +23020,18 @@ exports[`Markdown component xss: 33 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -22450,7 +23042,8 @@ exports[`Markdown component xss: 33 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -22701,7 +23294,8 @@ exports[`Markdown component xss: 33 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -22743,7 +23337,8 @@ exports[`Markdown component xss: 34 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -22767,12 +23362,18 @@ exports[`Markdown component xss: 34 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -22783,7 +23384,8 @@ exports[`Markdown component xss: 34 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -23034,7 +23636,8 @@ exports[`Markdown component xss: 34 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -23076,7 +23679,8 @@ exports[`Markdown component xss: 35 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -23100,12 +23704,18 @@ exports[`Markdown component xss: 35 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -23116,7 +23726,8 @@ exports[`Markdown component xss: 35 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -23367,7 +23978,8 @@ exports[`Markdown component xss: 35 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -23409,7 +24021,8 @@ exports[`Markdown component xss: 36 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -23433,12 +24046,18 @@ exports[`Markdown component xss: 36 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -23449,7 +24068,8 @@ exports[`Markdown component xss: 36 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -23700,7 +24320,8 @@ exports[`Markdown component xss: 36 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -23748,7 +24369,8 @@ exports[`Markdown component xss: 37 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -23772,12 +24394,18 @@ exports[`Markdown component xss: 37 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -23788,7 +24416,8 @@ exports[`Markdown component xss: 37 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -24039,7 +24668,8 @@ exports[`Markdown component xss: 37 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -24087,7 +24717,8 @@ exports[`Markdown component xss: 38 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -24111,12 +24742,18 @@ exports[`Markdown component xss: 38 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -24127,7 +24764,8 @@ exports[`Markdown component xss: 38 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -24378,7 +25016,8 @@ exports[`Markdown component xss: 38 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -24426,7 +25065,8 @@ exports[`Markdown component xss: 39 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -24450,12 +25090,18 @@ exports[`Markdown component xss: 39 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -24466,7 +25112,8 @@ exports[`Markdown component xss: 39 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -24717,7 +25364,8 @@ exports[`Markdown component xss: 39 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -24765,7 +25413,8 @@ exports[`Markdown component xss: 40 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -24789,12 +25438,18 @@ exports[`Markdown component xss: 40 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -24805,7 +25460,8 @@ exports[`Markdown component xss: 40 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -25056,7 +25712,8 @@ exports[`Markdown component xss: 40 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -25104,7 +25761,8 @@ exports[`Markdown component xss: 41 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -25128,12 +25786,18 @@ exports[`Markdown component xss: 41 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -25144,7 +25808,8 @@ exports[`Markdown component xss: 41 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -25395,7 +26060,8 @@ exports[`Markdown component xss: 41 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -25443,7 +26109,8 @@ exports[`Markdown component xss: 42 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -25467,12 +26134,18 @@ exports[`Markdown component xss: 42 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -25483,7 +26156,8 @@ exports[`Markdown component xss: 42 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -25734,7 +26408,8 @@ exports[`Markdown component xss: 42 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -25782,7 +26457,8 @@ exports[`Markdown component xss: 43 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -25806,12 +26482,18 @@ exports[`Markdown component xss: 43 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -25822,7 +26504,8 @@ exports[`Markdown component xss: 43 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -26073,7 +26756,8 @@ exports[`Markdown component xss: 43 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -26121,7 +26805,8 @@ exports[`Markdown component xss: 44 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -26145,12 +26830,18 @@ exports[`Markdown component xss: 44 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -26161,7 +26852,8 @@ exports[`Markdown component xss: 44 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -26412,7 +27104,8 @@ exports[`Markdown component xss: 44 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -26460,7 +27153,8 @@ exports[`Markdown component xss: 45 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -26484,12 +27178,18 @@ exports[`Markdown component xss: 45 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -26500,7 +27200,8 @@ exports[`Markdown component xss: 45 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -26751,7 +27452,8 @@ exports[`Markdown component xss: 45 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -26799,7 +27501,8 @@ exports[`Markdown component xss: 46 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -26823,12 +27526,18 @@ exports[`Markdown component xss: 46 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -26839,7 +27548,8 @@ exports[`Markdown component xss: 46 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -27090,7 +27800,8 @@ exports[`Markdown component xss: 46 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -27138,7 +27849,8 @@ exports[`Markdown component xss: 47 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -27162,12 +27874,18 @@ exports[`Markdown component xss: 47 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -27178,7 +27896,8 @@ exports[`Markdown component xss: 47 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -27429,7 +28148,8 @@ exports[`Markdown component xss: 47 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -27477,7 +28197,8 @@ exports[`Markdown component xss: 48 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -27501,12 +28222,18 @@ exports[`Markdown component xss: 48 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -27517,7 +28244,8 @@ exports[`Markdown component xss: 48 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -27768,7 +28496,8 @@ exports[`Markdown component xss: 48 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -27816,7 +28545,8 @@ exports[`Markdown component xss: 49 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -27840,12 +28570,18 @@ exports[`Markdown component xss: 49 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -27856,7 +28592,8 @@ exports[`Markdown component xss: 49 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -28107,7 +28844,8 @@ exports[`Markdown component xss: 49 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -28155,7 +28893,8 @@ exports[`Markdown component xss: 50 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -28179,12 +28918,18 @@ exports[`Markdown component xss: 50 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -28195,7 +28940,8 @@ exports[`Markdown component xss: 50 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -28446,7 +29192,8 @@ exports[`Markdown component xss: 50 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -28494,7 +29241,8 @@ exports[`Markdown component xss: 51 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -28518,12 +29266,18 @@ exports[`Markdown component xss: 51 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -28534,7 +29288,8 @@ exports[`Markdown component xss: 51 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -28785,7 +29540,8 @@ exports[`Markdown component xss: 51 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -28833,7 +29589,8 @@ exports[`Markdown component xss: 52 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -28857,12 +29614,18 @@ exports[`Markdown component xss: 52 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -28873,7 +29636,8 @@ exports[`Markdown component xss: 52 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -29124,7 +29888,8 @@ exports[`Markdown component xss: 52 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -29172,7 +29937,8 @@ exports[`Markdown component xss: 53 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -29196,12 +29962,18 @@ exports[`Markdown component xss: 53 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -29212,7 +29984,8 @@ exports[`Markdown component xss: 53 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -29463,7 +30236,8 @@ exports[`Markdown component xss: 53 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -29511,7 +30285,8 @@ exports[`Markdown component xss: 54 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -29535,12 +30310,18 @@ exports[`Markdown component xss: 54 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -29551,7 +30332,8 @@ exports[`Markdown component xss: 54 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -29802,7 +30584,8 @@ exports[`Markdown component xss: 54 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -29850,7 +30633,8 @@ exports[`Markdown component xss: 55 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -29874,12 +30658,18 @@ exports[`Markdown component xss: 55 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -29890,7 +30680,8 @@ exports[`Markdown component xss: 55 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -30141,7 +30932,8 @@ exports[`Markdown component xss: 55 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -30189,7 +30981,8 @@ exports[`Markdown component xss: 56 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -30213,12 +31006,18 @@ exports[`Markdown component xss: 56 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -30229,7 +31028,8 @@ exports[`Markdown component xss: 56 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -30480,7 +31280,8 @@ exports[`Markdown component xss: 56 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -30528,7 +31329,8 @@ exports[`Markdown component xss: 57 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -30552,12 +31354,18 @@ exports[`Markdown component xss: 57 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -30568,7 +31376,8 @@ exports[`Markdown component xss: 57 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -30819,7 +31628,8 @@ exports[`Markdown component xss: 57 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -30867,7 +31677,8 @@ exports[`Markdown component xss: 58 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -30891,12 +31702,18 @@ exports[`Markdown component xss: 58 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -30907,7 +31724,8 @@ exports[`Markdown component xss: 58 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -31158,7 +31976,8 @@ exports[`Markdown component xss: 58 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -31206,7 +32025,8 @@ exports[`Markdown component xss: 59 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -31230,12 +32050,18 @@ exports[`Markdown component xss: 59 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -31246,7 +32072,8 @@ exports[`Markdown component xss: 59 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -31497,7 +32324,8 @@ exports[`Markdown component xss: 59 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -31545,7 +32373,8 @@ exports[`Markdown component xss: 60 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -31569,12 +32398,18 @@ exports[`Markdown component xss: 60 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -31585,7 +32420,8 @@ exports[`Markdown component xss: 60 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -31836,7 +32672,8 @@ exports[`Markdown component xss: 60 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -31884,7 +32721,8 @@ exports[`Markdown component xss: 61 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -31908,12 +32746,18 @@ exports[`Markdown component xss: 61 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -31924,7 +32768,8 @@ exports[`Markdown component xss: 61 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -32175,7 +33020,8 @@ exports[`Markdown component xss: 61 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -32223,7 +33069,8 @@ exports[`Markdown component xss: 62 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -32247,12 +33094,18 @@ exports[`Markdown component xss: 62 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -32263,7 +33116,8 @@ exports[`Markdown component xss: 62 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -32514,7 +33368,8 @@ exports[`Markdown component xss: 62 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -32579,7 +33434,8 @@ exports[`Markdown component xss: 63 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -32603,12 +33459,18 @@ exports[`Markdown component xss: 63 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -32619,7 +33481,8 @@ exports[`Markdown component xss: 63 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -32870,7 +33733,8 @@ exports[`Markdown component xss: 63 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -32935,7 +33799,8 @@ exports[`Markdown component xss: 64 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -32959,12 +33824,18 @@ exports[`Markdown component xss: 64 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -32975,7 +33846,8 @@ exports[`Markdown component xss: 64 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -33226,7 +34098,8 @@ exports[`Markdown component xss: 64 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -33291,7 +34164,8 @@ exports[`Markdown component xss: 65 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -33315,12 +34189,18 @@ exports[`Markdown component xss: 65 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -33331,7 +34211,8 @@ exports[`Markdown component xss: 65 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -33582,7 +34463,8 @@ exports[`Markdown component xss: 65 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -33647,7 +34529,8 @@ exports[`Markdown component xss: 66 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -33671,12 +34554,18 @@ exports[`Markdown component xss: 66 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -33687,7 +34576,8 @@ exports[`Markdown component xss: 66 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -33938,7 +34828,8 @@ exports[`Markdown component xss: 66 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -34003,7 +34894,8 @@ exports[`Markdown component xss: 67 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -34027,12 +34919,18 @@ exports[`Markdown component xss: 67 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -34043,7 +34941,8 @@ exports[`Markdown component xss: 67 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -34294,7 +35193,8 @@ exports[`Markdown component xss: 67 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -34359,7 +35259,8 @@ exports[`Markdown component xss: 68 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -34383,12 +35284,18 @@ exports[`Markdown component xss: 68 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -34399,7 +35306,8 @@ exports[`Markdown component xss: 68 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -34650,7 +35558,8 @@ exports[`Markdown component xss: 68 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -34715,7 +35624,8 @@ exports[`Markdown component xss: 69 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -34739,12 +35649,18 @@ exports[`Markdown component xss: 69 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -34755,7 +35671,8 @@ exports[`Markdown component xss: 69 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -35006,7 +35923,8 @@ exports[`Markdown component xss: 69 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -35071,7 +35989,8 @@ exports[`Markdown component xss: 70 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -35095,12 +36014,18 @@ exports[`Markdown component xss: 70 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -35111,7 +36036,8 @@ exports[`Markdown component xss: 70 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -35362,7 +36288,8 @@ exports[`Markdown component xss: 70 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -35427,7 +36354,8 @@ exports[`Markdown component xss: 71 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -35451,12 +36379,18 @@ exports[`Markdown component xss: 71 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -35467,7 +36401,8 @@ exports[`Markdown component xss: 71 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -35718,7 +36653,8 @@ exports[`Markdown component xss: 71 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -35783,7 +36719,8 @@ exports[`Markdown component xss: 72 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -35807,12 +36744,18 @@ exports[`Markdown component xss: 72 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -35823,7 +36766,8 @@ exports[`Markdown component xss: 72 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -36074,7 +37018,8 @@ exports[`Markdown component xss: 72 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -36139,7 +37084,8 @@ exports[`Markdown component xss: 73 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -36163,12 +37109,18 @@ exports[`Markdown component xss: 73 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -36179,7 +37131,8 @@ exports[`Markdown component xss: 73 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -36430,7 +37383,8 @@ exports[`Markdown component xss: 73 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -36495,7 +37449,8 @@ exports[`Markdown component xss: 74 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -36519,12 +37474,18 @@ exports[`Markdown component xss: 74 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -36535,7 +37496,8 @@ exports[`Markdown component xss: 74 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -36786,7 +37748,8 @@ exports[`Markdown component xss: 74 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -36851,7 +37814,8 @@ exports[`Markdown component xss: 75 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -36875,12 +37839,18 @@ exports[`Markdown component xss: 75 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -36891,7 +37861,8 @@ exports[`Markdown component xss: 75 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -37142,7 +38113,8 @@ exports[`Markdown component xss: 75 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -37207,7 +38179,8 @@ exports[`Markdown component xss: 76 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -37231,12 +38204,18 @@ exports[`Markdown component xss: 76 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -37247,7 +38226,8 @@ exports[`Markdown component xss: 76 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -37498,7 +38478,8 @@ exports[`Markdown component xss: 76 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -37563,7 +38544,8 @@ exports[`Markdown component xss: 77 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -37587,12 +38569,18 @@ exports[`Markdown component xss: 77 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -37603,7 +38591,8 @@ exports[`Markdown component xss: 77 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -37854,7 +38843,8 @@ exports[`Markdown component xss: 77 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -37919,7 +38909,8 @@ exports[`Markdown component xss: 78 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -37943,12 +38934,18 @@ exports[`Markdown component xss: 78 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -37959,7 +38956,8 @@ exports[`Markdown component xss: 78 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -38210,7 +39208,8 @@ exports[`Markdown component xss: 78 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -38275,7 +39274,8 @@ exports[`Markdown component xss: 79 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -38299,12 +39299,18 @@ exports[`Markdown component xss: 79 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -38315,7 +39321,8 @@ exports[`Markdown component xss: 79 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -38566,7 +39573,8 @@ exports[`Markdown component xss: 79 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -38631,7 +39639,8 @@ exports[`Markdown component xss: 80 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -38655,12 +39664,18 @@ exports[`Markdown component xss: 80 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -38671,7 +39686,8 @@ exports[`Markdown component xss: 80 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -38922,7 +39938,8 @@ exports[`Markdown component xss: 80 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -38987,7 +40004,8 @@ exports[`Markdown component xss: 81 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -39011,12 +40029,18 @@ exports[`Markdown component xss: 81 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -39027,7 +40051,8 @@ exports[`Markdown component xss: 81 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -39278,7 +40303,8 @@ exports[`Markdown component xss: 81 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -39343,7 +40369,8 @@ exports[`Markdown component xss: 82 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -39367,12 +40394,18 @@ exports[`Markdown component xss: 82 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -39383,7 +40416,8 @@ exports[`Markdown component xss: 82 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -39634,7 +40668,8 @@ exports[`Markdown component xss: 82 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -39699,7 +40734,8 @@ exports[`Markdown component xss: 83 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -39723,12 +40759,18 @@ exports[`Markdown component xss: 83 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -39739,7 +40781,8 @@ exports[`Markdown component xss: 83 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -39990,7 +41033,8 @@ exports[`Markdown component xss: 83 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -40055,7 +41099,8 @@ exports[`Markdown component xss: 84 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -40079,12 +41124,18 @@ exports[`Markdown component xss: 84 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -40095,7 +41146,8 @@ exports[`Markdown component xss: 84 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -40346,7 +41398,8 @@ exports[`Markdown component xss: 84 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -40411,7 +41464,8 @@ exports[`Markdown component xss: 85 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -40435,12 +41489,18 @@ exports[`Markdown component xss: 85 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -40451,7 +41511,8 @@ exports[`Markdown component xss: 85 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -40702,7 +41763,8 @@ exports[`Markdown component xss: 85 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -40767,7 +41829,8 @@ exports[`Markdown component xss: 86 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -40791,12 +41854,18 @@ exports[`Markdown component xss: 86 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -40807,7 +41876,8 @@ exports[`Markdown component xss: 86 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -41058,7 +42128,8 @@ exports[`Markdown component xss: 86 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -41123,7 +42194,8 @@ exports[`Markdown component xss: 87 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -41147,12 +42219,18 @@ exports[`Markdown component xss: 87 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -41163,7 +42241,8 @@ exports[`Markdown component xss: 87 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -41414,7 +42493,8 @@ exports[`Markdown component xss: 87 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -41479,7 +42559,8 @@ exports[`Markdown component xss: 88 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -41503,12 +42584,18 @@ exports[`Markdown component xss: 88 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -41519,7 +42606,8 @@ exports[`Markdown component xss: 88 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -41770,7 +42858,8 @@ exports[`Markdown component xss: 88 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -41835,7 +42924,8 @@ exports[`Markdown component xss: 89 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -41859,12 +42949,18 @@ exports[`Markdown component xss: 89 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -41875,7 +42971,8 @@ exports[`Markdown component xss: 89 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -42126,7 +43223,8 @@ exports[`Markdown component xss: 89 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -42191,7 +43289,8 @@ exports[`Markdown component xss: 90 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -42215,12 +43314,18 @@ exports[`Markdown component xss: 90 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -42231,7 +43336,8 @@ exports[`Markdown component xss: 90 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -42482,7 +43588,8 @@ exports[`Markdown component xss: 90 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -42547,7 +43654,8 @@ exports[`Markdown component xss: 91 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -42571,12 +43679,18 @@ exports[`Markdown component xss: 91 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -42587,7 +43701,8 @@ exports[`Markdown component xss: 91 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -42838,7 +43953,8 @@ exports[`Markdown component xss: 91 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -42903,7 +44019,8 @@ exports[`Markdown component xss: 92 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -42927,12 +44044,18 @@ exports[`Markdown component xss: 92 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -42943,7 +44066,8 @@ exports[`Markdown component xss: 92 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -43194,7 +44318,8 @@ exports[`Markdown component xss: 92 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -43259,7 +44384,8 @@ exports[`Markdown component xss: 93 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -43283,12 +44409,18 @@ exports[`Markdown component xss: 93 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -43299,7 +44431,8 @@ exports[`Markdown component xss: 93 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -43550,7 +44683,8 @@ exports[`Markdown component xss: 93 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -43615,7 +44749,8 @@ exports[`Markdown component xss: 94 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -43639,12 +44774,18 @@ exports[`Markdown component xss: 94 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -43655,7 +44796,8 @@ exports[`Markdown component xss: 94 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -43906,7 +45048,8 @@ exports[`Markdown component xss: 94 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -43971,7 +45114,8 @@ exports[`Markdown component xss: 95 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -43995,12 +45139,18 @@ exports[`Markdown component xss: 95 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -44011,7 +45161,8 @@ exports[`Markdown component xss: 95 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -44262,7 +45413,8 @@ exports[`Markdown component xss: 95 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -44327,7 +45479,8 @@ exports[`Markdown component xss: 96 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -44351,12 +45504,18 @@ exports[`Markdown component xss: 96 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -44367,7 +45526,8 @@ exports[`Markdown component xss: 96 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -44618,7 +45778,8 @@ exports[`Markdown component xss: 96 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -44683,7 +45844,8 @@ exports[`Markdown component xss: 97 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -44707,12 +45869,18 @@ exports[`Markdown component xss: 97 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -44723,7 +45891,8 @@ exports[`Markdown component xss: 97 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -44974,7 +46143,8 @@ exports[`Markdown component xss: 97 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -45039,7 +46209,8 @@ exports[`Markdown component xss: 98 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -45063,12 +46234,18 @@ exports[`Markdown component xss: 98 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -45079,7 +46256,8 @@ exports[`Markdown component xss: 98 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -45330,7 +46508,8 @@ exports[`Markdown component xss: 98 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -45395,7 +46574,8 @@ exports[`Markdown component xss: 99 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -45419,12 +46599,18 @@ exports[`Markdown component xss: 99 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -45435,7 +46621,8 @@ exports[`Markdown component xss: 99 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -45686,7 +46873,8 @@ exports[`Markdown component xss: 99 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -45751,7 +46939,8 @@ exports[`Markdown component xss: 100 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -45775,12 +46964,18 @@ exports[`Markdown component xss: 100 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -45791,7 +46986,8 @@ exports[`Markdown component xss: 100 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -46042,7 +47238,8 @@ exports[`Markdown component xss: 100 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -46107,7 +47304,8 @@ exports[`Markdown component xss: 101 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -46131,12 +47329,18 @@ exports[`Markdown component xss: 101 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -46147,7 +47351,8 @@ exports[`Markdown component xss: 101 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -46398,7 +47603,8 @@ exports[`Markdown component xss: 101 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -46463,7 +47669,8 @@ exports[`Markdown component xss: 102 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -46487,12 +47694,18 @@ exports[`Markdown component xss: 102 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -46503,7 +47716,8 @@ exports[`Markdown component xss: 102 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -46754,7 +47968,8 @@ exports[`Markdown component xss: 102 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -46819,7 +48034,8 @@ exports[`Markdown component xss: 103 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -46843,12 +48059,18 @@ exports[`Markdown component xss: 103 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -46859,7 +48081,8 @@ exports[`Markdown component xss: 103 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -47110,7 +48333,8 @@ exports[`Markdown component xss: 103 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -47175,7 +48399,8 @@ exports[`Markdown component xss: 104 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -47199,12 +48424,18 @@ exports[`Markdown component xss: 104 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -47215,7 +48446,8 @@ exports[`Markdown component xss: 104 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -47466,7 +48698,8 @@ exports[`Markdown component xss: 104 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -47531,7 +48764,8 @@ exports[`Markdown component xss: 105 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -47555,12 +48789,18 @@ exports[`Markdown component xss: 105 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -47571,7 +48811,8 @@ exports[`Markdown component xss: 105 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -47822,7 +49063,8 @@ exports[`Markdown component xss: 105 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -47887,7 +49129,8 @@ exports[`Markdown component xss: 106 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -47911,12 +49154,18 @@ exports[`Markdown component xss: 106 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -47927,7 +49176,8 @@ exports[`Markdown component xss: 106 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -48178,7 +49428,8 @@ exports[`Markdown component xss: 106 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -48243,7 +49494,8 @@ exports[`Markdown component xss: 107 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -48267,12 +49519,18 @@ exports[`Markdown component xss: 107 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -48283,7 +49541,8 @@ exports[`Markdown component xss: 107 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -48534,7 +49793,8 @@ exports[`Markdown component xss: 107 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -48599,7 +49859,8 @@ exports[`Markdown component xss: 108 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -48623,12 +49884,18 @@ exports[`Markdown component xss: 108 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -48639,7 +49906,8 @@ exports[`Markdown component xss: 108 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -48890,7 +50158,8 @@ exports[`Markdown component xss: 108 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -48955,7 +50224,8 @@ exports[`Markdown component xss: 109 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -48979,12 +50249,18 @@ exports[`Markdown component xss: 109 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -48995,7 +50271,8 @@ exports[`Markdown component xss: 109 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -49246,7 +50523,8 @@ exports[`Markdown component xss: 109 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -49311,7 +50589,8 @@ exports[`Markdown component xss: 110 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -49335,12 +50614,18 @@ exports[`Markdown component xss: 110 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -49351,7 +50636,8 @@ exports[`Markdown component xss: 110 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -49602,7 +50888,8 @@ exports[`Markdown component xss: 110 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -49667,7 +50954,8 @@ exports[`Markdown component xss: 111 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -49691,12 +50979,18 @@ exports[`Markdown component xss: 111 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -49707,7 +51001,8 @@ exports[`Markdown component xss: 111 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -49958,7 +51253,8 @@ exports[`Markdown component xss: 111 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -50023,7 +51319,8 @@ exports[`Markdown component xss: 112 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -50047,12 +51344,18 @@ exports[`Markdown component xss: 112 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -50063,7 +51366,8 @@ exports[`Markdown component xss: 112 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -50314,7 +51618,8 @@ exports[`Markdown component xss: 112 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -50379,7 +51684,8 @@ exports[`Markdown component xss: 113 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -50403,12 +51709,18 @@ exports[`Markdown component xss: 113 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -50419,7 +51731,8 @@ exports[`Markdown component xss: 113 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -50670,7 +51983,8 @@ exports[`Markdown component xss: 113 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -50735,7 +52049,8 @@ exports[`Markdown component xss: 114 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -50759,12 +52074,18 @@ exports[`Markdown component xss: 114 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -50775,7 +52096,8 @@ exports[`Markdown component xss: 114 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -51026,7 +52348,8 @@ exports[`Markdown component xss: 114 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -51091,7 +52414,8 @@ exports[`Markdown component xss: 115 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -51115,12 +52439,18 @@ exports[`Markdown component xss: 115 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -51131,7 +52461,8 @@ exports[`Markdown component xss: 115 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -51382,7 +52713,8 @@ exports[`Markdown component xss: 115 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -51447,7 +52779,8 @@ exports[`Markdown component xss: 116 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -51471,12 +52804,18 @@ exports[`Markdown component xss: 116 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -51487,7 +52826,8 @@ exports[`Markdown component xss: 116 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -51738,7 +53078,8 @@ exports[`Markdown component xss: 116 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -51803,7 +53144,8 @@ exports[`Markdown component xss: 117 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -51827,12 +53169,18 @@ exports[`Markdown component xss: 117 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -51843,7 +53191,8 @@ exports[`Markdown component xss: 117 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -52094,7 +53443,8 @@ exports[`Markdown component xss: 117 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -52159,7 +53509,8 @@ exports[`Markdown component xss: 118 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -52183,12 +53534,18 @@ exports[`Markdown component xss: 118 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -52199,7 +53556,8 @@ exports[`Markdown component xss: 118 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -52450,7 +53808,8 @@ exports[`Markdown component xss: 118 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -52515,7 +53874,8 @@ exports[`Markdown component xss: 119 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -52539,12 +53899,18 @@ exports[`Markdown component xss: 119 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -52555,7 +53921,8 @@ exports[`Markdown component xss: 119 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -52806,7 +54173,8 @@ exports[`Markdown component xss: 119 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -52854,7 +54222,8 @@ exports[`Markdown component xss: 120 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -52878,12 +54247,18 @@ exports[`Markdown component xss: 120 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -52894,7 +54269,8 @@ exports[`Markdown component xss: 120 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -53145,7 +54521,8 @@ exports[`Markdown component xss: 120 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -53187,7 +54564,8 @@ exports[`Markdown component xss: 121 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -53211,12 +54589,18 @@ exports[`Markdown component xss: 121 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -53227,7 +54611,8 @@ exports[`Markdown component xss: 121 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -53478,7 +54863,8 @@ exports[`Markdown component xss: 121 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -53520,7 +54906,8 @@ exports[`Markdown component xss: 122 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -53544,12 +54931,18 @@ exports[`Markdown component xss: 122 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -53560,7 +54953,8 @@ exports[`Markdown component xss: 122 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -53811,7 +55205,8 @@ exports[`Markdown component xss: 122 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -53853,7 +55248,8 @@ exports[`Markdown component xss: 123 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -53877,12 +55273,18 @@ exports[`Markdown component xss: 123 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -53893,7 +55295,8 @@ exports[`Markdown component xss: 123 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -54144,7 +55547,8 @@ exports[`Markdown component xss: 123 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -54186,7 +55590,8 @@ exports[`Markdown component xss: 124 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -54210,12 +55615,18 @@ exports[`Markdown component xss: 124 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -54226,7 +55637,8 @@ exports[`Markdown component xss: 124 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -54477,7 +55889,8 @@ exports[`Markdown component xss: 124 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -54519,7 +55932,8 @@ exports[`Markdown component xss: 125 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -54543,12 +55957,18 @@ exports[`Markdown component xss: 125 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -54559,7 +55979,8 @@ exports[`Markdown component xss: 125 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -54810,7 +56231,8 @@ exports[`Markdown component xss: 125 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -54852,7 +56274,8 @@ exports[`Markdown component xss: 126 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -54876,12 +56299,18 @@ exports[`Markdown component xss: 126 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -54892,7 +56321,8 @@ exports[`Markdown component xss: 126 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -55143,7 +56573,8 @@ exports[`Markdown component xss: 126 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -55185,7 +56616,8 @@ exports[`Markdown component xss: 127 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -55209,12 +56641,18 @@ exports[`Markdown component xss: 127 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -55225,7 +56663,8 @@ exports[`Markdown component xss: 127 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -55476,7 +56915,8 @@ exports[`Markdown component xss: 127 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -55518,7 +56958,8 @@ exports[`Markdown component xss: 128 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -55542,12 +56983,18 @@ exports[`Markdown component xss: 128 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -55558,7 +57005,8 @@ exports[`Markdown component xss: 128 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -55809,7 +57257,8 @@ exports[`Markdown component xss: 128 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -55851,7 +57300,8 @@ exports[`Markdown component xss: 129 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -55875,12 +57325,18 @@ exports[`Markdown component xss: 129 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -55891,7 +57347,8 @@ exports[`Markdown component xss: 129 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -56142,7 +57599,8 @@ exports[`Markdown component xss: 129 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -56184,7 +57642,8 @@ exports[`Markdown component xss: 130 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -56208,12 +57667,18 @@ exports[`Markdown component xss: 130 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -56224,7 +57689,8 @@ exports[`Markdown component xss: 130 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -56475,7 +57941,8 @@ exports[`Markdown component xss: 130 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -56517,7 +57984,8 @@ exports[`Markdown component xss: 131 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -56541,12 +58009,18 @@ exports[`Markdown component xss: 131 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -56557,7 +58031,8 @@ exports[`Markdown component xss: 131 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -56808,7 +58283,8 @@ exports[`Markdown component xss: 131 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -56850,7 +58326,8 @@ exports[`Markdown component xss: 132 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -56874,12 +58351,18 @@ exports[`Markdown component xss: 132 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -56890,7 +58373,8 @@ exports[`Markdown component xss: 132 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -57141,7 +58625,8 @@ exports[`Markdown component xss: 132 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -57183,7 +58668,8 @@ exports[`Markdown component xss: 133 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -57207,12 +58693,18 @@ exports[`Markdown component xss: 133 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -57223,7 +58715,8 @@ exports[`Markdown component xss: 133 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -57474,7 +58967,8 @@ exports[`Markdown component xss: 133 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -57516,7 +59010,8 @@ exports[`Markdown component xss: 134 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -57540,12 +59035,18 @@ exports[`Markdown component xss: 134 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -57556,7 +59057,8 @@ exports[`Markdown component xss: 134 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -57807,7 +59309,8 @@ exports[`Markdown component xss: 134 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -57849,7 +59352,8 @@ exports[`Markdown component xss: 135 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -57873,12 +59377,18 @@ exports[`Markdown component xss: 135 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -57889,7 +59399,8 @@ exports[`Markdown component xss: 135 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -58140,7 +59651,8 @@ exports[`Markdown component xss: 135 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -58182,7 +59694,8 @@ exports[`Markdown component xss: 136 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -58206,12 +59719,18 @@ exports[`Markdown component xss: 136 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -58222,7 +59741,8 @@ exports[`Markdown component xss: 136 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -58473,7 +59993,8 @@ exports[`Markdown component xss: 136 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -58515,7 +60036,8 @@ exports[`Markdown component xss: 137 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -58539,12 +60061,18 @@ exports[`Markdown component xss: 137 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -58555,7 +60083,8 @@ exports[`Markdown component xss: 137 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -58806,7 +60335,8 @@ exports[`Markdown component xss: 137 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -58848,7 +60378,8 @@ exports[`Markdown component xss: 138 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -58872,12 +60403,18 @@ exports[`Markdown component xss: 138 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -58888,7 +60425,8 @@ exports[`Markdown component xss: 138 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -59139,7 +60677,8 @@ exports[`Markdown component xss: 138 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -59181,7 +60720,8 @@ exports[`Markdown component xss: 139 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -59205,12 +60745,18 @@ exports[`Markdown component xss: 139 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -59221,7 +60767,8 @@ exports[`Markdown component xss: 139 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -59472,7 +61019,8 @@ exports[`Markdown component xss: 139 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -59514,7 +61062,8 @@ exports[`Markdown component xss: 140 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -59538,12 +61087,18 @@ exports[`Markdown component xss: 140 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -59554,7 +61109,8 @@ exports[`Markdown component xss: 140 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -59805,7 +61361,8 @@ exports[`Markdown component xss: 140 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -59847,7 +61404,8 @@ exports[`Markdown component xss: 141 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -59871,12 +61429,18 @@ exports[`Markdown component xss: 141 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -59887,7 +61451,8 @@ exports[`Markdown component xss: 141 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -60138,7 +61703,8 @@ exports[`Markdown component xss: 141 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -60180,7 +61746,8 @@ exports[`Markdown component xss: 142 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -60204,12 +61771,18 @@ exports[`Markdown component xss: 142 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -60220,7 +61793,8 @@ exports[`Markdown component xss: 142 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -60471,7 +62045,8 @@ exports[`Markdown component xss: 142 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -60513,7 +62088,8 @@ exports[`Markdown component xss: 143 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -60537,12 +62113,18 @@ exports[`Markdown component xss: 143 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -60553,7 +62135,8 @@ exports[`Markdown component xss: 143 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -60804,7 +62387,8 @@ exports[`Markdown component xss: 143 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -60846,7 +62430,8 @@ exports[`Markdown component xss: 144 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -60870,12 +62455,18 @@ exports[`Markdown component xss: 144 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -60886,7 +62477,8 @@ exports[`Markdown component xss: 144 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -61137,7 +62729,8 @@ exports[`Markdown component xss: 144 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -61179,7 +62772,8 @@ exports[`Markdown component xss: 145 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -61203,12 +62797,18 @@ exports[`Markdown component xss: 145 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -61219,7 +62819,8 @@ exports[`Markdown component xss: 145 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -61470,7 +63071,8 @@ exports[`Markdown component xss: 145 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -61512,7 +63114,8 @@ exports[`Markdown component xss: 146 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -61536,12 +63139,18 @@ exports[`Markdown component xss: 146 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -61552,7 +63161,8 @@ exports[`Markdown component xss: 146 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -61803,7 +63413,8 @@ exports[`Markdown component xss: 146 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -61845,7 +63456,8 @@ exports[`Markdown component xss: 147 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -61869,12 +63481,18 @@ exports[`Markdown component xss: 147 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -61885,7 +63503,8 @@ exports[`Markdown component xss: 147 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -62136,7 +63755,8 @@ exports[`Markdown component xss: 147 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -62178,7 +63798,8 @@ exports[`Markdown component xss: 148 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -62202,12 +63823,18 @@ exports[`Markdown component xss: 148 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -62218,7 +63845,8 @@ exports[`Markdown component xss: 148 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -62469,7 +64097,8 @@ exports[`Markdown component xss: 148 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -62511,7 +64140,8 @@ exports[`Markdown component xss: 149 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -62535,12 +64165,18 @@ exports[`Markdown component xss: 149 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -62551,7 +64187,8 @@ exports[`Markdown component xss: 149 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -62802,7 +64439,8 @@ exports[`Markdown component xss: 149 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -62844,7 +64482,8 @@ exports[`Markdown component xss: 150 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -62868,12 +64507,18 @@ exports[`Markdown component xss: 150 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -62884,7 +64529,8 @@ exports[`Markdown component xss: 150 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -63135,7 +64781,8 @@ exports[`Markdown component xss: 150 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -63177,7 +64824,8 @@ exports[`Markdown component xss: 151 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -63201,12 +64849,18 @@ exports[`Markdown component xss: 151 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -63217,7 +64871,8 @@ exports[`Markdown component xss: 151 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -63468,7 +65123,8 @@ exports[`Markdown component xss: 151 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -63510,7 +65166,8 @@ exports[`Markdown component xss: 152 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -63534,12 +65191,18 @@ exports[`Markdown component xss: 152 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -63550,7 +65213,8 @@ exports[`Markdown component xss: 152 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -63801,7 +65465,8 @@ exports[`Markdown component xss: 152 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -63843,7 +65508,8 @@ exports[`Markdown component xss: 153 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -63867,12 +65533,18 @@ exports[`Markdown component xss: 153 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -63883,7 +65555,8 @@ exports[`Markdown component xss: 153 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -64134,7 +65807,8 @@ exports[`Markdown component xss: 153 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -64176,7 +65850,8 @@ exports[`Markdown component xss: 154 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -64200,12 +65875,18 @@ exports[`Markdown component xss: 154 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -64216,7 +65897,8 @@ exports[`Markdown component xss: 154 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -64467,7 +66149,8 @@ exports[`Markdown component xss: 154 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -64509,7 +66192,8 @@ exports[`Markdown component xss: 155 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -64533,12 +66217,18 @@ exports[`Markdown component xss: 155 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -64549,7 +66239,8 @@ exports[`Markdown component xss: 155 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -64800,7 +66491,8 @@ exports[`Markdown component xss: 155 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -64842,7 +66534,8 @@ exports[`Markdown component xss: 156 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -64866,12 +66559,18 @@ exports[`Markdown component xss: 156 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -64882,7 +66581,8 @@ exports[`Markdown component xss: 156 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -65133,7 +66833,8 @@ exports[`Markdown component xss: 156 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -65175,7 +66876,8 @@ exports[`Markdown component xss: 157 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -65199,12 +66901,18 @@ exports[`Markdown component xss: 157 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -65215,7 +66923,8 @@ exports[`Markdown component xss: 157 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -65466,7 +67175,8 @@ exports[`Markdown component xss: 157 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -65508,7 +67218,8 @@ exports[`Markdown component xss: 158 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -65532,12 +67243,18 @@ exports[`Markdown component xss: 158 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -65548,7 +67265,8 @@ exports[`Markdown component xss: 158 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -65799,7 +67517,8 @@ exports[`Markdown component xss: 158 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -65841,7 +67560,8 @@ exports[`Markdown component xss: 159 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -65865,12 +67585,18 @@ exports[`Markdown component xss: 159 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -65881,7 +67607,8 @@ exports[`Markdown component xss: 159 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -66132,7 +67859,8 @@ exports[`Markdown component xss: 159 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -66174,7 +67902,8 @@ exports[`Markdown component xss: 160 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -66198,12 +67927,18 @@ exports[`Markdown component xss: 160 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -66214,7 +67949,8 @@ exports[`Markdown component xss: 160 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -66465,7 +68201,8 @@ exports[`Markdown component xss: 160 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -66507,7 +68244,8 @@ exports[`Markdown component xss: 161 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -66531,12 +68269,18 @@ exports[`Markdown component xss: 161 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -66547,7 +68291,8 @@ exports[`Markdown component xss: 161 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -66798,7 +68543,8 @@ exports[`Markdown component xss: 161 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -66840,7 +68586,8 @@ exports[`Markdown component xss: 162 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -66864,12 +68611,18 @@ exports[`Markdown component xss: 162 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -66880,7 +68633,8 @@ exports[`Markdown component xss: 162 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -67131,7 +68885,8 @@ exports[`Markdown component xss: 162 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -67173,7 +68928,8 @@ exports[`Markdown component xss: 163 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -67197,12 +68953,18 @@ exports[`Markdown component xss: 163 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -67213,7 +68975,8 @@ exports[`Markdown component xss: 163 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -67464,7 +69227,8 @@ exports[`Markdown component xss: 163 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -67506,7 +69270,8 @@ exports[`Markdown component xss: 164 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -67530,12 +69295,18 @@ exports[`Markdown component xss: 164 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -67546,7 +69317,8 @@ exports[`Markdown component xss: 164 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -67797,7 +69569,8 @@ exports[`Markdown component xss: 164 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -67839,7 +69612,8 @@ exports[`Markdown component xss: 165 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -67863,12 +69637,18 @@ exports[`Markdown component xss: 165 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -67879,7 +69659,8 @@ exports[`Markdown component xss: 165 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -68130,7 +69911,8 @@ exports[`Markdown component xss: 165 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -68172,7 +69954,8 @@ exports[`Markdown component xss: 166 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -68196,12 +69979,18 @@ exports[`Markdown component xss: 166 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -68212,7 +70001,8 @@ exports[`Markdown component xss: 166 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -68463,7 +70253,8 @@ exports[`Markdown component xss: 166 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -68505,7 +70296,8 @@ exports[`Markdown component xss: 167 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -68529,12 +70321,18 @@ exports[`Markdown component xss: 167 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -68545,7 +70343,8 @@ exports[`Markdown component xss: 167 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -68796,7 +70595,8 @@ exports[`Markdown component xss: 167 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -68838,7 +70638,8 @@ exports[`Markdown component xss: 168 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -68862,12 +70663,18 @@ exports[`Markdown component xss: 168 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -68878,7 +70685,8 @@ exports[`Markdown component xss: 168 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -69129,7 +70937,8 @@ exports[`Markdown component xss: 168 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -69171,7 +70980,8 @@ exports[`Markdown component xss: 169 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -69195,12 +71005,18 @@ exports[`Markdown component xss: 169 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -69211,7 +71027,8 @@ exports[`Markdown component xss: 169 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -69462,7 +71279,8 @@ exports[`Markdown component xss: 169 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -69504,7 +71322,8 @@ exports[`Markdown component xss: 170 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -69528,12 +71347,18 @@ exports[`Markdown component xss: 170 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -69544,7 +71369,8 @@ exports[`Markdown component xss: 170 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -69795,7 +71621,8 @@ exports[`Markdown component xss: 170 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -69837,7 +71664,8 @@ exports[`Markdown component xss: 171 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -69861,12 +71689,18 @@ exports[`Markdown component xss: 171 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -69877,7 +71711,8 @@ exports[`Markdown component xss: 171 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -70128,7 +71963,8 @@ exports[`Markdown component xss: 171 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -70170,7 +72006,8 @@ exports[`Markdown component xss: 172 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -70194,12 +72031,18 @@ exports[`Markdown component xss: 172 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -70210,7 +72053,8 @@ exports[`Markdown component xss: 172 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -70461,7 +72305,8 @@ exports[`Markdown component xss: 172 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -70503,7 +72348,8 @@ exports[`Markdown component xss: 173 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -70527,12 +72373,18 @@ exports[`Markdown component xss: 173 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -70543,7 +72395,8 @@ exports[`Markdown component xss: 173 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -70794,7 +72647,8 @@ exports[`Markdown component xss: 173 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -70836,7 +72690,8 @@ exports[`Markdown component xss: 174 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -70860,12 +72715,18 @@ exports[`Markdown component xss: 174 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -70876,7 +72737,8 @@ exports[`Markdown component xss: 174 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -71127,7 +72989,8 @@ exports[`Markdown component xss: 174 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -71169,7 +73032,8 @@ exports[`Markdown component xss: 175 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -71193,12 +73057,18 @@ exports[`Markdown component xss: 175 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -71209,7 +73079,8 @@ exports[`Markdown component xss: 175 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -71460,7 +73331,8 @@ exports[`Markdown component xss: 175 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -71502,7 +73374,8 @@ exports[`Markdown component xss: 176 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -71526,12 +73399,18 @@ exports[`Markdown component xss: 176 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -71542,7 +73421,8 @@ exports[`Markdown component xss: 176 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -71793,7 +73673,8 @@ exports[`Markdown component xss: 176 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -71835,7 +73716,8 @@ exports[`Markdown component xss: 177 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -71859,12 +73741,18 @@ exports[`Markdown component xss: 177 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -71875,7 +73763,8 @@ exports[`Markdown component xss: 177 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -72126,7 +74015,8 @@ exports[`Markdown component xss: 177 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -72168,7 +74058,8 @@ exports[`Markdown component xss: 178 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -72192,12 +74083,18 @@ exports[`Markdown component xss: 178 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -72208,7 +74105,8 @@ exports[`Markdown component xss: 178 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -72459,7 +74357,8 @@ exports[`Markdown component xss: 178 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -72501,7 +74400,8 @@ exports[`Markdown component xss: 179 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -72525,12 +74425,18 @@ exports[`Markdown component xss: 179 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -72541,7 +74447,8 @@ exports[`Markdown component xss: 179 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -72792,7 +74699,8 @@ exports[`Markdown component xss: 179 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -72834,7 +74742,8 @@ exports[`Markdown component xss: 180 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -72858,12 +74767,18 @@ exports[`Markdown component xss: 180 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -72874,7 +74789,8 @@ exports[`Markdown component xss: 180 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -73125,7 +75041,8 @@ exports[`Markdown component xss: 180 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -73167,7 +75084,8 @@ exports[`Markdown component xss: 181 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -73191,12 +75109,18 @@ exports[`Markdown component xss: 181 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -73207,7 +75131,8 @@ exports[`Markdown component xss: 181 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -73458,7 +75383,8 @@ exports[`Markdown component xss: 181 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -73500,7 +75426,8 @@ exports[`Markdown component xss: 182 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -73524,12 +75451,18 @@ exports[`Markdown component xss: 182 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -73540,7 +75473,8 @@ exports[`Markdown component xss: 182 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -73791,7 +75725,8 @@ exports[`Markdown component xss: 182 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -73833,7 +75768,8 @@ exports[`Markdown component xss: 183 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -73857,12 +75793,18 @@ exports[`Markdown component xss: 183 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -73873,7 +75815,8 @@ exports[`Markdown component xss: 183 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -74124,7 +76067,8 @@ exports[`Markdown component xss: 183 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -74166,7 +76110,8 @@ exports[`Markdown component xss: 184 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -74190,12 +76135,18 @@ exports[`Markdown component xss: 184 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -74206,7 +76157,8 @@ exports[`Markdown component xss: 184 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -74457,7 +76409,8 @@ exports[`Markdown component xss: 184 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -74499,7 +76452,8 @@ exports[`Markdown component xss: 185 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -74523,12 +76477,18 @@ exports[`Markdown component xss: 185 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -74539,7 +76499,8 @@ exports[`Markdown component xss: 185 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -74790,7 +76751,8 @@ exports[`Markdown component xss: 185 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -74832,7 +76794,8 @@ exports[`Markdown component xss: 186 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -74856,12 +76819,18 @@ exports[`Markdown component xss: 186 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -74872,7 +76841,8 @@ exports[`Markdown component xss: 186 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -75123,7 +77093,8 @@ exports[`Markdown component xss: 186 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -75165,7 +77136,8 @@ exports[`Markdown component xss: 187 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -75189,12 +77161,18 @@ exports[`Markdown component xss: 187 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -75205,7 +77183,8 @@ exports[`Markdown component xss: 187 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -75456,7 +77435,8 @@ exports[`Markdown component xss: 187 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -75498,7 +77478,8 @@ exports[`Markdown component xss: 188 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -75522,12 +77503,18 @@ exports[`Markdown component xss: 188 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -75538,7 +77525,8 @@ exports[`Markdown component xss: 188 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -75789,7 +77777,8 @@ exports[`Markdown component xss: 188 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -75831,7 +77820,8 @@ exports[`Markdown component xss: 189 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -75855,12 +77845,18 @@ exports[`Markdown component xss: 189 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -75871,7 +77867,8 @@ exports[`Markdown component xss: 189 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -76122,7 +78119,8 @@ exports[`Markdown component xss: 189 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -76164,7 +78162,8 @@ exports[`Markdown component xss: 190 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -76188,12 +78187,18 @@ exports[`Markdown component xss: 190 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -76204,7 +78209,8 @@ exports[`Markdown component xss: 190 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -76455,7 +78461,8 @@ exports[`Markdown component xss: 190 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -76497,7 +78504,8 @@ exports[`Markdown component xss: 191 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -76521,12 +78529,18 @@ exports[`Markdown component xss: 191 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -76537,7 +78551,8 @@ exports[`Markdown component xss: 191 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -76788,7 +78803,8 @@ exports[`Markdown component xss: 191 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -76830,7 +78846,8 @@ exports[`Markdown component xss: 192 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -76854,12 +78871,18 @@ exports[`Markdown component xss: 192 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -76870,7 +78893,8 @@ exports[`Markdown component xss: 192 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -77121,7 +79145,8 @@ exports[`Markdown component xss: 192 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -77163,7 +79188,8 @@ exports[`Markdown component xss: 193 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -77187,12 +79213,18 @@ exports[`Markdown component xss: 193 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -77203,7 +79235,8 @@ exports[`Markdown component xss: 193 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -77454,7 +79487,8 @@ exports[`Markdown component xss: 193 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -77496,7 +79530,8 @@ exports[`Markdown component xss: 194 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -77520,12 +79555,18 @@ exports[`Markdown component xss: 194 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -77536,7 +79577,8 @@ exports[`Markdown component xss: 194 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -77787,7 +79829,8 @@ exports[`Markdown component xss: 194 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -77829,7 +79872,8 @@ exports[`Markdown component xss: 195 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -77853,12 +79897,18 @@ exports[`Markdown component xss: 195 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -77869,7 +79919,8 @@ exports[`Markdown component xss: 195 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -78120,7 +80171,8 @@ exports[`Markdown component xss: 195 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -78162,7 +80214,8 @@ exports[`Markdown component xss: 196 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -78186,12 +80239,18 @@ exports[`Markdown component xss: 196 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -78202,7 +80261,8 @@ exports[`Markdown component xss: 196 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -78453,7 +80513,8 @@ exports[`Markdown component xss: 196 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -78495,7 +80556,8 @@ exports[`Markdown component xss: 197 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -78519,12 +80581,18 @@ exports[`Markdown component xss: 197 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -78535,7 +80603,8 @@ exports[`Markdown component xss: 197 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -78786,7 +80855,8 @@ exports[`Markdown component xss: 197 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -78828,7 +80898,8 @@ exports[`Markdown component xss: 198 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -78852,12 +80923,18 @@ exports[`Markdown component xss: 198 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -78868,7 +80945,8 @@ exports[`Markdown component xss: 198 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -79119,7 +81197,8 @@ exports[`Markdown component xss: 198 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -79161,7 +81240,8 @@ exports[`Markdown component xss: 199 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -79185,12 +81265,18 @@ exports[`Markdown component xss: 199 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -79201,7 +81287,8 @@ exports[`Markdown component xss: 199 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -79452,7 +81539,8 @@ exports[`Markdown component xss: 199 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -79494,7 +81582,8 @@ exports[`Markdown component xss: 200 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -79518,12 +81607,18 @@ exports[`Markdown component xss: 200 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -79534,7 +81629,8 @@ exports[`Markdown component xss: 200 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -79785,7 +81881,8 @@ exports[`Markdown component xss: 200 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -79844,7 +81941,8 @@ exports[`Markdown component xss: 201 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -79868,12 +81966,18 @@ exports[`Markdown component xss: 201 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -79884,7 +81988,8 @@ exports[`Markdown component xss: 201 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -80135,7 +82240,8 @@ exports[`Markdown component xss: 201 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -80182,7 +82288,8 @@ exports[`Markdown component xss: 202 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -80206,12 +82313,18 @@ exports[`Markdown component xss: 202 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -80222,7 +82335,8 @@ exports[`Markdown component xss: 202 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -80473,7 +82587,8 @@ exports[`Markdown component xss: 202 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -80523,7 +82638,8 @@ exports[`Markdown component xss: 203 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -80547,12 +82663,18 @@ exports[`Markdown component xss: 203 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -80563,7 +82685,8 @@ exports[`Markdown component xss: 203 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -80814,7 +82937,8 @@ exports[`Markdown component xss: 203 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -80856,7 +82980,8 @@ exports[`Markdown component xss: 204 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -80880,12 +83005,18 @@ exports[`Markdown component xss: 204 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -80896,7 +83027,8 @@ exports[`Markdown component xss: 204 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -81147,7 +83279,8 @@ exports[`Markdown component xss: 204 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -81200,7 +83333,8 @@ exports[`Markdown component xss: 205 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -81224,12 +83358,18 @@ exports[`Markdown component xss: 205 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -81240,7 +83380,8 @@ exports[`Markdown component xss: 205 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -81491,7 +83632,8 @@ exports[`Markdown component xss: 205 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -81543,7 +83685,8 @@ exports[`Markdown component xss: 206 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -81567,12 +83710,18 @@ exports[`Markdown component xss: 206 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -81583,7 +83732,8 @@ exports[`Markdown component xss: 206 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -81834,7 +83984,8 @@ exports[`Markdown component xss: 206 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -81870,7 +84021,8 @@ exports[`Markdown component xss: 207 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -81894,12 +84046,18 @@ exports[`Markdown component xss: 207 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -81910,7 +84068,8 @@ exports[`Markdown component xss: 207 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -82161,7 +84320,8 @@ exports[`Markdown component xss: 207 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -82197,7 +84357,8 @@ exports[`Markdown component xss: 208 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -82221,12 +84382,18 @@ exports[`Markdown component xss: 208 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -82237,7 +84404,8 @@ exports[`Markdown component xss: 208 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -82488,7 +84656,8 @@ exports[`Markdown component xss: 208 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -82524,7 +84693,8 @@ exports[`Markdown component xss: 209 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -82548,12 +84718,18 @@ exports[`Markdown component xss: 209 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -82564,7 +84740,8 @@ exports[`Markdown component xss: 209 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -82815,7 +84992,8 @@ exports[`Markdown component xss: 209 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -82851,7 +85029,8 @@ exports[`Markdown component xss: 210 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -82875,12 +85054,18 @@ exports[`Markdown component xss: 210 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -82891,7 +85076,8 @@ exports[`Markdown component xss: 210 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -83142,7 +85328,8 @@ exports[`Markdown component xss: 210 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -83185,7 +85372,8 @@ exports[`Markdown component xss: 211 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -83209,12 +85397,18 @@ exports[`Markdown component xss: 211 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -83225,7 +85419,8 @@ exports[`Markdown component xss: 211 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -83476,7 +85671,8 @@ exports[`Markdown component xss: 211 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -83514,7 +85710,8 @@ exports[`Markdown component xss: 212 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -83538,12 +85735,18 @@ exports[`Markdown component xss: 212 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -83554,7 +85757,8 @@ exports[`Markdown component xss: 212 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -83805,7 +86009,8 @@ exports[`Markdown component xss: 212 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -83845,7 +86050,8 @@ exports[`Markdown component xss: 213 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -83869,12 +86075,18 @@ exports[`Markdown component xss: 213 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -83885,7 +86097,8 @@ exports[`Markdown component xss: 213 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -84136,7 +86349,8 @@ exports[`Markdown component xss: 213 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -84178,7 +86392,8 @@ exports[`Markdown component xss: 214 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -84202,12 +86417,18 @@ exports[`Markdown component xss: 214 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -84218,7 +86439,8 @@ exports[`Markdown component xss: 214 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -84469,7 +86691,8 @@ exports[`Markdown component xss: 214 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -84507,7 +86730,8 @@ exports[`Markdown component xss: 215 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -84531,12 +86755,18 @@ exports[`Markdown component xss: 215 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -84547,7 +86777,8 @@ exports[`Markdown component xss: 215 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -84798,7 +87029,8 @@ exports[`Markdown component xss: 215 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -84836,7 +87068,8 @@ exports[`Markdown component xss: 216 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -84860,12 +87093,18 @@ exports[`Markdown component xss: 216 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -84876,7 +87115,8 @@ exports[`Markdown component xss: 216 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -85127,7 +87367,8 @@ exports[`Markdown component xss: 216 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -85165,7 +87406,8 @@ exports[`Markdown component xss: 217 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -85189,12 +87431,18 @@ exports[`Markdown component xss: 217 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -85205,7 +87453,8 @@ exports[`Markdown component xss: 217 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -85456,7 +87705,8 @@ exports[`Markdown component xss: 217 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -85494,7 +87744,8 @@ exports[`Markdown component xss: 218 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -85518,12 +87769,18 @@ exports[`Markdown component xss: 218 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -85534,7 +87791,8 @@ exports[`Markdown component xss: 218 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -85785,7 +88043,8 @@ exports[`Markdown component xss: 218 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -85823,7 +88082,8 @@ exports[`Markdown component xss: 219 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -85847,12 +88107,18 @@ exports[`Markdown component xss: 219 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -85863,7 +88129,8 @@ exports[`Markdown component xss: 219 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -86114,7 +88381,8 @@ exports[`Markdown component xss: 219 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -86152,7 +88420,8 @@ exports[`Markdown component xss: 220 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -86176,12 +88445,18 @@ exports[`Markdown component xss: 220 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -86192,7 +88467,8 @@ exports[`Markdown component xss: 220 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -86443,7 +88719,8 @@ exports[`Markdown component xss: 220 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -86481,7 +88758,8 @@ exports[`Markdown component xss: 221 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -86505,12 +88783,18 @@ exports[`Markdown component xss: 221 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -86521,7 +88805,8 @@ exports[`Markdown component xss: 221 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -86772,7 +89057,8 @@ exports[`Markdown component xss: 221 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -86810,7 +89096,8 @@ exports[`Markdown component xss: 222 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -86834,12 +89121,18 @@ exports[`Markdown component xss: 222 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -86850,7 +89143,8 @@ exports[`Markdown component xss: 222 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -87101,7 +89395,8 @@ exports[`Markdown component xss: 222 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -87143,7 +89438,8 @@ exports[`Markdown component xss: 223 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -87167,12 +89463,18 @@ exports[`Markdown component xss: 223 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -87183,7 +89485,8 @@ exports[`Markdown component xss: 223 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -87434,7 +89737,8 @@ exports[`Markdown component xss: 223 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -87489,7 +89793,8 @@ exports[`Markdown component xss: 224 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -87513,12 +89818,18 @@ exports[`Markdown component xss: 224 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -87529,7 +89840,8 @@ exports[`Markdown component xss: 224 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -87780,7 +90092,8 @@ exports[`Markdown component xss: 224 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -87829,7 +90142,8 @@ exports[`Markdown component xss: 225 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -87853,12 +90167,18 @@ exports[`Markdown component xss: 225 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -87869,7 +90189,8 @@ exports[`Markdown component xss: 225 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -88120,7 +90441,8 @@ exports[`Markdown component xss: 225 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -88173,7 +90495,8 @@ exports[`Markdown component xss: 226 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -88197,12 +90520,18 @@ exports[`Markdown component xss: 226 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -88213,7 +90542,8 @@ exports[`Markdown component xss: 226 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -88464,7 +90794,8 @@ exports[`Markdown component xss: 226 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -88511,7 +90842,8 @@ exports[`Markdown component xss: 227 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -88535,12 +90867,18 @@ exports[`Markdown component xss: 227 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -88551,7 +90889,8 @@ exports[`Markdown component xss: 227 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -88802,7 +91141,8 @@ exports[`Markdown component xss: 227 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -88844,7 +91184,8 @@ exports[`Markdown component xss: 228 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -88868,12 +91209,18 @@ exports[`Markdown component xss: 228 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -88884,7 +91231,8 @@ exports[`Markdown component xss: 228 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -89135,7 +91483,8 @@ exports[`Markdown component xss: 228 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -89171,7 +91520,8 @@ exports[`Markdown component xss: 229 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -89195,12 +91545,18 @@ exports[`Markdown component xss: 229 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -89211,7 +91567,8 @@ exports[`Markdown component xss: 229 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -89462,7 +91819,8 @@ exports[`Markdown component xss: 229 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -89498,7 +91856,8 @@ exports[`Markdown component xss: 230 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -89522,12 +91881,18 @@ exports[`Markdown component xss: 230 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -89538,7 +91903,8 @@ exports[`Markdown component xss: 230 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -89789,7 +92155,8 @@ exports[`Markdown component xss: 230 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -89831,7 +92198,8 @@ exports[`Markdown component xss: 231 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -89855,12 +92223,18 @@ exports[`Markdown component xss: 231 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -89871,7 +92245,8 @@ exports[`Markdown component xss: 231 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -90122,7 +92497,8 @@ exports[`Markdown component xss: 231 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -90158,7 +92534,8 @@ exports[`Markdown component xss: 232 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -90182,12 +92559,18 @@ exports[`Markdown component xss: 232 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -90198,7 +92581,8 @@ exports[`Markdown component xss: 232 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -90449,7 +92833,8 @@ exports[`Markdown component xss: 232 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -90491,7 +92876,8 @@ exports[`Markdown component xss: 233 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -90515,12 +92901,18 @@ exports[`Markdown component xss: 233 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -90531,7 +92923,8 @@ exports[`Markdown component xss: 233 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -90782,7 +93175,8 @@ exports[`Markdown component xss: 233 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -90824,7 +93218,8 @@ exports[`Markdown component xss: 234 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -90848,12 +93243,18 @@ exports[`Markdown component xss: 234 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -90864,7 +93265,8 @@ exports[`Markdown component xss: 234 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -91115,7 +93517,8 @@ exports[`Markdown component xss: 234 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -91159,7 +93562,8 @@ exports[`Markdown component xss: 235 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -91183,12 +93587,18 @@ exports[`Markdown component xss: 235 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -91199,7 +93609,8 @@ exports[`Markdown component xss: 235 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -91450,7 +93861,8 @@ exports[`Markdown component xss: 235 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -91486,7 +93898,8 @@ exports[`Markdown component xss: 236 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -91510,12 +93923,18 @@ exports[`Markdown component xss: 236 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -91526,7 +93945,8 @@ exports[`Markdown component xss: 236 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -91777,7 +94197,8 @@ exports[`Markdown component xss: 236 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }
@@ -91819,7 +94240,8 @@ exports[`Markdown component xss: 237 1`] = `
   color: #2A506F;
 }
 
-.c2 code[class*='language-'],.c2 pre[class*='language-'] {
+.c2 code[class*='language-'],
+.c2 pre[class*='language-'] {
   color: black;
   background: none;
   text-shadow: 0 1px white;
@@ -91843,12 +94265,18 @@ exports[`Markdown component xss: 237 1`] = `
   hyphens: none;
 }
 
-.c2 pre[class*='language-']::-moz-selection,.c2 pre[class*='language-'] ::-moz-selection,.c2 code[class*='language-']::-moz-selection,.c2 code[class*='language-'] ::-moz-selection {
+.c2 pre[class*='language-']::-moz-selection,
+.c2 pre[class*='language-'] ::-moz-selection,
+.c2 code[class*='language-']::-moz-selection,
+.c2 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-.c2 pre[class*='language-']::selection,.c2 pre[class*='language-'] ::selection,.c2 code[class*='language-']::selection,.c2 code[class*='language-'] ::selection {
+.c2 pre[class*='language-']::selection,
+.c2 pre[class*='language-'] ::selection,
+.c2 code[class*='language-']::selection,
+.c2 code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -91859,7 +94287,8 @@ exports[`Markdown component xss: 237 1`] = `
   overflow: auto;
 }
 
-.c2:not(pre) > code[class*='language-'],.c2 pre[class*='language-'] {
+.c2:not(pre) > code[class*='language-'],
+.c2 pre[class*='language-'] {
   background: #f5f2f0;
 }
 
@@ -92110,7 +94539,8 @@ exports[`Markdown component xss: 237 1`] = `
 }
 
 @media print {
-  .c2 code[class*='language-'],.c2 pre[class*='language-'] {
+  .c2 code[class*='language-'],
+  .c2 pre[class*='language-'] {
     text-shadow: none;
   }
 }

--- a/src/unstable-temp/DownloadImageModal/models.ts
+++ b/src/unstable-temp/DownloadImageModal/models.ts
@@ -55,6 +55,7 @@ export interface OsVersion {
 	basedOnVersion?: string;
 	osType: string;
 	line?: OsLines;
+	// TODO: Mark as non-nullable in the next major
 	variant?: string;
 	formattedVersion: string;
 	isRecommended?: boolean;

--- a/src/unstable-temp/DownloadImageModal/versions.ts
+++ b/src/unstable-temp/DownloadImageModal/versions.ts
@@ -40,7 +40,9 @@ export const transformVersions = (versions: OsVersion[]) => {
 			osType: version.osType,
 			line: version.line,
 			knownIssueList: version.known_issue_list,
-			...(version.variant == null
+			// Unified releases in the model have variant === ''
+			// but we also test for nullish for backgwards compatibility w/ the typings.
+			...(!version.variant
 				? {
 						hasPrebuiltVariants: false,
 						rawVersion: version.raw_version,


### PR DESCRIPTION
This is in order to match the actual
Release.variant field in open-balena.

Change-type: patch
See: https://github.com/balena-io/balena-sdk/pull/1232

<!-- You can remove tags that do not apply. -->

Connects-to: # <!-- waffle convention to track a PR's status through its connected, open issue -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->
Change-type: major|minor|patch <!-- The change type of this PR -->

---

##### Contributor checklist

<!-- For completed items, change [ ] to [x].  -->

- [ ] I have regenerated jest snapshots for any affected components with `npm run generate-snapshots`

##### Reviewer Guidelines

- When submitting a review, please pick:
  - '_Approve_' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '_Request Changes_' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '_Comment_' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)

---
