### PR TITLE
Filters: Hide `Save view` button by default if not using `views` renderMode

### DIFF
--- a/src/components/Filters/index.tsx
+++ b/src/components/Filters/index.tsx
@@ -70,6 +70,7 @@ export interface FiltersProps {
 	schema: JSONSchema;
 	/** Properties that are passed to the "Add filter" button, these are the same props used for the [`Button`](#button) component */
 	addFilterButtonProps?: ButtonProps;
+	/** If true, show the `Save view` button in the `summary` renderMode. By default is set depending on whether `views` renderMode is included */
 	showSaveView?: boolean;
 	/** Properties that are passed to the "Views" button, these are the same props used for the [DropDownButton](#dropdownbutton) component */
 	viewsMenuButtonProps?: DropDownButtonProps;
@@ -93,7 +94,7 @@ export const Filters = ({
 	renderMode,
 	dark,
 	compact,
-	showSaveView = true,
+	showSaveView,
 	onViewsUpdate,
 	onFiltersUpdate,
 	onSearch,
@@ -242,7 +243,7 @@ export const Filters = ({
 							setFilters([]);
 							onFiltersUpdate?.([]);
 						}}
-						showSaveView={showSaveView}
+						showSaveView={showSaveView ?? renderMode?.includes('views')}
 						onSaveView={({ name }) => saveView(name)}
 						filters={internalFilters}
 					/>

--- a/src/components/Filters/spec.tsx
+++ b/src/components/Filters/spec.tsx
@@ -182,7 +182,7 @@ describe('Filters component', () => {
 		it('should not show scopes selector if one or less scopes are passed', () => {
 			const view = mount(
 				<Provider>
-					<Filters schema={schema} filters={[filter]} />
+					<Filters schema={schema} filters={[filter]} showSaveView />
 				</Provider>,
 			);
 


### PR DESCRIPTION
Filters: Hide `Save view` button by default if not using `views` renderMode

Change-type: patch

---

##### Contributor checklist

<!-- For completed items, change [ ] to [x].  -->

- [ ] I have regenerated jest snapshots for any affected components with `npm run generate-snapshots`

##### Reviewer Guidelines

- When submitting a review, please pick:
  - '_Approve_' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '_Request Changes_' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '_Comment_' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)

---
