### PR TITLE
Fix server side checked items getter and fix useRequest when paginati…

### DIFF
--- a/src/components/Table/TableBase.tsx
+++ b/src/components/Table/TableBase.tsx
@@ -360,15 +360,22 @@ export class TableBase<T extends {}> extends React.Component<
 	);
 
 	private getSelectedRows = (selectedRows: T[]) => {
-		const { rowKey, data } = this.props;
-
-		const selectedKeys = this.$getSelectedIdentifiersSet(selectedRows, rowKey);
-		const checkedItems = this.$getValidatedCheckedItems(
-			data,
-			selectedKeys,
-			rowKey,
-			selectedRows,
-		);
+		const { rowKey, data, pagination } = this.props;
+		let checkedItems;
+		if (!pagination?.serverSide) {
+			const selectedKeys = this.$getSelectedIdentifiersSet(
+				selectedRows,
+				rowKey,
+			);
+			checkedItems = this.$getValidatedCheckedItems(
+				data,
+				selectedKeys,
+				rowKey,
+				selectedRows,
+			);
+		} else {
+			checkedItems = selectedRows;
+		}
 		const checkedState = this.howManyRowsChecked(checkedItems);
 
 		return { checkedItems, checkedState };


### PR DESCRIPTION
Fix server side checked items getter and fix useRequest when pagination is a dependency

Change-type: patch
Signed-off-by: Andrea Rosci <andrear@balena.io>

<!-- You can remove tags that do not apply. -->

Connects-to: # <!-- waffle convention to track a PR's status through its connected, open issue -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->
Change-type: major|minor|patch <!-- The change type of this PR -->

---

##### Contributor checklist

<!-- For completed items, change [ ] to [x].  -->

- [ ] I have regenerated jest snapshots for any affected components with `npm run generate-snapshots`

##### Reviewer Guidelines

- When submitting a review, please pick:
  - '_Approve_' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '_Request Changes_' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '_Comment_' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)

---
