### PR TITLE
Add `null` as an acceptable type for DisabledTextWidget

### DIFF
--- a/src/components/Renderer/widgets/DisabledTextWidget.tsx
+++ b/src/components/Renderer/widgets/DisabledTextWidget.tsx
@@ -1,21 +1,29 @@
 import React from 'react';
-import { Copy } from '../../Copy';
-import { Flex } from '../../Flex';
 import { Txt } from '../../Txt';
 import { JsonTypes } from '../types';
 import { widgetFactory } from './widget-util';
+import { useTranslation } from '../../../hooks/useTranslation';
 
 export const DisabledTextWidget = widgetFactory('DisabledText', {}, [
 	JsonTypes.string,
 	JsonTypes.number,
+	JsonTypes.null,
 ])(({ value }) => {
-	const val = typeof value !== 'string' ? value.toString() : value;
+	const { t } = useTranslation();
+	const val =
+		value != null && typeof value !== 'string' ? value.toString() : value;
 	return (
-		<Flex>
-			<Txt maxWidth="300px" truncate title={val} color="#b3b6b9" monospace>
-				{val}
-			</Txt>
-			{val.length > 45 && <Copy content={val} />}
-		</Flex>
+		<Txt
+			maxWidth="350px"
+			truncate
+			title={val ?? t('info.not_defined')}
+			color="#b3b6b9"
+			monospace
+			copy={val != null && val.length > 45 ? val : undefined}
+			italic={val == null}
+			px={1}
+		>
+			{val ?? t('info.not_defined')}
+		</Txt>
 	);
 });

--- a/src/hooks/useTranslation.tsx
+++ b/src/hooks/useTranslation.tsx
@@ -129,6 +129,8 @@ const translationMap = {
 	'questions.how_about_adding_one': 'How about adding one?',
 
 	'success.resource_added_successfully': '{{name}} added successfully',
+
+	'info.not_defined': 'not defined',
 };
 
 const getTranslation = (str: string, opts?: any) => {


### PR DESCRIPTION
Add `null` as an acceptable type for DisabledTextWidget

Change-type: minor

---

##### Contributor checklist

<!-- For completed items, change [ ] to [x].  -->

- [ ] I have regenerated jest snapshots for any affected components with `npm run generate-snapshots`

##### Reviewer Guidelines

- When submitting a review, please pick:
  - '_Approve_' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '_Request Changes_' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '_Comment_' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)

---
