### PR TITLE
DownloadImageModal: Add `onFieldChange` & improve `onDownloadStart` use

### DIFF
--- a/src/unstable-temp/DownloadImageModal/DownloadImageModal.tsx
+++ b/src/unstable-temp/DownloadImageModal/DownloadImageModal.tsx
@@ -111,6 +111,7 @@ export interface UnstableTempDownloadImageModalProps {
 	modalActions?: ModalAction[];
 	authToken?: string;
 	docsIcon?: IconProp;
+	onFieldChange?: (fields: { [key: string]: any }) => void;
 }
 
 export const UnstableTempDownloadImageModal = ({
@@ -132,6 +133,7 @@ export const UnstableTempDownloadImageModal = ({
 	modalActions,
 	authToken,
 	docsIcon,
+	onFieldChange,
 }: UnstableTempDownloadImageModalProps) => {
 	const { t } = useTranslation();
 	const [deviceType, setDeviceType] = React.useState(initialDeviceType);
@@ -251,6 +253,7 @@ export const UnstableTempDownloadImageModal = ({
 								)}
 								{!!osType && !!compatibleDeviceTypes && (
 									<ImageForm
+										onFieldChange={onFieldChange}
 										onDownloadStart={onDownloadStart}
 										setIsDownloadingConfig={setIsDownloadingConfig}
 										deviceType={deviceType}


### PR DESCRIPTION
DownloadImageModal: Add `onFieldChange` & improve `onDownloadStart` use

Changelog-entry: DownloadImageModal: Add `onFieldChange` and call `onDownloadStart` whenever a download is started, regardless of type
Change-type: minor

---

##### Contributor checklist

<!-- For completed items, change [ ] to [x].  -->

- [ ] I have regenerated jest snapshots for any affected components with `npm run generate-snapshots`

##### Reviewer Guidelines

- When submitting a review, please pick:
  - '_Approve_' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '_Request Changes_' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '_Comment_' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)

---
