### PR TITLE
Add table column property headerDocumentation to add header documenta…

### DIFF
--- a/src/components/Table/TableBase.tsx
+++ b/src/components/Table/TableBase.tsx
@@ -1,4 +1,5 @@
 import { faSort } from '@fortawesome/free-solid-svg-icons/faSort';
+import { faQuestionCircle } from '@fortawesome/free-solid-svg-icons/faQuestionCircle';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import isEqual from 'lodash/isEqual';
 import isPlainObject from 'lodash/isPlainObject';
@@ -14,6 +15,7 @@ import { px } from '../../utils';
 import { CheckboxProps, Checkbox } from '../Checkbox';
 import { Pager } from '../Pager';
 import { CheckboxWrapper, TableBaseColumn, TableRow } from './TableRow';
+import { Link } from '../Link';
 
 const highlightStyle = `
 	background-color: ${theme.colors.info.light};
@@ -628,7 +630,6 @@ export class TableBase<T extends {}> extends React.Component<
 			this.state.checkedState === 'all'
 				? totalItems
 				: this.state.checkedItems?.length;
-
 		return (
 			<>
 				{shouldShowPager &&
@@ -669,12 +670,12 @@ export class TableBase<T extends {}> extends React.Component<
 									</CheckboxWrapper>
 								)}
 								{columns.map((item) => {
-									if (item.sortable) {
-										return (
-											<div
-												data-display="table-cell"
-												key={item.key || (item.field as string)}
-											>
+									return (
+										<div
+											data-display="table-cell"
+											key={item.key || (item.field as string)}
+										>
+											{item.sortable ? (
 												<Button
 													data-field={item.field}
 													data-ref-scheme={item.refScheme}
@@ -693,15 +694,24 @@ export class TableBase<T extends {}> extends React.Component<
 														}
 													/>
 												</Button>
-											</div>
-										);
-									}
-									return (
-										<div
-											data-display="table-cell"
-											key={item.key || (item.field as string)}
-										>
-											{item.label || item.field}
+											) : (
+												<div
+													data-display="table-cell"
+													key={item.key || (item.field as string)}
+												>
+													{item.label || item.field}
+												</div>
+											)}
+											{item.headerDocumentation && (
+												<Link
+													blank
+													ml={1}
+													href={item.headerDocumentation.url}
+													tooltip={item.headerDocumentation.tooltip}
+												>
+													<FontAwesomeIcon icon={faQuestionCircle} />
+												</Link>
+											)}
 										</div>
 									);
 								})}

--- a/src/components/Table/TableRow.tsx
+++ b/src/components/Table/TableRow.tsx
@@ -35,6 +35,10 @@ export interface TableBaseColumn<T> {
 		row: T,
 	) => string | number | JSX.Element | null | undefined;
 	sortable?: boolean | TableSortFunction<T>;
+	headerDocumentation?: {
+		url: string | undefined;
+		tooltip: string | undefined;
+	};
 	refScheme?: string;
 }
 

--- a/src/components/Table/index.tsx
+++ b/src/components/Table/index.tsx
@@ -157,6 +157,10 @@ export interface TableColumn<T> extends TableBaseColumn<T> {
 	title?: string;
 	selected?: boolean;
 	locked?: boolean;
+	headerDocumentation?: {
+		url: string | undefined;
+		tooltip: string | undefined;
+	};
 }
 
 type TableColumnInternal<T> = TableBaseColumn<T> & TableColumnState;


### PR DESCRIPTION
Add table column property headerDocumentation to add header documentation link and tooltip

See: https://balena.zulipchat.com/#narrow/stream/346007-balena-io.2FbalenaCloud/topic/x-header-docs.20positioning/near/348710839
Change-type: minor


---

##### Contributor checklist

<!-- For completed items, change [ ] to [x].  -->

- [ ] I have regenerated jest snapshots for any affected components with `npm run generate-snapshots`

##### Reviewer Guidelines

- When submitting a review, please pick:
  - '_Approve_' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '_Request Changes_' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '_Comment_' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)

---
