### PR TITLE
Table: Restrict the tagField to be a string key of the entity type

### DIFF
--- a/src/components/Form/__snapshots__/spec.tsx.snap
+++ b/src/components/Form/__snapshots__/spec.tsx.snap
@@ -1,5 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Form component description keyword should support markdown 1`] = `"<div id=\\"root_foo__description\\" class=\\"sc-gKPRtg bjEUft sc-iBYQkv ejZKSF sc-hHTYSt jjODDw sc-gJqSRm gWwVhv rendition-form-description\\"><div class=\\"sc-iveFHk kbYoxQ sc-cwSeag evZsOT\\">Lorem ipsum *dolor* sit amet</div></div>"`;
+exports[`Form component description keyword should support markdown 1`] = `"<div id=\\"root_foo__description\\" class=\\"sc-gLDzan eRnLwx sc-iAEyYk kuKnpC sc-hIqOWS fLSYYm sc-gHbYXZ jWPvYa rendition-form-description\\"><div class=\\"sc-ivnCJf kHRgvu sc-cyRfQX bjKyrT\\">Lorem ipsum *dolor* sit amet</div></div>"`;
 
-exports[`Form component ui:help keyword should support markdown 1`] = `"<div id=\\"root_foo\\" class=\\"sc-gKPRtg bjEUft sc-iBYQkv ejZKSF sc-hHTYSt jjODDw sc-gJqSRm dbDVQC rendition-form-help\\"><div class=\\"sc-iveFHk kbYoxQ sc-cwSeag evZsOT\\">Lorem ipsum *dolor* sit amet</div></div>"`;
+exports[`Form component ui:help keyword should support markdown 1`] = `"<div id=\\"root_foo\\" class=\\"sc-gLDzan eRnLwx sc-iAEyYk kuKnpC sc-hIqOWS fLSYYm sc-gHbYXZ iJYCrP rendition-form-help\\"><div class=\\"sc-ivnCJf kHRgvu sc-cyRfQX bjKyrT\\">Lorem ipsum *dolor* sit amet</div></div>"`;

--- a/src/components/Table/TableRow.tsx
+++ b/src/components/Table/TableRow.tsx
@@ -26,7 +26,7 @@ export interface TableBaseColumn<T> {
 	cellAttributes?:
 		| React.AnchorHTMLAttributes<HTMLAnchorElement>
 		| ((value: any, row: T) => React.AnchorHTMLAttributes<HTMLAnchorElement>);
-	field: keyof T;
+	field: Extract<keyof T, string>;
 	key?: string;
 	icon?: string;
 	label?: string | JSX.Element;

--- a/src/components/Table/index.tsx
+++ b/src/components/Table/index.tsx
@@ -163,14 +163,14 @@ type TableColumnInternal<T> = TableBaseColumn<T> & TableColumnState;
 
 const getTagTableColumn = <T extends {}>(
 	columnState: TagTableColumnState,
-	tagField: keyof T,
+	tagField: Extract<keyof T, string>,
 ) => {
 	const column: TableColumnInternal<T> = {
 		...columnState,
 		// this field path doesn't exist
 		// but we need to define something unique
 		// for the table to work
-		field: `${tagField}.${columnState.tagKey}` as keyof T,
+		field: `${tagField}.${columnState.tagKey}` as Extract<keyof T, string>,
 		cellAttributes: tagCellAttributes,
 	};
 	column.sortable = (a: T, b: T) => {
@@ -236,7 +236,7 @@ const normalizeTableColumn = <T extends {}>(
 };
 
 const getAllTagsTableColumn = <T extends {}>(
-	tagField: keyof T,
+	tagField: Extract<keyof T, string>,
 	enableCustomColumns?: boolean,
 ) =>
 	normalizeTableColumn(
@@ -323,7 +323,7 @@ const saveColumnPreferences = (
 const applyColumnPreferences = <T extends {}>(
 	columns: Array<TableColumnInternal<T>>,
 	loadedColumns: TableColumnState[] | undefined,
-	tagField: keyof T | undefined,
+	tagField: Extract<keyof T, string> | undefined,
 	enableCustomColumns?: boolean,
 ): Array<TableColumnInternal<T>> => {
 	if (!loadedColumns?.length) {
@@ -398,7 +398,7 @@ export interface TableProps<T> extends TableBaseProps<T> {
 	/** An array of column objects, as described above */
 	columns: Array<TableColumn<T>>;
 	/** Set a field for tags */
-	tagField?: keyof T;
+	tagField?: Extract<keyof T, string>;
 	innerRef?: React.LegacyRef<
 		React.Component<
 			TableProps<T> & { enableCustomColumns?: boolean | undefined },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,6 @@
     "allowJs": true,
     "esModuleInterop": true,
     "baseUrl": ".",
-    "keyofStringsOnly": true,
     "jsx": "react",
     "lib": [
       "es2019",


### PR DESCRIPTION
Prepares us for TS 5.0 which deprecates
keyofStringsOnly.

Change-type: patch