### PR TITLE
Fix download image modal specific instructions

### DIFF
--- a/src/unstable-temp/DownloadImageModal/ApplicationInstructions.tsx
+++ b/src/unstable-temp/DownloadImageModal/ApplicationInstructions.tsx
@@ -15,7 +15,7 @@ export type OsOptions = ReturnType<typeof getUserOs>;
 
 export const osTitles: Record<OsOptions, string> = {
 	windows: 'Windows',
-	osx: 'MacOS',
+	macos: 'MacOS',
 	linux: 'Linux',
 	unknown: 'Unknown',
 };
@@ -27,7 +27,7 @@ export const getUserOs = () => {
 	}
 
 	if (platform.includes('mac')) {
-		return 'osx';
+		return 'macos';
 	}
 
 	if (platform.includes('x11') || platform.includes('linux')) {
@@ -38,9 +38,9 @@ export const getUserOs = () => {
 };
 
 const osTabIndices: Record<OsOptions, number> = {
-	windows: 0,
-	osx: 1,
-	linux: 2,
+	linux: 0,
+	macos: 1,
+	windows: 2,
 	unknown: 0,
 };
 
@@ -63,7 +63,9 @@ export const ApplicationInstructions = React.memo(
 
 		React.useEffect(() => {
 			if (hasOsSpecificInstructions && instructions) {
-				const oses = Object.keys(instructions) as unknown as OsOptions;
+				const oses = Object.keys(instructions).map((os) =>
+					os.toLowerCase(),
+				) as unknown as OsOptions;
 				if (!oses.includes(currentOs) && oses.length > 0) {
 					setCurrentOs(oses[0] as OsOptions);
 				}
@@ -75,11 +77,11 @@ export const ApplicationInstructions = React.memo(
 		}
 
 		const interpolatedInstructions = (
-			hasOsSpecificInstructions
+			(hasOsSpecificInstructions
 				? (instructions as DeviceTypeInstructions)[
 						osTitles[normalizedOs] as keyof DeviceTypeInstructions
 				  ]
-				: (instructions as string[])
+				: instructions) ?? []
 		).map((instruction) =>
 			interpolateMustache(
 				templateData,
@@ -106,10 +108,17 @@ export const ApplicationInstructions = React.memo(
 					<Box mb={3}>
 						<Tabs
 							activeIndex={osTabIndices[currentOs]}
-							onActive={(index) => setCurrentOs(osTabNames[index.toString()])}
+							onActive={(index) => {
+								setCurrentOs(osTabNames[index.toString()]);
+							}}
 						>
-							{(Object.keys(instructions) as OsOptions[]).map((os) => {
-								return <Tab key={os} title={osTitles[os]}></Tab>;
+							{Object.keys(instructions).map((os) => {
+								return (
+									<Tab
+										key={os}
+										title={osTitles[os.toLowerCase() as keyof typeof osTitles]}
+									></Tab>
+								);
 							})}
 						</Tabs>
 					</Box>


### PR DESCRIPTION
Change-type: patch

<img width="1418" alt="Screenshot 2023-07-27 at 13 16 56" src="https://github.com/balena-io-modules/rendition/assets/7238159/b2de22e3-a45e-4826-9734-386414f1bdf1">



<!-- You can remove tags that do not apply. -->

Connects-to: # <!-- waffle convention to track a PR's status through its connected, open issue -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->
Change-type: major|minor|patch <!-- The change type of this PR -->

---

##### Contributor checklist

<!-- For completed items, change [ ] to [x].  -->

- [ ] I have regenerated jest snapshots for any affected components with `npm run generate-snapshots`

##### Reviewer Guidelines

- When submitting a review, please pick:
  - '_Approve_' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '_Request Changes_' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '_Comment_' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)

---
